### PR TITLE
fix: paths.scan の正規化と重複統合

### DIFF
--- a/snotra-core/src/config.rs
+++ b/snotra-core/src/config.rs
@@ -306,6 +306,84 @@ pub struct PathsConfig {
     pub scan: Vec<ScanPath>,
 }
 
+fn is_drive_root(path: &str) -> bool {
+    let b = path.as_bytes();
+    b.len() == 3 && b[1] == b':' && b[2] == b'\\'
+}
+
+fn normalize_scan_path_key(path: &str) -> String {
+    let mut key = path.trim().replace('/', "\\").to_lowercase();
+    if key.ends_with('\\') && !is_drive_root(&key) {
+        let trimmed_len = key.trim_end_matches('\\').len();
+        key.truncate(trimmed_len);
+    }
+    key
+}
+
+fn normalize_extension(ext: &str) -> String {
+    let trimmed = ext.trim().trim_start_matches('.');
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    format!(".{}", trimmed.to_lowercase())
+}
+
+fn normalize_extensions(exts: &[String]) -> Vec<String> {
+    let mut result: Vec<String> = exts
+        .iter()
+        .map(|e| normalize_extension(e))
+        .filter(|e| !e.is_empty())
+        .collect();
+    result.sort();
+    result.dedup();
+    result
+}
+
+pub fn dedup_scan_paths(scan: &[ScanPath]) -> Vec<ScanPath> {
+    let mut result: Vec<ScanPath> = Vec::new();
+    let mut keys: Vec<String> = Vec::new();
+
+    for sp in scan {
+        let trimmed = sp.path.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let key = normalize_scan_path_key(trimmed);
+        let exts = normalize_extensions(&sp.extensions);
+
+        if let Some(pos) = keys.iter().position(|k| k == &key) {
+            let existing = &mut result[pos];
+            for ext in &exts {
+                if !existing.extensions.iter().any(|e| e == ext) {
+                    existing.extensions.push(ext.clone());
+                }
+            }
+            existing.extensions.sort();
+            existing.include_folders |= sp.include_folders;
+        } else {
+            keys.push(key);
+            result.push(ScanPath {
+                path: trimmed.to_string(),
+                extensions: exts,
+                include_folders: sp.include_folders,
+            });
+        }
+    }
+
+    result
+}
+
+impl PathsConfig {
+    pub fn normalize_scan_paths(&mut self) -> bool {
+        let normalized = dedup_scan_paths(&self.scan);
+        if normalized != self.scan {
+            self.scan = normalized;
+            return true;
+        }
+        false
+    }
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {
@@ -429,6 +507,9 @@ impl Config {
                 }
                 #[allow(deprecated)]
                 if config.search.sanitize() {
+                    needs_save = true;
+                }
+                if config.paths.normalize_scan_paths() {
                     needs_save = true;
                 }
                 if needs_save {
@@ -1014,6 +1095,221 @@ mod tests {
         }];
         let errors = config.validate();
         assert!(errors.contains(&ConfigError::ScanPathEmpty { index: 0 }));
+    }
+
+    // ---- normalize_scan_path_key tests ----
+
+    #[test]
+    fn normalize_scan_path_key_case_insensitive() {
+        assert_eq!(normalize_scan_path_key("C:\\Tools"), "c:\\tools");
+    }
+
+    #[test]
+    fn normalize_scan_path_key_slash_to_backslash() {
+        assert_eq!(normalize_scan_path_key("C:/Tools"), "c:\\tools");
+    }
+
+    #[test]
+    fn normalize_scan_path_key_trims_whitespace() {
+        assert_eq!(normalize_scan_path_key("  C:\\Tools  "), "c:\\tools");
+    }
+
+    #[test]
+    fn normalize_scan_path_key_strips_trailing_backslash() {
+        assert_eq!(normalize_scan_path_key("C:\\Tools\\"), "c:\\tools");
+    }
+
+    #[test]
+    fn normalize_scan_path_key_preserves_drive_root() {
+        assert_eq!(normalize_scan_path_key("C:\\"), "c:\\");
+    }
+
+    #[test]
+    fn normalize_scan_path_key_drive_root_forward_slash() {
+        assert_eq!(normalize_scan_path_key("C:/"), "c:\\");
+    }
+
+    #[test]
+    fn normalize_scan_path_key_equivalence() {
+        let a = normalize_scan_path_key("C:\\Tools");
+        let b = normalize_scan_path_key("c:/tools");
+        let c = normalize_scan_path_key("  C:\\Tools\\  ");
+        assert_eq!(a, b);
+        assert_eq!(b, c);
+    }
+
+    // ---- normalize_extension tests ----
+
+    #[test]
+    fn normalize_extension_adds_dot() {
+        assert_eq!(normalize_extension("exe"), ".exe");
+    }
+
+    #[test]
+    fn normalize_extension_keeps_dot() {
+        assert_eq!(normalize_extension(".exe"), ".exe");
+    }
+
+    #[test]
+    fn normalize_extension_lowercases() {
+        assert_eq!(normalize_extension(".EXE"), ".exe");
+    }
+
+    #[test]
+    fn normalize_extension_empty() {
+        assert_eq!(normalize_extension(""), "");
+        assert_eq!(normalize_extension("."), "");
+        assert_eq!(normalize_extension("  "), "");
+    }
+
+    // ---- dedup_scan_paths tests ----
+
+    #[test]
+    fn dedup_scan_paths_merges_case_variants() {
+        let scan = vec![
+            ScanPath {
+                path: "C:\\Tools".to_string(),
+                extensions: vec![".exe".to_string()],
+                include_folders: false,
+            },
+            ScanPath {
+                path: "c:\\TOOLS".to_string(),
+                extensions: vec![".bat".to_string()],
+                include_folders: true,
+            },
+        ];
+        let result = dedup_scan_paths(&scan);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].path, "C:\\Tools");
+        assert_eq!(result[0].extensions, vec![".bat", ".exe"]);
+        assert!(result[0].include_folders);
+    }
+
+    #[test]
+    fn dedup_scan_paths_preserves_first_seen_order() {
+        let scan = vec![
+            ScanPath {
+                path: "D:\\Apps".to_string(),
+                extensions: vec![".exe".to_string()],
+                include_folders: false,
+            },
+            ScanPath {
+                path: "C:\\Tools".to_string(),
+                extensions: vec![".lnk".to_string()],
+                include_folders: false,
+            },
+            ScanPath {
+                path: "d:/apps".to_string(),
+                extensions: vec![".bat".to_string()],
+                include_folders: false,
+            },
+        ];
+        let result = dedup_scan_paths(&scan);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].path, "D:\\Apps");
+        assert_eq!(result[1].path, "C:\\Tools");
+    }
+
+    #[test]
+    fn dedup_scan_paths_normalizes_extensions() {
+        let scan = vec![ScanPath {
+            path: "C:\\Tools".to_string(),
+            extensions: vec!["EXE".to_string(), ".exe".to_string(), "bat".to_string()],
+            include_folders: false,
+        }];
+        let result = dedup_scan_paths(&scan);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].extensions, vec![".bat", ".exe"]);
+    }
+
+    #[test]
+    fn dedup_scan_paths_skips_empty_paths() {
+        let scan = vec![
+            ScanPath {
+                path: "".to_string(),
+                extensions: vec![".exe".to_string()],
+                include_folders: false,
+            },
+            ScanPath {
+                path: "  ".to_string(),
+                extensions: vec![".bat".to_string()],
+                include_folders: false,
+            },
+        ];
+        let result = dedup_scan_paths(&scan);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn dedup_scan_paths_trailing_backslash_merge() {
+        let scan = vec![
+            ScanPath {
+                path: "C:\\Tools".to_string(),
+                extensions: vec![".exe".to_string()],
+                include_folders: false,
+            },
+            ScanPath {
+                path: "C:\\Tools\\".to_string(),
+                extensions: vec![".bat".to_string()],
+                include_folders: false,
+            },
+        ];
+        let result = dedup_scan_paths(&scan);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].path, "C:\\Tools");
+        assert_eq!(result[0].extensions, vec![".bat", ".exe"]);
+    }
+
+    #[test]
+    fn dedup_scan_paths_no_duplicates_unchanged() {
+        let scan = vec![
+            ScanPath {
+                path: "C:\\Tools".to_string(),
+                extensions: vec![".exe".to_string()],
+                include_folders: false,
+            },
+            ScanPath {
+                path: "D:\\Apps".to_string(),
+                extensions: vec![".bat".to_string()],
+                include_folders: false,
+            },
+        ];
+        let result = dedup_scan_paths(&scan);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].path, "C:\\Tools");
+        assert_eq!(result[1].path, "D:\\Apps");
+    }
+
+    // ---- PathsConfig::normalize_scan_paths tests ----
+
+    #[test]
+    fn normalize_scan_paths_returns_true_when_changed() {
+        let mut config = Config::default();
+        config.paths.scan = vec![
+            ScanPath {
+                path: "C:\\Tools".to_string(),
+                extensions: vec![".exe".to_string()],
+                include_folders: false,
+            },
+            ScanPath {
+                path: "c:\\tools".to_string(),
+                extensions: vec![".bat".to_string()],
+                include_folders: false,
+            },
+        ];
+        assert!(config.paths.normalize_scan_paths());
+        assert_eq!(config.paths.scan.len(), 1);
+    }
+
+    #[test]
+    fn normalize_scan_paths_returns_false_when_no_change() {
+        let mut config = Config::default();
+        config.paths.scan = vec![ScanPath {
+            path: "C:\\Tools".to_string(),
+            extensions: vec![".exe".to_string()],
+            include_folders: false,
+        }];
+        assert!(!config.paths.normalize_scan_paths());
     }
 
     // ---- find_matching_tools tests ----

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -33,10 +33,12 @@ pub fn load_config() -> Config {
 
 #[tauri::command]
 pub fn save_config(
-    config: Config,
+    mut config: Config,
     state: State<AppState>,
     app: AppHandle,
 ) -> Result<SaveConfigResult, String> {
+    config.paths.normalize_scan_paths();
+
     // Clone old config and drop the engine lock before platform bridge communication
     let old_config = state.engine.lock().unwrap().config().clone();
 

--- a/ui/src/components/SettingsIndex.tsx
+++ b/ui/src/components/SettingsIndex.tsx
@@ -1,9 +1,34 @@
 import type { Component } from "solid-js";
 import { createEffect, createSignal, For, Show } from "solid-js";
 import { open } from "@tauri-apps/plugin-dialog";
-import { draft, updateDraft } from "../stores/settings";
+import { draft, updateDraft, setStatus } from "../stores/settings";
 import SettingRow from "./SettingRow";
 import ToggleSwitch from "./ToggleSwitch";
+
+function normalizeScanPathKey(path: string): string {
+  let key = path.trim().replace(/\//g, "\\").toLowerCase();
+  if (key.endsWith("\\") && !/^[a-z]:\\$/.test(key)) {
+    key = key.replace(/\\+$/, "");
+  }
+  return key;
+}
+
+function parseExtensions(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function mergeExtensions(target: { extensions: string[] }, exts: string[]): void {
+  for (const ext of exts) {
+    const norm = ext.startsWith(".") ? ext.toLowerCase() : `.${ext.toLowerCase()}`;
+    if (!target.extensions.some((e) => e.toLowerCase() === norm)) {
+      target.extensions.push(norm);
+    }
+  }
+  target.extensions.sort();
+}
 
 const SettingsIndex: Component = () => {
   const d = () => draft()!;
@@ -12,6 +37,14 @@ const SettingsIndex: Component = () => {
   const [editPath, setEditPath] = createSignal("");
   const [editExtensions, setEditExtensions] = createSignal("");
   const [editIncludeFolders, setEditIncludeFolders] = createSignal(false);
+
+  function findDuplicateIndex(path: string, excludeIndex: number | null): number {
+    const key = normalizeScanPathKey(path);
+    if (!key) return -1;
+    return d().paths.scan.findIndex(
+      (sp, i) => i !== excludeIndex && normalizeScanPathKey(sp.path) === key
+    );
+  }
 
   // Sync form fields when selection changes
   createEffect(() => {
@@ -33,23 +66,44 @@ const SettingsIndex: Component = () => {
   function applyEdit() {
     const idx = selectedIndex();
     if (idx === null) return;
+
+    const dupIdx = findDuplicateIndex(editPath(), idx);
+    if (dupIdx >= 0) {
+      const extensions = parseExtensions(editExtensions());
+      const includeFolders = editIncludeFolders();
+      updateDraft((c) => {
+        mergeExtensions(c.paths.scan[dupIdx], extensions);
+        if (includeFolders) c.paths.scan[dupIdx].include_folders = true;
+        c.paths.scan.splice(idx, 1);
+      });
+      setSelectedIndex(dupIdx > idx ? dupIdx - 1 : dupIdx);
+      setStatus("重複するパスを統合しました");
+      return;
+    }
+
     updateDraft((c) => {
       c.paths.scan[idx].path = editPath();
-      c.paths.scan[idx].extensions = editExtensions()
-        .split(",")
-        .map((s) => s.trim())
-        .filter((s) => s.length > 0);
+      c.paths.scan[idx].extensions = parseExtensions(editExtensions());
       c.paths.scan[idx].include_folders = editIncludeFolders();
     });
   }
 
   function addScanPath() {
     const path = editPath();
-    const extensions = editExtensions()
-      .split(",")
-      .map((s) => s.trim())
-      .filter((s) => s.length > 0);
+    const extensions = parseExtensions(editExtensions());
     const includeFolders = editIncludeFolders();
+
+    const dupIdx = findDuplicateIndex(path, null);
+    if (dupIdx >= 0) {
+      updateDraft((c) => {
+        mergeExtensions(c.paths.scan[dupIdx], extensions);
+        if (includeFolders) c.paths.scan[dupIdx].include_folders = true;
+      });
+      setSelectedIndex(dupIdx);
+      setStatus("既存のパスに統合しました");
+      return;
+    }
+
     updateDraft((c) => {
       c.paths.scan.push({ path, extensions, include_folders: includeFolders });
     });
@@ -207,6 +261,7 @@ const SettingsIndex: Component = () => {
                   参照...
                 </button>
               </div>
+              <span class="scan-path-form-hint">同じパスは自動的に統合されます</span>
             </label>
             <label>
               拡張子 (カンマ区切り)

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -632,3 +632,9 @@
   font-size: 0.85em;
   color: var(--hint-text-color, #808080);
 }
+
+.scan-path-form-hint {
+  font-size: 0.75em;
+  color: var(--hint-text-color, #808080);
+  opacity: 0.7;
+}


### PR DESCRIPTION
## Summary

- `paths.scan` に大小文字違い・スラッシュ違いで同一パスを複数登録できる問題を修正
- バックエンド（防御線）と UI（即時フィードバック）の両方で正規化・重複統合を実装
- 表記揺れだけで不要な再インデックスが走るバグを解消

## 変更内容

### snotra-core/src/config.rs
- `normalize_scan_path_key`: trim → `/`→`\` → lowercase → 末尾 `\` 除去（ドライブルート除く）
- `normalize_extension` / `normalize_extensions`: 拡張子を `.ext` 形式に統一・ソート・dedup
- `dedup_scan_paths`: 正規化キーで重複検知し、extensions を union・include_folders を OR でマージ
- `PathsConfig::normalize_scan_paths()`: `Config::load()` に migrate → sanitize → **normalize** の順で統合
- テスト 19件追加

### src-tauri/src/commands/config.rs
- `save_config` の冒頭で `normalize_scan_paths()` を呼び出し、表記揺れによる `index_changed = true` を防止

### ui/src/components/SettingsIndex.tsx
- `addScanPath`: 重複検知 → 既存行にマージ +「既存のパスに統合しました」表示
- `applyEdit`: 重複検知 → マージ後に元行を削除 + 「重複するパスを統合しました」表示
- `parseExtensions` / `mergeExtensions` ヘルパーで拡張子処理を DRY 化
- パス入力フォームにヒントテキストを追加

### ui/src/styles/settings.css
- `.scan-path-form-hint` スタイルを追加

## Test plan

- [x] `cargo test -p snotra-core` — 新規テスト 19件すべて pass
- [x] `cargo check -p snotra-core -p snotra` — コンパイル成功
- [x] `npm run build` — フロントエンドビルド成功
- [x] 手動: 設定画面で `C:\Tools` を追加後、`c:/tools` を追加 → 「既存のパスに統合しました」+ 1行にマージ
- [x] 手動: 既存行を編集して別の既存行と同じパスに変更 → 「重複するパスを統合しました」+ マージ
- [x] 手動: config.toml に重複パスを手書き → 起動後に正規化されて1行に統合されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)