### PR TITLE
perf: 起動経路を遅延初期化へ最適化

### DIFF
--- a/RETROSPECTIVE.md
+++ b/RETROSPECTIVE.md
@@ -90,3 +90,27 @@
 | WM_CONTEXTMENU と WM_RBUTTONUP の二重メニュー | platform.rs | 一部環境での二重表示リスク・未対応 |
 | requestId の二重管理 | App.tsx / search.ts | 現状整合・設計上の注意点として記録 |
 | commands.rs:124 の `"hotkey_registration_failed"` | commands.rs | ユーザーに英語コードが表示される責務違反・今サイクル対象外 |
+
+---
+
+## 6. 設定ウィンドウ初回オープン遅延の自動計測（2026-02-25）
+
+### 計測条件
+- 事前生成廃止後の実装で計測（`settings` は遅延生成）。
+- Tauri バックエンド側で `open_settings` の内部時間をログ化。
+- 1回目（`existed=false`）と2回目（`existed=true`）を同一プロセス内で分離計測。
+- ログ: `workspace/settings_open_bench_double.log`
+
+### 結果（5ラン）
+- 1回目 `open_settings` 内部時間（`total_ms`）: 平均 `4.8ms`（最小 3 / 最大 12）
+- 2回目 `open_settings` 内部時間（`total_ms`）: 平均 `0ms`（全サンプル 0）
+- 1回目 `trigger -> shown`: 平均 `6.2ms`（最小 4 / 最大 13）
+- 2回目 `trigger -> shown`: 平均 `1.4ms`（最小 1 / 最大 2）
+
+### 解釈
+- 「設定ウィンドウ事前生成をやめると初回オープンが重くなるのでは」という懸念に対して、アプリ内部処理の追加コストはミリ秒オーダーで小さい。
+- 既存A/B計測で確認済みの起動時短縮（`setup_exit` 約 `-80ms`）を維持しつつ、設定オープン時の実害は限定的と判断できる。
+
+### 運用メモ
+- ベンチ用フック（`SNOTRA_BENCH_*`、`[startup]`/`[settings-open]` ログ）は計測後に削除済み。
+- 以後の性能確認は、必要時に同等の一時フックを短期導入して再計測する。

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7,8 +7,9 @@ use snotra_core::search::{HistoryBoostConfig, SearchMode};
 use snotra_core::ui_types::SearchResult;
 use snotra_core::window_data::{self, WindowPlacement, WindowSize};
 use tauri::{AppHandle, Emitter, LogicalSize, Manager, State};
+use tauri::{WebviewUrl, WebviewWindowBuilder};
 
-use crate::icon::IconCacheState;
+use crate::icon::{IconCache, IconCacheState};
 use crate::indexing;
 use crate::platform::{PlatformBridge, PlatformCommand};
 use crate::state::AppState;
@@ -16,6 +17,105 @@ use crate::state::AppState;
 #[derive(serde::Serialize, Clone)]
 pub struct SaveConfigResult {
     pub reindex_started: bool,
+}
+
+#[derive(serde::Serialize, Clone)]
+pub struct BootstrapGeneralConfig {
+    pub auto_hide_on_focus_lost: bool,
+}
+
+#[derive(serde::Serialize, Clone)]
+pub struct BootstrapPayload {
+    pub visual: snotra_core::config::VisualConfig,
+    pub general: BootstrapGeneralConfig,
+    pub indexing: bool,
+}
+
+fn ensure_results_window(app: &AppHandle) -> tauri::Result<()> {
+    if app.get_webview_window("results").is_some() {
+        return Ok(());
+    }
+    WebviewWindowBuilder::new(app, "results", WebviewUrl::App(Default::default()))
+        .title("")
+        .inner_size(600.0, 300.0)
+        .visible(false)
+        .decorations(false)
+        .skip_taskbar(true)
+        .always_on_top(true)
+        .resizable(false)
+        .focused(false)
+        .build()?;
+    let _ = set_window_no_activate(app.clone());
+    Ok(())
+}
+
+fn ensure_about_window(app: &AppHandle) -> tauri::Result<()> {
+    if app.get_webview_window("about").is_some() {
+        return Ok(());
+    }
+    let about_window = WebviewWindowBuilder::new(app, "about", WebviewUrl::App(Default::default()))
+        .title("Snotra について")
+        .inner_size(400.0, 300.0)
+        .resizable(false)
+        .visible(false)
+        .build()?;
+
+    let handle_for_about_close = app.clone();
+    about_window.on_window_event(move |event| {
+        if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+            api.prevent_close();
+            if let Some(w) = handle_for_about_close.get_webview_window("about") {
+                let _ = w.hide();
+            }
+        }
+    });
+    Ok(())
+}
+
+pub fn ensure_settings_window(app: &AppHandle) -> tauri::Result<()> {
+    if app.get_webview_window("settings").is_some() {
+        return Ok(());
+    }
+    let settings_window = WebviewWindowBuilder::new(app, "settings", WebviewUrl::App(Default::default()))
+        .title("Snotra 設定")
+        .inner_size(760.0, 560.0)
+        .min_inner_size(520.0, 360.0)
+        .resizable(true)
+        .visible(false)
+        .build()?;
+
+    // Keep window alive to avoid repeated WebView initialization.
+    let handle_for_close = app.clone();
+    settings_window.on_window_event(move |event| {
+        if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+            api.prevent_close();
+            if let Some(w) = handle_for_close.get_webview_window("settings") {
+                let _ = w.hide();
+            }
+            // First-run: start index build when settings is dismissed.
+            let state = handle_for_close.state::<AppState>();
+            if state.indexing.load(Ordering::SeqCst) && !state.index_build_started.load(Ordering::SeqCst)
+            {
+                indexing::start_index_build(&handle_for_close);
+            }
+        }
+    });
+    Ok(())
+}
+
+fn ensure_icon_cache_loaded_if_enabled(state: &State<AppState>, icons: &State<IconCacheState>) {
+    let show_icons = {
+        let cfg = state.config.lock().unwrap();
+        cfg.appearance.show_icons
+    };
+    let mut cache = icons.lock().unwrap();
+    if !show_icons {
+        *cache = None;
+        return;
+    }
+    if cache.is_none() {
+        *cache = Some(IconCache::load());
+    }
 }
 
 #[tauri::command]
