### PR TITLE
feat: simplify search flow with /r history and tray recent menu

### DIFF
--- a/snotra-core/src/history.rs
+++ b/snotra-core/src/history.rs
@@ -163,7 +163,7 @@ impl HistoryStore {
             .map(|(path, entry)| (path.as_str(), entry.last_launched))
             .collect();
 
-        entries.sort_by(|a, b| b.1.cmp(&a.1));
+        entries.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
         entries.truncate(self.max_history_display);
         entries.into_iter().map(|(path, _)| path).collect()
     }
@@ -389,6 +389,30 @@ mod tests {
         assert_eq!(recent.len(), 2);
         assert_eq!(recent[0], "C:\\app_new.lnk");
         assert_eq!(recent[1], "C:\\app_old.lnk");
+    }
+
+    #[test]
+    fn recent_launches_same_timestamp_sorted_by_path() {
+        let mut store = fresh_store();
+        store.data.global.insert(
+            "C:\\zeta.lnk".to_string(),
+            GlobalEntry {
+                launch_count: 1,
+                last_launched: 2000,
+            },
+        );
+        store.data.global.insert(
+            "C:\\alpha.lnk".to_string(),
+            GlobalEntry {
+                launch_count: 1,
+                last_launched: 2000,
+            },
+        );
+
+        let recent = store.recent_launches();
+        assert_eq!(recent.len(), 2);
+        assert_eq!(recent[0], "C:\\alpha.lnk");
+        assert_eq!(recent[1], "C:\\zeta.lnk");
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -44,9 +44,13 @@ pub fn get_history_results(state: State<AppState>) -> Vec<SearchResult> {
 
 #[tauri::command]
 pub fn launch_item(path: String, query: String, state: State<AppState>) {
+    launch_item_with_state(&path, &query, &state);
+}
+
+pub fn launch_item_with_state(path: &str, query: &str, state: &AppState) {
     {
         let mut history = state.history.lock().unwrap();
-        history.record_launch(&path, &query);
+        history.record_launch(path, query);
         history.save_if_dirty(5);
     }
     #[cfg(windows)]
@@ -55,6 +59,7 @@ pub fn launch_item(path: String, query: String, state: State<AppState>) {
         use windows::Win32::UI::Shell::ShellExecuteW;
         use windows::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
         use windows::core::HSTRING;
+        let path = path.to_string();
         // ShellExecuteW はフォルダ・画像などのシェル拡張に COM STA を要求する。
         // Tauri コマンドハンドラのスレッドは COM 状態が保証されないため、
         // 新規 OS スレッドで CoInitializeEx → ShellExecuteW → CoUninitialize を実行する。
@@ -285,8 +290,8 @@ pub fn set_window_no_activate(app: AppHandle) -> Result<(), String> {
 }
 
 #[tauri::command]
-pub fn notify_result_clicked(index: usize, app: AppHandle) -> Result<(), String> {
-    app.emit("result-clicked", index).map_err(|e| e.to_string())
+pub fn notify_result_clicked(path: String, app: AppHandle) -> Result<(), String> {
+    app.emit("result-clicked", path).map_err(|e| e.to_string())
 }
 
 #[tauri::command]

--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -1,7 +1,7 @@
 use std::sync::mpsc::{self, Receiver, Sender};
 
 use snotra_core::config::HotkeyConfig;
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
 use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
 use windows::Win32::System::LibraryLoader::GetModuleHandleW;
 use windows::Win32::System::Threading::GetCurrentThreadId;
@@ -15,17 +15,19 @@ use windows::Win32::UI::WindowsAndMessaging::{
     MF_SEPARATOR, MF_STRING, MSG, PM_NOREMOVE, PeekMessageW, PostMessageW, PostQuitMessage,
     PostThreadMessageW, RegisterClassExW, SetForegroundWindow, TPM_BOTTOMALIGN, TPM_LEFTALIGN,
     TPM_NONOTIFY, TPM_RETURNCMD, TPM_RIGHTBUTTON, TrackPopupMenuEx, TranslateMessage,
-    WINDOW_EX_STYLE, WINDOW_STYLE, WM_APP, WM_COMMAND, WM_CONTEXTMENU, WM_HOTKEY, WM_LBUTTONDBLCLK,
+    WINDOW_EX_STYLE, WINDOW_STYLE, WM_APP, WM_COMMAND, WM_CONTEXTMENU, WM_HOTKEY, WM_LBUTTONUP,
     WM_NULL, WM_RBUTTONUP, WNDCLASSEXW,
 };
 use windows::core::{PCWSTR, w};
 
-use crate::{hotkey, ime};
+use crate::state::AppState;
+use crate::{commands, hotkey, ime};
 
 const WM_PLATFORM_WAKE: u32 = WM_APP + 40;
 const WM_TRAY_ICON: u32 = WM_APP + 41;
 const ID_MENU_SETTINGS: usize = 1000;
 const ID_MENU_EXIT: usize = 1001;
+const ID_MENU_RECENT_BASE: usize = 2000;
 
 unsafe extern "system" fn platform_default_wnd_proc(
     hwnd: HWND,
@@ -190,7 +192,7 @@ fn platform_thread_loop(
                     );
                 }
                 WM_COMMAND => {
-                    handle_menu_command(msg.wParam, &app_handle);
+                    handle_menu_command(msg.wParam, &app_handle, &tray);
                 }
                 WM_PLATFORM_WAKE => {
                     process_commands(
@@ -262,7 +264,33 @@ fn process_commands(
     }
 }
 
-fn handle_menu_command(wparam: WPARAM, app_handle: &AppHandle) {
+fn recent_history_items(app_handle: &AppHandle) -> Vec<snotra_core::ui_types::SearchResult> {
+    let state = app_handle.state::<AppState>();
+    let max_history_display = {
+        let config = state.config.lock().unwrap();
+        config.appearance.max_history_display
+    };
+    let engine = state.engine.lock().unwrap();
+    let history = state.history.lock().unwrap();
+    engine.recent_history(&history, max_history_display)
+}
+
+fn format_recent_history_label(item: &snotra_core::ui_types::SearchResult) -> String {
+    const MAX_LABEL_LEN: usize = 90;
+    let base = if item.name.is_empty() || item.name == item.path {
+        item.path.clone()
+    } else {
+        format!("{} - {}", item.name, item.path)
+    };
+    if base.chars().count() <= MAX_LABEL_LEN {
+        return base;
+    }
+    let mut truncated: String = base.chars().take(MAX_LABEL_LEN - 3).collect();
+    truncated.push_str("...");
+    truncated
+}
+
+fn handle_menu_command(wparam: WPARAM, app_handle: &AppHandle, tray: &Option<TrayIcon>) {
     let id = wparam.0 & 0xFFFF;
     match id {
         ID_MENU_SETTINGS => {
@@ -270,6 +298,13 @@ fn handle_menu_command(wparam: WPARAM, app_handle: &AppHandle) {
         }
         ID_MENU_EXIT => {
             let _ = app_handle.emit("exit-requested", ());
+        }
+        id if id >= ID_MENU_RECENT_BASE => {
+            let id = id as usize;
+            if let Some(path) = tray.as_ref().and_then(|t| t.recent_path_for_id(id)) {
+                let state = app_handle.state::<AppState>();
+                commands::launch_item_with_state(&path, "", &state);
+            }
         }
         _ => {}
     }
@@ -284,13 +319,15 @@ fn handle_tray_message(
 ) {
     let event = (lparam.0 & 0xFFFF) as u32;
     match event {
+        x if x == WM_LBUTTONUP => {
+            if let Some(tray) = tray.as_mut() {
+                tray.show_recent_history_menu(hwnd, app_handle);
+            }
+        }
         x if x == WM_CONTEXTMENU => {
             if let Some(tray) = tray.as_ref() {
                 tray.show_context_menu(hwnd, indexing);
             }
-        }
-        x if x == WM_LBUTTONDBLCLK => {
-            let _ = app_handle.emit("hotkey-pressed", ());
         }
         x if x == WM_RBUTTONUP => {
             // Known: some environments deliver both WM_RBUTTONUP and WM_CONTEXTMENU
@@ -308,6 +345,7 @@ fn handle_tray_message(
 struct TrayIcon {
     nid: NOTIFYICONDATAW,
     owned_icon: Option<HICON>,
+    recent_menu_paths: Vec<String>,
 }
 
 impl TrayIcon {
@@ -335,7 +373,16 @@ impl TrayIcon {
             let _ = Shell_NotifyIconW(NIM_SETVERSION, &nid);
         }
 
-        Self { nid, owned_icon }
+        Self {
+            nid,
+            owned_icon,
+            recent_menu_paths: Vec::new(),
+        }
+    }
+
+    fn recent_path_for_id(&self, id: usize) -> Option<String> {
+        let offset = id.checked_sub(ID_MENU_RECENT_BASE)?;
+        self.recent_menu_paths.get(offset).cloned()
     }
 
     fn show_context_menu(&self, hwnd: HWND, indexing: bool) {
@@ -412,6 +459,55 @@ impl TrayIcon {
             }
 
             // MSDN: send WM_NULL after TrackPopupMenuEx so the menu dismisses correctly.
+            let _ = PostMessageW(Some(hwnd), WM_NULL, WPARAM(0), LPARAM(0));
+            let _ = DestroyMenu(hmenu);
+        }
+    }
+
+    fn show_recent_history_menu(&mut self, hwnd: HWND, app_handle: &AppHandle) {
+        unsafe {
+            let Ok(hmenu) = CreatePopupMenu() else {
+                return;
+            };
+
+            self.recent_menu_paths.clear();
+            let recent = recent_history_items(app_handle);
+            if recent.is_empty() {
+                let empty_text: Vec<u16> =
+                    "履歴なし".encode_utf16().chain(std::iter::once(0)).collect();
+                let _ = AppendMenuW(hmenu, MF_GRAYED, 0, PCWSTR(empty_text.as_ptr()));
+            } else {
+                for (idx, item) in recent.iter().enumerate() {
+                    let id = ID_MENU_RECENT_BASE + idx;
+                    let label = format_recent_history_label(item);
+                    let label_wide: Vec<u16> =
+                        label.encode_utf16().chain(std::iter::once(0)).collect();
+                    let _ = AppendMenuW(hmenu, MF_STRING, id, PCWSTR(label_wide.as_ptr()));
+                    self.recent_menu_paths.push(item.path.clone());
+                }
+            }
+
+            let mut pt = Default::default();
+            let _ = GetCursorPos(&mut pt);
+            let _ = SetForegroundWindow(hwnd);
+
+            let command = TrackPopupMenuEx(
+                hmenu,
+                (TPM_LEFTALIGN | TPM_BOTTOMALIGN | TPM_NONOTIFY | TPM_RETURNCMD).0,
+                pt.x,
+                pt.y,
+                hwnd,
+                None,
+            );
+            if command.0 != 0 {
+                let _ = PostMessageW(
+                    Some(hwnd),
+                    WM_COMMAND,
+                    WPARAM(command.0 as usize),
+                    LPARAM(0),
+                );
+            }
+
             let _ = PostMessageW(Some(hwnd), WM_NULL, WPARAM(0), LPARAM(0));
             let _ = DestroyMenu(hmenu);
         }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { type Component, onMount, Switch, Match } from "solid-js";
+import { type Component, onMount, onCleanup, Switch, Match } from "solid-js";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { listen } from "@tauri-apps/api/event";
@@ -7,7 +7,12 @@ import SearchWindow from "./components/SearchWindow";
 import ResultsWindow from "./components/ResultsWindow";
 import SettingsWindow from "./components/SettingsWindow";
 import AboutWindow from "./components/AboutWindow";
-import { resetForShow, setSelected, activateSelected, initIndexingState } from "./stores/search";
+import {
+  resetForShow,
+  setSelected,
+  activateSelectedByPath,
+  initIndexingState,
+} from "./stores/search";
 import { applyTheme } from "./lib/theme";
 import type { VisualConfig } from "./lib/types";
 import * as api from "./lib/invoke";
@@ -26,6 +31,7 @@ type ResultsRenderDonePayload = {
 
 const App: Component = () => {
   const windowLabel = getCurrentWindow().label;
+  const unlistenFns: Array<() => void> = [];
 
   onMount(async () => {
     const win = getCurrentWindow();
@@ -34,6 +40,7 @@ const App: Component = () => {
     let lastResultsSize: { width: number; height: number } | undefined;
     let lastResultsPosition: { x: number; y: number } | undefined;
     let latestResultsRequestId = 0;
+    let registerAutoHideOnFocusLost: (() => void) | undefined;
 
     const getResultsWindow = async () => {
       if (!resultsWindowPromise) {
@@ -42,58 +49,19 @@ const App: Component = () => {
       return resultsWindowPromise;
     };
 
-    // Register listeners before any await to avoid race conditions
     if (label === "main") {
-      listen("window-shown", () => {
-        resetForShow();
-      });
-      initIndexingState();
-    }
-
-    // Listen for visual config changes (all windows)
-    listen<VisualConfig>("visual-config-changed", (event) => {
-      applyTheme(event.payload);
-    });
-
-    // Load config and apply theme (non-fatal on failure)
-    let config: Awaited<ReturnType<typeof api.getConfig>> | null = null;
-    try {
-      config = await api.getConfig();
-      applyTheme(config.visual);
-    } catch (e) {
-      console.error("Failed to load config/apply theme:", e);
-    }
-
-    if (label === "main" && config) {
       let cachedScaleFactor = 1;
       let cachedMainLogicalHeight = 52;
       let positionApplyInFlight = false;
       let pendingResultsPosition: { x: number; y: number } | undefined;
 
-      try {
-        const [sf, size] = await Promise.all([win.scaleFactor(), win.innerSize()]);
-        cachedScaleFactor = sf;
-        cachedMainLogicalHeight = size.toLogical(sf).height;
-      } catch (e) {
-        console.warn("Failed to initialize main window geometry cache:", e);
-      }
-
-      // Auto-hide on focus lost (with grace period for drag operations)
-      if (config.general.auto_hide_on_focus_lost) {
-        let blurTimer: ReturnType<typeof setTimeout> | undefined;
-        win.onFocusChanged(({ payload: focused }) => {
-          if (!focused) {
-            blurTimer = setTimeout(() => {
-              win.hide();
-              getResultsWindow().then((rw) => {
-                if (rw) rw.hide();
-              });
-            }, 100);
-          } else {
-            clearTimeout(blurTimer);
-          }
-        });
-      }
+      const hideMainAndResults = async () => {
+        await win.hide();
+        const rw = await getResultsWindow();
+        if (rw) {
+          await rw.hide();
+        }
+      };
 
       const queueResultsPosition = (rw: WebviewWindow, nextPosition: { x: number; y: number }) => {
         pendingResultsPosition = nextPosition;
@@ -114,6 +82,146 @@ const App: Component = () => {
           positionApplyInFlight = false;
         });
       };
+
+      registerAutoHideOnFocusLost = () => {
+        let blurTimer: ReturnType<typeof setTimeout> | undefined;
+        win.onFocusChanged(({ payload: focused }) => {
+          if (!focused) {
+            blurTimer = setTimeout(() => {
+              void hideMainAndResults();
+            }, 100);
+          } else {
+            clearTimeout(blurTimer);
+          }
+        });
+      };
+
+      // Wait for all critical listeners to be attached before first reset/show.
+      const [unlistenWindowShown, unlistenResultsCountChanged, unlistenResultClicked, unlistenRenderDone, unlistenResultDoubleClicked] =
+        await Promise.all([
+          listen("window-shown", () => {
+            resetForShow();
+          }),
+          listen<ResultsCountChangedPayload>("results-count-changed", async (event) => {
+            const { count, requestId } = event.payload;
+            if (requestId < latestResultsRequestId) return;
+            latestResultsRequestId = requestId;
+            const isStale = () => requestId !== latestResultsRequestId;
+
+            const rw = await getResultsWindow();
+            if (!rw || isStale()) return;
+
+            if (count === 0) {
+              const visible = await rw.isVisible();
+              if (isStale()) return;
+              if (visible) {
+                await rw.hide();
+              }
+              return;
+            }
+
+            // Use current main window width (may have been updated via settings)
+            const [currentSize, currentSf, mainPos, mainVisible] = await Promise.all([
+              win.innerSize(),
+              win.scaleFactor(),
+              win.outerPosition(),
+              win.isVisible(),
+            ]);
+            if (isStale()) return;
+
+            const mainSize = currentSize;
+            const sf = currentSf;
+            const currentWidth = currentSize.toLogical(currentSf).width;
+            cachedScaleFactor = currentSf;
+            cachedMainLogicalHeight = currentSize.toLogical(currentSf).height;
+
+            // Resize results window based on count
+            const resultsHeight = Math.min(count * RESULT_ROW_HEIGHT + RESULTS_PADDING * 2, 400);
+            if (
+              !lastResultsSize ||
+              lastResultsSize.width !== currentWidth ||
+              lastResultsSize.height !== resultsHeight
+            ) {
+              await rw.setSize(new LogicalSize(currentWidth, resultsHeight));
+              if (isStale()) return;
+              lastResultsSize = { width: currentWidth, height: resultsHeight };
+            }
+
+            // Position results below main
+            const logicalMainPos = mainPos.toLogical(sf);
+            const logicalH = mainSize.toLogical(sf).height;
+            const nextPosition = {
+              x: logicalMainPos.x,
+              y: logicalMainPos.y + logicalH + RESULTS_GAP,
+            };
+            if (
+              !lastResultsPosition ||
+              lastResultsPosition.x !== nextPosition.x ||
+              lastResultsPosition.y !== nextPosition.y
+            ) {
+              await rw.setPosition(new LogicalPosition(nextPosition.x, nextPosition.y));
+              if (isStale()) return;
+              lastResultsPosition = nextPosition;
+            }
+
+            if (!mainVisible) {
+              const visible = await rw.isVisible();
+              if (isStale()) return;
+              if (visible) {
+                await rw.hide();
+              }
+              return;
+            }
+
+            const visible = await rw.isVisible();
+            if (isStale()) return;
+            if (!visible) {
+              await rw.show();
+              if (isStale()) {
+                await rw.hide();
+                return;
+              }
+              void api.setWindowNoActivate();
+            }
+          }),
+          listen<string>("result-clicked", async (event) => {
+            const launched = await activateSelectedByPath(event.payload);
+            if (launched) {
+              void hideMainAndResults();
+            } else {
+              console.warn("Failed to launch clicked result", { path: event.payload });
+            }
+          }),
+          listen<ResultsRenderDonePayload>("results-render-done", (event) => {
+            perfMarkRenderDone(event.payload.requestId);
+          }),
+          listen<number>("result-double-clicked", (event) => {
+            setSelected(event.payload);
+          }),
+        ]);
+
+      unlistenFns.push(
+        unlistenWindowShown,
+        unlistenResultsCountChanged,
+        unlistenResultClicked,
+        unlistenRenderDone,
+        unlistenResultDoubleClicked,
+      );
+
+      if (await win.isVisible()) {
+        resetForShow();
+      }
+      void initIndexingState();
+
+      void (async () => {
+        try {
+          const [sf, size] = await Promise.all([win.scaleFactor(), win.innerSize()]);
+          cachedScaleFactor = sf;
+          cachedMainLogicalHeight = size.toLogical(sf).height;
+        } catch (e) {
+          console.warn("Failed to initialize main window geometry cache:", e);
+        }
+      })();
 
       win.onResized(({ payload: sz }) => {
         const logicalSize = sz.toLogical(cachedScaleFactor);
@@ -156,90 +264,24 @@ const App: Component = () => {
         })();
       });
 
-      // Listen for results-count-changed to show/hide/resize results window
-      listen<ResultsCountChangedPayload>("results-count-changed", async (event) => {
-        const { count, requestId } = event.payload;
-        if (requestId < latestResultsRequestId) return;
-        latestResultsRequestId = requestId;
+    }
 
-        const rw = await getResultsWindow();
-        if (!rw) return;
+    // Listen for visual config changes (all windows)
+    listen<VisualConfig>("visual-config-changed", (event) => {
+      applyTheme(event.payload);
+    });
 
-        if (count === 0) {
-          if (await rw.isVisible()) {
-            await rw.hide();
-          }
-          return;
-        }
+    // Load config and apply theme (non-fatal on failure)
+    let config: Awaited<ReturnType<typeof api.getConfig>> | null = null;
+    try {
+      config = await api.getConfig();
+      applyTheme(config.visual);
+    } catch (e) {
+      console.error("Failed to load config/apply theme:", e);
+    }
 
-        // Use current main window width (may have been updated via settings)
-        const [currentSize, currentSf, mainPos, mainVisible] = await Promise.all([
-          win.innerSize(),
-          win.scaleFactor(),
-          win.outerPosition(),
-          win.isVisible(),
-        ]);
-        if (requestId !== latestResultsRequestId) return;
-
-        const mainSize = currentSize;
-        const sf = currentSf;
-        const currentWidth = currentSize.toLogical(currentSf).width;
-        cachedScaleFactor = currentSf;
-        cachedMainLogicalHeight = currentSize.toLogical(currentSf).height;
-
-        // Resize results window based on count
-        const resultsHeight = Math.min(count * RESULT_ROW_HEIGHT + RESULTS_PADDING * 2, 400);
-        if (
-          !lastResultsSize ||
-          lastResultsSize.width !== currentWidth ||
-          lastResultsSize.height !== resultsHeight
-        ) {
-          await rw.setSize(new LogicalSize(currentWidth, resultsHeight));
-          if (requestId !== latestResultsRequestId) return;
-          lastResultsSize = { width: currentWidth, height: resultsHeight };
-        }
-
-        // Position results below main
-        const logicalMainPos = mainPos.toLogical(sf);
-        const logicalH = mainSize.toLogical(sf).height;
-        const nextPosition = {
-          x: logicalMainPos.x,
-          y: logicalMainPos.y + logicalH + RESULTS_GAP,
-        };
-        if (
-          !lastResultsPosition ||
-          lastResultsPosition.x !== nextPosition.x ||
-          lastResultsPosition.y !== nextPosition.y
-        ) {
-          await rw.setPosition(new LogicalPosition(nextPosition.x, nextPosition.y));
-          if (requestId !== latestResultsRequestId) return;
-          lastResultsPosition = nextPosition;
-        }
-
-        // Show if main is visible
-        if (mainVisible) {
-          if (!(await rw.isVisible())) {
-            await rw.show();
-            void api.setWindowNoActivate();
-          }
-        }
-      });
-
-      // Listen for result-clicked from results window
-      listen<number>("result-clicked", async (event) => {
-        setSelected(event.payload);
-        const launched = await activateSelected();
-        if (launched) void win.hide();
-      });
-
-      listen<ResultsRenderDonePayload>("results-render-done", (event) => {
-        perfMarkRenderDone(event.payload.requestId);
-      });
-
-      // Listen for result-double-clicked from results window
-      listen<number>("result-double-clicked", (event) => {
-        setSelected(event.payload);
-      });
+    if (label === "main" && config?.general.auto_hide_on_focus_lost) {
+      registerAutoHideOnFocusLost?.();
     }
 
     if (label === "settings") {
@@ -281,6 +323,16 @@ const App: Component = () => {
           })();
         }, 500);
       });
+    }
+  });
+
+  onCleanup(() => {
+    for (const unlisten of unlistenFns) {
+      try {
+        unlisten();
+      } catch (e) {
+        console.warn("Failed to cleanup listener:", e);
+      }
     }
   });
 

--- a/ui/src/components/ResultsWindow.tsx
+++ b/ui/src/components/ResultsWindow.tsx
@@ -105,7 +105,7 @@ const ResultsWindow: Component = () => {
               isSelected={idx() === selected()}
               icon={iconCache().get(result.path)}
               containerWidth={containerWidth()}
-              onClick={() => api.notifyResultClicked(idx())}
+              onClick={() => api.notifyResultClicked(result.path)}
               onDoubleClick={() => api.notifyResultDoubleClicked(idx())}
             />
           )}

--- a/ui/src/components/SearchWindow.tsx
+++ b/ui/src/components/SearchWindow.tsx
@@ -16,7 +16,6 @@ import {
   navigateFolderUp,
   enterFolderExpansion,
   activateSelected,
-  refreshResults,
   indexing,
 } from "../stores/search";
 import { initCommands } from "../lib/commands";
@@ -64,7 +63,6 @@ const SearchWindow: Component = () => {
 
   onMount(() => {
     initCommands(hideAllWindows);
-    refreshResults();
     let unlistenWindowShown: (() => void) | undefined;
     let unlistenFocusChanged: (() => void) | undefined;
     void listen("window-shown", () => {

--- a/ui/src/lib/commands.ts
+++ b/ui/src/lib/commands.ts
@@ -11,6 +11,14 @@ let hideAllWindowsFn: (() => void) | undefined;
 
 export const SLASH_COMMANDS: SlashCommand[] = [
   {
+    command: "/r",
+    label: "/r",
+    description: "直近履歴を表示",
+    action: () => {
+      // /r is handled by search store as a result-producing command.
+    },
+  },
+  {
     command: "/a",
     label: "/a",
     description: "バージョン情報",

--- a/ui/src/lib/invoke.ts
+++ b/ui/src/lib/invoke.ts
@@ -97,8 +97,8 @@ export async function setWindowNoActivate(): Promise<void> {
   return invoke("set_window_no_activate");
 }
 
-export async function notifyResultClicked(index: number): Promise<void> {
-  return invoke("notify_result_clicked", { index });
+export async function notifyResultClicked(path: string): Promise<void> {
+  return invoke("notify_result_clicked", { path });
 }
 
 export async function notifyResultDoubleClicked(index: number): Promise<void> {

--- a/ui/src/stores/search.ts
+++ b/ui/src/stores/search.ts
@@ -17,6 +17,12 @@ let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 let refreshInFlight: Promise<void> | undefined;
 let latestRequestId = 0;
 let activationInFlight = false;
+let suppressNextQueryEffectRefresh = false;
+
+function clampSelectedIndex(index: number, len: number): number {
+  if (len <= 0) return 0;
+  return Math.min(Math.max(index, 0), len - 1);
+}
 
 function emitResults(items: SearchResult[], selectedIndex: number, requestId: number) {
   emit("results-updated", { results: items, selected: selectedIndex, requestId });
@@ -55,13 +61,7 @@ function debouncedRefresh() {
   clearTimeout(debounceTimer);
   debounceTimer = setTimeout(() => {
     debounceTimer = undefined;
-    const pending = refreshResults();
-    refreshInFlight = pending;
-    void pending.finally(() => {
-      if (refreshInFlight === pending) {
-        refreshInFlight = undefined;
-      }
-    });
+    void runRefresh();
   }, DEBOUNCE_MS);
 }
 
@@ -108,6 +108,20 @@ async function refreshResults() {
   const fs = folderState();
   const q = query();
   const trimmed = q.trim();
+  if (!fs && trimmed === "/r") {
+    perfStartSearch(requestId, "history");
+    const items = await api.getHistoryResults();
+    if (requestId !== latestRequestId) {
+      perfCancelSearch(requestId);
+      return;
+    }
+    setCommandMatches([]);
+    setResults(items);
+    setSelected(0);
+    perfMarkSearchDone(requestId, items.length);
+    emitResults(items, 0, requestId);
+    return;
+  }
   if (!fs && trimmed.startsWith("/")) {
     const matches = filterCommands(q);
     setCommandMatches(matches);
@@ -120,15 +134,16 @@ async function refreshResults() {
   const pathQuery = fs ? null : parsePathQuery(q);
   const source = indexing()
     ? "indexing"
-    : fs || pathQuery
+    : trimmed === "/r"
+      ? "history"
+      : fs || pathQuery
       ? "folder"
-      : q.trim() === ""
-        ? "history"
-        : "query";
+      : "query";
   perfStartSearch(requestId, source);
 
   if (indexing()) {
     setResults([]);
+    setSelected(0);
     perfMarkSearchDone(requestId, 0);
     emitResults([], 0, requestId);
     return;
@@ -140,7 +155,7 @@ async function refreshResults() {
   } else if (pathQuery) {
     items = await api.listFolder(pathQuery.dir, pathQuery.filter);
   } else if (q.trim() === "") {
-    items = await api.getHistoryResults();
+    items = [];
   } else {
     items = await api.search(q);
   }
@@ -151,19 +166,34 @@ async function refreshResults() {
   }
 
   setResults(items);
+  const nextSelected = clampSelectedIndex(selected(), items.length);
+  setSelected(nextSelected);
   perfMarkSearchDone(requestId, items.length);
-  emitResults(items, selected(), requestId);
+  emitResults(items, nextSelected, requestId);
 }
 
 // Auto-refresh when query changes (non-folder mode)
 createEffect(
   on(query, (q) => {
+    if (suppressNextQueryEffectRefresh) {
+      suppressNextQueryEffectRefresh = false;
+      return;
+    }
     if (folderState()) return;
     const trimmed = q.trim();
 
+    if (trimmed === "/r") {
+      clearTimeout(debounceTimer);
+      debounceTimer = undefined;
+      setCommandMatches([]);
+      setSelected(0);
+      void runRefresh();
+      return;
+    }
+
     if (trimmed.startsWith("/")) {
       const cmd = findCommand(q);
-      if (cmd) {
+      if (cmd && cmd.command !== "/r") {
         clearTimeout(debounceTimer);
         debounceTimer = undefined;
         clearCommandModeStateAndEmit();
@@ -194,16 +224,20 @@ createEffect(
 );
 
 function emitSelectionUpdate() {
-  emitResults(results(), selected(), latestRequestId);
+  const nextSelected = clampSelectedIndex(selected(), results().length);
+  if (nextSelected !== selected()) {
+    setSelected(nextSelected);
+  }
+  emitResults(results(), nextSelected, latestRequestId);
 }
 
 function moveSelectionUp() {
-  setSelected((s) => Math.max(0, s - 1));
+  setSelected((s) => clampSelectedIndex(s - 1, results().length));
   emitSelectionUpdate();
 }
 
 function moveSelectionDown() {
-  setSelected((s) => Math.min(results().length - 1, s + 1));
+  setSelected((s) => clampSelectedIndex(s + 1, results().length));
   emitSelectionUpdate();
 }
 
@@ -224,7 +258,7 @@ function enterFolderExpansion(dir: string) {
   void api.recordFolderExpansion(dir);
   setFolderFilter("");
   setSelected(0);
-  refreshResults();
+  void runRefresh();
 }
 
 function exitFolderExpansion(): boolean {
@@ -259,20 +293,32 @@ function navigateFolderUp() {
   setFolderState({ ...fs, currentDir: parent });
   setFolderFilter("");
   setSelected(0);
-  refreshResults();
+  void runRefresh();
+}
+
+function trackRefresh(pending: Promise<void>): Promise<void> {
+  refreshInFlight = pending;
+  void pending.finally(() => {
+    if (refreshInFlight === pending) {
+      refreshInFlight = undefined;
+    }
+  });
+  return pending;
+}
+
+function runRefresh(): Promise<void> {
+  return trackRefresh(
+    refreshResults().catch((e) => {
+      console.error("Failed to refresh results:", e);
+    }),
+  );
 }
 
 async function flushPendingRefresh() {
   if (debounceTimer !== undefined) {
     clearTimeout(debounceTimer);
     debounceTimer = undefined;
-    const pending = refreshResults();
-    refreshInFlight = pending;
-    await pending.finally(() => {
-      if (refreshInFlight === pending) {
-        refreshInFlight = undefined;
-      }
-    });
+    await runRefresh();
     return;
   }
   if (refreshInFlight) {
@@ -280,59 +326,147 @@ async function flushPendingRefresh() {
   }
 }
 
+function resolveActivationIndex(items: SearchResult[], preferredPath?: string): number {
+  if (preferredPath !== undefined) {
+    return items.findIndex((item) => item.path === preferredPath);
+  }
+  return clampSelectedIndex(selected(), items.length);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function resolveActivationTarget(
+  preferredPath?: string,
+): Promise<{ idx: number; result: SearchResult } | null> {
+  await flushPendingRefresh();
+  const items = results();
+  const idx = resolveActivationIndex(items, preferredPath);
+  const result = idx >= 0 ? items[idx] : undefined;
+  if (!result) {
+    return null;
+  }
+  return { idx, result };
+}
+
+function consumeCommandSelection(index: number): boolean {
+  const trimmed = query().trim();
+  if (!folderState() && trimmed.startsWith("/") && commandMatches().length > 0) {
+    const cmd = commandMatches()[index];
+    if (cmd) {
+      if (cmd.command === "/r") {
+        setQuery("/r");
+        setCommandMatches([]);
+        setSelected(0);
+        void runRefresh();
+        return true;
+      }
+      clearCommandModeStateAndEmit();
+      cmd.action();
+      return true;
+    }
+  }
+  return false;
+}
+
+async function launchAndReset(result: SearchResult): Promise<boolean> {
+  if (result.isError) return false;
+
+  // Fix C: launchItem の前に count=0 を先行 emit し、flushPendingRefresh が
+  // 発生させた count>0 ハンドラを rw.show() 到達前に stale 化する
+  emitResults([], 0, ++latestRequestId);
+  let launchError: unknown;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      await api.launchItem(result.path, query());
+      launchError = undefined;
+      break;
+    } catch (e) {
+      launchError = e;
+      if (attempt < 2) {
+        await sleep(120);
+      }
+    }
+  }
+  if (launchError !== undefined) {
+    console.error("Failed to launch item:", launchError);
+    void runRefresh();
+    return false;
+  }
+
+  setFolderState(null);
+  setFolderFilter("");
+  setResults([]);
+  setSelected(0);
+  emitResults([], 0, ++latestRequestId);
+
+  return true;
+}
+
 async function activateSelected(): Promise<boolean> {
   if (activationInFlight) return false;
   activationInFlight = true;
   try {
-    await flushPendingRefresh();
-    if (!folderState() && query().trim().startsWith("/")) {
-      const cmd = commandMatches()[selected()];
-      if (cmd) {
-        clearCommandModeStateAndEmit();
-        cmd.action();
-      }
+    const target = await resolveActivationTarget();
+    if (!target) return false;
+    const { idx, result } = target;
+    if (idx !== selected()) {
+      setSelected(idx);
+    }
+    if (consumeCommandSelection(idx)) return false;
+    return launchAndReset(result);
+  } finally {
+    activationInFlight = false;
+  }
+}
+
+async function activateSelectedByPath(path: string): Promise<boolean> {
+  if (activationInFlight) return false;
+  activationInFlight = true;
+  try {
+    const target = await resolveActivationTarget(path);
+    if (!target) {
       return false;
     }
-    const r = results()[selected()];
-    if (!r) return false;
-
-    if (r.isError) return false;
-
-    // Fix C: launchItem の前に count=0 を先行 emit し、flushPendingRefresh が
-    // 発生させた count>0 ハンドラを rw.show() 到達前に stale 化する
-    emitResults([], 0, ++latestRequestId);
-    await api.launchItem(r.path, query());
-
-    setFolderState(null);
-    setFolderFilter("");
-    setResults([]);
-    setSelected(0);
-    emitResults([], 0, ++latestRequestId);
-
-    return true;
+    const { idx, result } = target;
+    if (idx !== selected()) {
+      setSelected(idx);
+    }
+    if (consumeCommandSelection(idx)) return false;
+    return launchAndReset(result);
   } finally {
     activationInFlight = false;
   }
 }
 
 function resetForShow() {
-  setQuery("");
   setFolderState(null);
+  if (query() !== "") {
+    suppressNextQueryEffectRefresh = true;
+  }
+  setQuery("");
   setFolderFilter("");
   setCommandMatches([]);
   setSelected(0);
-  refreshResults();
+  void runRefresh();
 }
 
 let unlistenIndexingComplete: (() => void) | undefined;
 
 async function initIndexingState() {
-  const state = await api.getIndexingState();
-  setIndexing(state);
+  try {
+    const state = await api.getIndexingState();
+    setIndexing(state);
+  } catch (e) {
+    console.error("Failed to get indexing state:", e);
+  }
 
   unlistenIndexingComplete = await listen("indexing-complete", () => {
     setIndexing(false);
-    refreshResults();
+    void runRefresh();
   });
 }
 
@@ -351,6 +485,7 @@ export {
   exitFolderExpansion,
   navigateFolderUp,
   activateSelected,
+  activateSelectedByPath,
   refreshResults,
   resetForShow,
   indexing,

--- a/workspace/research.md
+++ b/workspace/research.md
@@ -1,0 +1,134 @@
+# 検索ウィンドウ表示直後の履歴リスト不具合 構造調査
+
+## 調査日時
+- 2026-02-25
+- 手法: 静的解析（`ui` / `src-tauri` / `snotra-core` のコード追跡）
+
+## 調査目的
+- 「検索ウィンドウ表示後に出る直近選択アイテム（空クエリ履歴）表示・クリック周辺」で不具合が多発する理由を、個別バグではなく**構造要因**として整理する。
+
+## 対象コード
+- `ui/src/App.tsx`
+- `ui/src/stores/search.ts`
+- `ui/src/components/SearchWindow.tsx`
+- `ui/src/components/ResultsWindow.tsx`
+- `src-tauri/src/main.rs`
+- `src-tauri/src/commands.rs`
+- `snotra-core/src/search.rs`
+- `snotra-core/src/history.rs`
+
+---
+
+## 1. 表示直後フロー（空クエリ履歴）で起きていること
+
+1. Rust 側 `show_main_and_emit()` が `window-shown` を emit（`src-tauri/src/main.rs:65-87`）。
+2. main 側 `App.tsx` が `window-shown` を受け `resetForShow()` 実行（`ui/src/App.tsx:51-57`）。
+3. `resetForShow()` は `query=""` にし `refreshResults()` を即実行（`ui/src/stores/search.ts:335-342`）。
+4. `query` 変更の `createEffect` でも debounce 経由で `refreshResults()` が走り得る（`ui/src/stores/search.ts:166-191`）。
+5. `refreshResults()` は空クエリなら `getHistoryResults()` を呼び、`results-updated` / `results-count-changed` を emit（`ui/src/stores/search.ts:148-163`）。
+6. `results` ウィンドウは別 WebView で、イベント受信して独自 state を更新し行クリック時に index を返す（`ui/src/components/ResultsWindow.tsx:69-110`）。
+7. click は Rust command を経由して `result-clicked(index)` として main に戻る（`src-tauri/src/commands.rs:288-295` → `ui/src/App.tsx:253-261`）。
+
+---
+
+## 2. 不具合が増えやすい構造要因
+
+## C1. 2つの WebView 間で state をイベント同期している（単一状態源が壊れやすい）
+- `main` と `results` は JS コンテキストを共有しないため、`results-updated` イベントを介して擬似同期している。
+- `main` 側 store state と `results` 側 local state が、非同期到着順に依存してズレる可能性がある。
+- 表示直後は `window-shown`, `refresh`, `count-changed`, `render-done`, `click` が短時間に重なるため、ズレが顕在化しやすい。
+
+## C2. クリック確定プロトコルが `index` ベース（アイテム同一性を失う）
+- `ResultRow` click は `notifyResultClicked(idx)` で index のみ送る（`ui/src/components/ResultsWindow.tsx:108`）。
+- main 側で受ける時点の配列が変化していると、同じ index が別アイテムを指す。
+- 現在は `searchResults()[index]` をスナップショットして改善したが、根本的には「path/id を送る」より脆い構造のまま。
+
+## C3. 表示直後に `refresh` が多重発火する設計
+- `resetForShow()` の即時 `refreshResults()` と、`setQuery("")` による effect 側 debounce refresh が共存。
+- これに `SearchWindow.onMount()` の `refreshResults()`、`indexing-complete` refresh も重なる。
+- 表示直後は「複数 request が同一 UI 領域を更新」する前提になっており、クリックタイミングとの競合が起きやすい。
+
+## C4. UI制御（show/hide）をデータイベント（count-changed）に強く結合
+- `results` ウィンドウの表示制御は `results-count-changed` に依存（`ui/src/App.tsx:169-251`）。
+- 本来はウィンドウ状態機械（Visible/Hidden）で扱うべき責務が、検索結果件数イベントに埋め込まれている。
+- そのため stale request / 競合時に「データ更新の遅延」が「ウィンドウ残留・再表示」に直結する。
+
+## C5. requestId 管理が層ごとに分散
+- `search.ts`（データ）、`App.tsx`（ウィンドウ）、`ResultsWindow.tsx`（描画）でそれぞれ requestId を管理。
+- 各層で stale 判定はあるが、全体として単一の state machine ではない。
+- 1箇所のガード漏れが残ると、他層が正しくても不整合が再発する構造。
+
+## C6. 履歴順序の時刻解像度が秒単位（同秒 launch の並びが不安定）
+- `record_launch()` は `as_secs()` で秒単位保存（`snotra-core/src/history.rs:88-97`）。
+- `recent_launches()` は `last_launched` 降順のみで、同値 tie-break がない（`snotra-core/src/history.rs:158-169`）。
+- 連続起動が同一秒に収まると表示順が確定せず、表示更新ごとに体感的な「並び揺れ」が起こり得る。
+- 表示揺れは index クリック設計（C2）と組み合わさると誤選択/無反応に見えやすい。
+
+## C7. 主要 listener 登録が config 取得成功に依存
+- `result-clicked` / `results-count-changed` listener は `if (label === "main" && config)` 内で登録（`ui/src/App.tsx:73-271`）。
+- `getConfig()` 失敗時に listener 未登録となり、表示やクリック経路が部分停止する。
+- 一見「たまにクリックが効かない」症状に見える潜在構造。
+
+## C8. launch 成否が UI に返らない fire-and-forget
+- `launch_item` はスレッド起動後に即復帰し、実行成否を返さない（`src-tauri/src/commands.rs:46-83`）。
+- UI は「呼び出し成功」を「実際に開いた成功」と区別できない。
+- 失敗時はユーザー視点で「クリックしたのに開かない」に見えるが、UI 側は検知不能。
+
+---
+
+## 3. なぜ「表示直後 + 履歴リスト + クリック」で特に壊れやすいか
+
+- 表示直後は state 初期化・履歴取得・ウィンドウ再配置・focus 連動が同時進行する。
+- そのタイミングの履歴リストは「空クエリによる自動更新」の対象で、ユーザーのクリックと並行して再計算される。
+- クリック確定は index 伝搬であるため、更新中のリストに対して同一性保証が弱い。
+- 結果として、同じ不具合に見える症状でも、実体は「配列ズレ」「表示順揺れ」「listener未登録」「launch失敗」の複合で起きる。
+
+---
+
+## 4. あるべき構造（To-Be）
+
+## T1. クリック確定は index ではなく item identity（path または内部ID）で伝搬
+- `results -> main` は `index` ではなく `path` を送る。
+- main 側で `path` を直接起動対象にし、配列変化の影響を受けないようにする。
+
+## T2. 表示直後の refresh を単一入口に統一
+- `window-shown` で実行する refresh を1本化し、同一フェーズで多重発火させない。
+- `resetForShow()` と query effect refresh の重複を整理する。
+
+## T3. データ更新とウィンドウ表示制御を分離
+- `count-changed` で window show/hide を直接決める方式から、明示状態機械へ分離。
+- 例: `Standby -> ShowingHistory -> SearchReady -> Activating -> Closing`
+
+## T4. requestId を UI全体で一元化
+- 層ごとの独立カウンタではなく、共通 generation を配布する。
+- stale 判定ルールを共通化してガード漏れ面積を減らす。
+
+## T5. 履歴順序の tie-break を定義
+- `last_launched` 同値時は `path` などで安定ソートする。
+- 可能なら timestamp 解像度を ms/ns へ上げる。
+
+## T6. listener は config 取得成否と分離して登録
+- core なイベント経路（クリック・結果表示制御）は常に有効化する。
+- config 必須処理だけを条件分岐へ分離する。
+
+## T7. launch 結果を UI へ返す
+- fire-and-forget ではなく、最低限の成功/失敗結果を返し、失敗時にユーザーへ理由を表示する。
+
+---
+
+## 5. 優先度（構造改善の順序）
+
+1. `index` 伝搬の廃止（T1）
+2. 表示直後 refresh の一本化（T2）
+3. listener 登録条件の分離（T6）
+4. 履歴順序の安定化（T5）
+5. launch 成否返却（T7）
+6. requestId 一元化・状態機械化（T3, T4）
+
+---
+
+## 6. 結論
+
+- 不具合多発の主因は、個別ロジックよりも「**分散状態 + index クリック + 多重非同期更新**」という構造の組み合わせ。
+- 直近の修正で一部レースは軽減されたが、構造的には同種の不具合を再生産しやすい設計が残っている。
+- 改善効果が最も高いのは「クリック同一性を path/id 化」し、「表示直後 refresh を単一入口化」すること。


### PR DESCRIPTION
## 概要
- 検索フローを簡素化し、`/r` を使った履歴寄りの検索導線を追加
- システムトレイの recent メニュー連携を追加
- フロント（Solid）と Tauri 側のコマンド/IPC を整理して一貫性を改善

## 主な変更
- `search` ストアの状態遷移と結果反映ロジックの整理
- `App` / `ResultsWindow` / `SearchWindow` のイベント処理調整
- `src-tauri` 側の command/platform 連携更新
- 履歴処理 (`snotra-core/src/history.rs`) の更新

## 補足
- ローカル権限設定の見直し（`.claude/settings.local.json`、`.gitignore`）は #56 で先行マージ済みです。
- 本PRでは、検索体験改善・高速化に関わるコード変更を中心にレビューしてください。