@@ -213,8 +313,7 @@ pub fn open_settings(state: State<AppState>, app: AppHandle) -> Result<(), Strin
         return Ok(());
     }
 
-    // The settings window is pre-created in setup() and hidden on close,
-    // so it always exists. Just show and focus it.
+    ensure_settings_window(&app).map_err(|e| e.to_string())?;
     if let Some(w) = app.get_webview_window("settings") {
         let _ = app.emit("settings-shown", ());
         let _ = w.show();
@@ -224,7 +323,12 @@ pub fn open_settings(state: State<AppState>, app: AppHandle) -> Result<(), Strin
 }
 
 #[tauri::command]
-pub fn get_icon_base64(path: String, icons: State<IconCacheState>) -> Option<String> {
+pub fn get_icon_base64(
+    path: String,
+    state: State<AppState>,
+    icons: State<IconCacheState>,
+) -> Option<String> {
+    ensure_icon_cache_loaded_if_enabled(&state, &icons);
     let mut cache = icons.lock().unwrap();
     cache.as_mut()?.get_or_extract(&path)
 }
@@ -232,8 +336,10 @@ pub fn get_icon_base64(path: String, icons: State<IconCacheState>) -> Option<Str
 #[tauri::command]
 pub fn get_icons_batch(
     paths: Vec<String>,
+    state: State<AppState>,
     icons: State<IconCacheState>,
 ) -> std::collections::HashMap<String, String> {
+    ensure_icon_cache_loaded_if_enabled(&state, &icons);
     let mut cache = icons.lock().unwrap();
     match cache.as_mut() {
         Some(c) => c.get_or_extract_batch(&paths),
@@ -380,9 +486,44 @@ pub fn record_folder_expansion(path: String, state: State<AppState>) {
 
 #[tauri::command]
 pub fn open_about(app: AppHandle) -> Result<(), String> {
+    ensure_about_window(&app).map_err(|e| e.to_string())?;
     if let Some(w) = app.get_webview_window("about") {
         let _ = w.show();
         let _ = w.set_focus();
     }
     Ok(())
+}
+
+#[tauri::command]
+pub fn get_bootstrap_payload(state: State<AppState>) -> BootstrapPayload {
+    let config = state.config.lock().unwrap();
+    BootstrapPayload {
+        visual: config.visual.clone(),
+        general: BootstrapGeneralConfig {
+            auto_hide_on_focus_lost: config.general.auto_hide_on_focus_lost,
+        },
+        indexing: state.indexing.load(Ordering::SeqCst),
+    }
+}
+
+#[tauri::command]
+pub fn ensure_window(label: String, app: AppHandle) -> Result<bool, String> {
+    match label.as_str() {
+        "results" => {
+            let existed = app.get_webview_window("results").is_some();
+            ensure_results_window(&app).map_err(|e| e.to_string())?;
+            Ok(!existed)
+        }
+        "about" => {
+            let existed = app.get_webview_window("about").is_some();
+            ensure_about_window(&app).map_err(|e| e.to_string())?;
+            Ok(!existed)
+        }
+        "settings" => {
+            let existed = app.get_webview_window("settings").is_some();
+            ensure_settings_window(&app).map_err(|e| e.to_string())?;
+            Ok(!existed)
+        }
+        _ => Err("unsupported_window_label".to_string()),
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,9 +16,9 @@ use snotra_core::history::HistoryStore;
 use snotra_core::indexer;
 use snotra_core::search::SearchEngine;
 use snotra_core::window_data;
-use tauri::{AppHandle, Emitter, Listener, Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri::{AppHandle, Emitter, Listener, Manager};
 
-use crate::icon::{IconCache, IconCacheState};
+use crate::icon::IconCacheState;
 
 use crate::platform::{PlatformBridge, PlatformCommand};
 use crate::state::AppState;
@@ -101,7 +101,8 @@ fn main() {
     };
 
     let icon_cache_state: IconCacheState = if config.appearance.show_icons {
-        Mutex::new(Some(IconCache::load()))
+        // Lazy-load icon cache on first icon request to keep startup path short.
+        Mutex::new(None)
     } else {
         Mutex::new(None)
     };
@@ -164,6 +165,8 @@ fn main() {
             commands::rebuild_index,
             commands::quit_app,
             commands::record_folder_expansion,
+            commands::get_bootstrap_payload,
+            commands::ensure_window,
         ])
         .setup(move |app| {
             let app_handle = app.handle().clone();
@@ -197,77 +200,12 @@ fn main() {
                 app_handle.manage(Mutex::new(bridge));
             }
 
-            // Create results window (hidden by default)
-            WebviewWindowBuilder::new(app, "results", WebviewUrl::App(Default::default()))
-                .title("")
-                .inner_size(600.0, 300.0)
-                .visible(false)
-                .decorations(false)
-                .skip_taskbar(true)
-                .always_on_top(true)
-                .resizable(false)
-                .focused(false)
-                .build()?;
-            // Apply no-activate at creation time so first show cannot steal focus.
-            let _ = commands::set_window_no_activate(app_handle.clone());
-
-            // Create about window (hidden by default).
-            let about_window =
-                WebviewWindowBuilder::new(app, "about", WebviewUrl::App(Default::default()))
-                    .title("Snotra について")
-                    .inner_size(400.0, 300.0)
-                    .resizable(false)
-                    .visible(false)
-                    .build()?;
-
-            let handle_for_about_close = app_handle.clone();
-            about_window.on_window_event(move |event| {
-                if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                    api.prevent_close();
-                    if let Some(w) = handle_for_about_close.get_webview_window("about") {
-                        let _ = w.hide();
-                    }
-                }
-            });
-
-            // Create settings window (hidden by default).
-            // WebView2 initialization requires a nested message pump, which
-            // deadlocks when called during the event loop (run_on_main_thread /
-            // Tauri command). Creating the window here in setup() — before the
-            // event loop starts — avoids this entirely.
-            let settings_window =
-                WebviewWindowBuilder::new(app, "settings", WebviewUrl::App(Default::default()))
-                    .title("Snotra 設定")
-                    .inner_size(760.0, 560.0)
-                    .min_inner_size(520.0, 360.0)
-                    .resizable(true)
-                    .visible(false)
-                    .build()?;
-
-            // Intercept close to hide instead of destroy.
-            // This keeps the WebView2 instance alive so we never need to
-            // re-create it (which would deadlock during the event loop).
-            let handle_for_close = app_handle.clone();
-            settings_window.on_window_event(move |event| {
-                if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                    api.prevent_close();
-                    if let Some(w) = handle_for_close.get_webview_window("settings") {
-                        let _ = w.hide();
-                    }
-                    // First-run: start index build when settings is dismissed
-                    // (safe to call multiple times — guarded by compare_exchange)
-                    let state = handle_for_close.state::<AppState>();
-                    if state.indexing.load(std::sync::atomic::Ordering::SeqCst)
-                        && !state.index_build_started.load(std::sync::atomic::Ordering::SeqCst)
-                    {
-                        indexing::start_index_build(&handle_for_close);
-                    }
-                }
-            });
-
             if is_first_run {
-                let _ = settings_window.show();
-                let _ = settings_window.set_focus();
+                commands::ensure_settings_window(&app_handle)?;
+                if let Some(settings_window) = app_handle.get_webview_window("settings") {
+                    let _ = settings_window.show();
+                    let _ = settings_window.set_focus();
+                }
             }
 
             // Listen for hotkey toggle events

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -14,7 +14,7 @@ import {
   initIndexingState,
 } from "./stores/search";
 import { applyTheme } from "./lib/theme";
-import type { VisualConfig } from "./lib/types";
+import type { BootstrapPayload, VisualConfig } from "./lib/types";
 import * as api from "./lib/invoke";
 import { perfMarkRenderDone } from "./lib/perf";
 
@@ -44,6 +44,7 @@ const App: Component = () => {
 
     const getResultsWindow = async () => {
       if (!resultsWindowPromise) {
+        await api.ensureWindow("results");
         resultsWindowPromise = WebviewWindow.getByLabel("results");
       }
       return resultsWindowPromise;
@@ -108,10 +109,9 @@ const App: Component = () => {
             latestResultsRequestId = requestId;
             const isStale = () => requestId !== latestResultsRequestId;
 
-            const rw = await getResultsWindow();
-            if (!rw || isStale()) return;
-
             if (count === 0) {
+              const rw = await WebviewWindow.getByLabel("results");
+              if (!rw || isStale()) return;
               const visible = await rw.isVisible();
               if (isStale()) return;
               if (visible) {
@@ -119,6 +119,8 @@ const App: Component = () => {
               }
               return;
             }
+            const rw = await getResultsWindow();
+            if (!rw || isStale()) return;
 
             // Use current main window width (may have been updated via settings)
             const [currentSize, currentSf, mainPos, mainVisible] = await Promise.all([
@@ -267,20 +269,21 @@ const App: Component = () => {
     }
 
     // Listen for visual config changes (all windows)
-    listen<VisualConfig>("visual-config-changed", (event) => {
+    const unlistenVisual = await listen<VisualConfig>("visual-config-changed", (event) => {
       applyTheme(event.payload);
     });
+    unlistenFns.push(unlistenVisual);
 
-    // Load config and apply theme (non-fatal on failure)
-    let config: Awaited<ReturnType<typeof api.getConfig>> | null = null;
+    // Load bootstrap payload and apply theme (non-fatal on failure)
+    let bootstrap: BootstrapPayload | null = null;
     try {
-      config = await api.getConfig();
-      applyTheme(config.visual);
+      bootstrap = await api.getBootstrapPayload();
+      applyTheme(bootstrap.visual);
     } catch (e) {
-      console.error("Failed to load config/apply theme:", e);
+      console.error("Failed to load bootstrap payload:", e);
     }
 
-    if (label === "main" && config?.general.auto_hide_on_focus_lost) {
+    if (label === "main" && bootstrap?.general.auto_hide_on_focus_lost) {
       registerAutoHideOnFocusLost?.();
     }
 

--- a/ui/src/lib/invoke.ts
+++ b/ui/src/lib/invoke.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { Config, SearchResult } from "./types";
+import type { BootstrapPayload, Config, SearchResult } from "./types";
 
 export async function search(query: string): Promise<SearchResult[]> {
   return invoke<SearchResult[]>("search", { query });
@@ -37,6 +37,10 @@ export async function saveConfig(config: Config): Promise<SaveConfigResult> {
 
 export async function getConfig(): Promise<Config> {
   return invoke<Config>("get_config");
+}
+
+export async function getBootstrapPayload(): Promise<BootstrapPayload> {
+  return invoke<BootstrapPayload>("get_bootstrap_payload");
 }
 
 export async function getIconBase64(path: string): Promise<string | null> {
@@ -123,6 +127,10 @@ export async function quitApp(): Promise<void> {
 
 export async function openAbout(): Promise<void> {
   return invoke("open_about");
+}
+
+export async function ensureWindow(label: "results" | "about"): Promise<boolean> {
+  return invoke<boolean>("ensure_window", { label });
 }
 
 export async function recordFolderExpansion(path: string): Promise<void> {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -63,3 +63,13 @@ export interface Config {
   paths: PathsConfig;
   search: SearchConfig;
 }
+
+export interface BootstrapGeneralConfig {
+  auto_hide_on_focus_lost: boolean;
+}
+
+export interface BootstrapPayload {
+  visual: VisualConfig;
+  general: BootstrapGeneralConfig;
+  indexing: boolean;
+}


### PR DESCRIPTION
## 対応Issue
- Closes #54

## 変更内容

- 起動時の `settings` 事前生成を廃止し、`open_settings` 時の遅延生成へ変更
- `results` / `about` の遅延生成を維持しつつ、`ensure_window` API を拡張
- 起動時の bootstrap 取得導線を追加（`get_bootstrap_payload`）
- アイコンキャッシュを起動時ロードから遅延ロードへ変更
- 設定ウィンドウ初回/2回目オープンの計測結果を `RETROSPECTIVE.md` に追記

## 確認

- `cargo check`
- `npm run typecheck`