### PR TITLE
fix: オープナーの拡張子表記とグルーピングを統一

### DIFF
--- a/snotra-core/src/config.rs
+++ b/snotra-core/src/config.rs
@@ -339,6 +339,27 @@ fn normalize_extensions(exts: &[String]) -> Vec<String> {
     result
 }
 
+fn normalize_opener_target(target: &str) -> String {
+    let trimmed = target.trim();
+    if trimmed.eq_ignore_ascii_case("folder") {
+        return "folder".to_string();
+    }
+
+    if let Some((kind, raw_exts)) = trimmed.split_once(':')
+        && kind.eq_ignore_ascii_case("ext")
+    {
+        let exts = normalize_extensions(
+            &raw_exts
+                .split(',')
+                .map(|ext| ext.to_string())
+                .collect::<Vec<_>>(),
+        );
+        return format!("ext:{}", exts.join(","));
+    }
+
+    trimmed.to_string()
+}
+
 pub fn dedup_scan_paths(scan: &[ScanPath]) -> Vec<ScanPath> {
     let mut result: Vec<ScanPath> = Vec::new();
     let mut keys: Vec<String> = Vec::new();
@@ -366,6 +387,27 @@ pub fn dedup_scan_paths(scan: &[ScanPath]) -> Vec<ScanPath> {
                 path: trimmed.to_string(),
                 extensions: exts,
                 include_folders: sp.include_folders,
+            });
+        }
+    }
+
+    result
+}
+
+pub fn normalize_openers(openers: &[OpenerRule]) -> Vec<OpenerRule> {
+    let mut result: Vec<OpenerRule> = Vec::new();
+    let mut targets: Vec<String> = Vec::new();
+
+    for rule in openers {
+        let target = normalize_opener_target(&rule.target);
+
+        if let Some(pos) = targets.iter().position(|existing| existing == &target) {
+            result[pos].tools.extend(rule.tools.iter().cloned());
+        } else {
+            targets.push(target.clone());
+            result.push(OpenerRule {
+                target,
+                tools: rule.tools.clone(),
             });
         }
     }
@@ -512,6 +554,9 @@ impl Config {
                 if config.paths.normalize_scan_paths() {
                     needs_save = true;
                 }
+                if config.normalize_openers() {
+                    needs_save = true;
+                }
                 if needs_save {
                     config.save();
                 }
@@ -573,6 +618,15 @@ impl Config {
         }
 
         errors
+    }
+
+    pub fn normalize_openers(&mut self) -> bool {
+        let normalized = normalize_openers(&self.openers);
+        if normalized != self.openers {
+            self.openers = normalized;
+            return true;
+        }
+        false
     }
 }
 
@@ -1162,6 +1216,30 @@ mod tests {
         assert_eq!(normalize_extension("  "), "");
     }
 
+    #[test]
+    fn normalize_opener_target_adds_dot_and_sorts_extensions() {
+        assert_eq!(
+            normalize_opener_target("ext: png, .JPG, gif , png"),
+            "ext:.gif,.jpg,.png"
+        );
+    }
+
+    #[test]
+    fn normalize_openers_merges_equivalent_targets() {
+        let openers = vec![
+            make_rule("ext:png,jpg", &[("Viewer 1", "viewer.exe", "")]),
+            make_rule("ext:.jpg,.png", &[("Viewer 2", "viewer2.exe", "")]),
+        ];
+
+        let normalized = normalize_openers(&openers);
+
+        assert_eq!(normalized.len(), 1);
+        assert_eq!(normalized[0].target, "ext:.jpg,.png");
+        assert_eq!(normalized[0].tools.len(), 2);
+        assert_eq!(normalized[0].tools[0].name, "Viewer 1");
+        assert_eq!(normalized[0].tools[1].name, "Viewer 2");
+    }
+
     // ---- dedup_scan_paths tests ----
 
     #[test]
@@ -1310,6 +1388,23 @@ mod tests {
             include_folders: false,
         }];
         assert!(!config.paths.normalize_scan_paths());
+    }
+
+    #[test]
+    fn normalize_openers_returns_true_when_changed() {
+        let mut config = Config::default();
+        config.openers = vec![make_rule("ext:png,jpg", &[("Viewer", "viewer.exe", "")])];
+
+        assert!(config.normalize_openers());
+        assert_eq!(config.openers[0].target, "ext:.jpg,.png");
+    }
+
+    #[test]
+    fn normalize_openers_returns_false_when_no_change() {
+        let mut config = Config::default();
+        config.openers = vec![make_rule("ext:.jpg,.png", &[("Viewer", "viewer.exe", "")])];
+
+        assert!(!config.normalize_openers());
     }
 
     // ---- find_matching_tools tests ----

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -38,6 +38,7 @@ pub fn save_config(
     app: AppHandle,
 ) -> Result<SaveConfigResult, String> {
     config.paths.normalize_scan_paths();
+    config.normalize_openers();
 
     // Clone old config and drop the engine lock before platform bridge communication
     let old_config = state.engine.lock().unwrap().config().clone();

--- a/ui/src/components/SettingsOpener.tsx
+++ b/ui/src/components/SettingsOpener.tsx
@@ -1,39 +1,35 @@
 import type { Component } from "solid-js";
 import { createSignal, For, Show } from "solid-js";
 import { open } from "@tauri-apps/plugin-dialog";
-import type { OpenerRule, OpenerTool } from "../lib/types";
+import type { OpenerRule } from "../lib/types";
+import type { GroupedOpenerEntry } from "../lib/openerGroups";
+import {
+  buildGroupedOpeners,
+  cloneGroupedOpenerEntry,
+  isSameGroupedOpener,
+  mergeGroupedOpenerEntries,
+  serializeGroupedOpeners,
+} from "../lib/openerGroups";
+import {
+  getOpenerTargetExtensions,
+  normalizeOpenerTarget,
+} from "../lib/openerTarget";
 import { draft, updateDraft } from "../stores/settings";
 import SettingsEditableList from "./SettingsEditableList";
 import SettingsEditorActions from "./SettingsEditorActions";
 import SettingsEditorModal from "./SettingsEditorModal";
 
-type FlatEntry = {
-  ruleIndex: number;
-  toolIndex: number;
+type FlatEntry = GroupedOpenerEntry & {
   targetLabel: string;
   toolName: string;
 };
 
 function buildFlatList(openers: OpenerRule[]): FlatEntry[] {
-  const entries: FlatEntry[] = [];
-  for (let ri = 0; ri < openers.length; ri++) {
-    const rule = openers[ri];
-    const targetLabel =
-      rule.target === "folder"
-        ? "フォルダ"
-        : rule.target.startsWith("ext:")
-          ? rule.target.slice(4)
-          : rule.target;
-    for (let ti = 0; ti < rule.tools.length; ti++) {
-      entries.push({
-        ruleIndex: ri,
-        toolIndex: ti,
-        targetLabel,
-        toolName: rule.tools[ti].name || "(名前未設定)",
-      });
-    }
-  }
-  return entries;
+  return buildGroupedOpeners(openers).map((entry) => ({
+    ...entry,
+    targetLabel: entry.targetKind === "folder" ? "フォルダ" : entry.extensions.join(","),
+    toolName: entry.tool.name || "(名前未設定)",
+  }));
 }
 
 const SettingsOpener: Component = () => {
@@ -76,72 +72,75 @@ const SettingsOpener: Component = () => {
     if (!entry) {
       return;
     }
-    const rule = d().openers[entry.ruleIndex];
-    const tool = rule?.tools[entry.toolIndex];
-    if (!rule || !tool) {
-      return;
-    }
     setEditingFlat(flatIndex);
-    if (rule.target === "folder") {
+    if (entry.targetKind === "folder") {
       setEditTarget("folder");
       setEditTargetExt("");
     } else {
       setEditTarget("ext");
-      setEditTargetExt(rule.target.startsWith("ext:") ? rule.target.slice(4) : rule.target);
+      setEditTargetExt(entry.extensions.join(","));
     }
-    setEditToolName(tool.name);
-    setEditToolExe(tool.exe);
-    setEditToolArgs(tool.args);
+    setEditToolName(entry.tool.name);
+    setEditToolExe(entry.tool.exe);
+    setEditToolArgs(entry.tool.args);
     setModalMode("edit");
   }
 
   function buildTarget(): string {
-    return editTarget() === "folder" ? "folder" : `ext:${editTargetExt()}`;
+    return editTarget() === "folder"
+      ? "folder"
+      : normalizeOpenerTarget(`ext:${editTargetExt()}`);
+  }
+
+  function buildEntryFromForm(): GroupedOpenerEntry {
+    const target = buildTarget();
+    return {
+      targetKind: target === "folder" ? "folder" : "ext",
+      extensions:
+        target === "folder"
+          ? []
+          : getOpenerTargetExtensions(target)
+              .split(",")
+              .filter((ext) => ext.length > 0),
+      tool: {
+        name: editToolName(),
+        exe: editToolExe(),
+        args: editToolArgs(),
+      },
+    };
   }
 
   function saveEntry() {
-    const target = buildTarget();
-    const tool: OpenerTool = {
-      name: editToolName(),
-      exe: editToolExe(),
-      args: editToolArgs(),
-    };
+    const entries = flatList().map((entry) =>
+      cloneGroupedOpenerEntry({
+        targetKind: entry.targetKind,
+        extensions: entry.extensions,
+        tool: entry.tool,
+      }),
+    );
+    const nextEntry = buildEntryFromForm();
 
     if (modalMode() === "edit") {
       const fi = editingFlat();
       if (fi === null) return;
-      const entry = flatList()[fi];
-      if (!entry) return;
-
-      updateDraft((c) => {
-        const oldRule = c.openers[entry.ruleIndex];
-        if (oldRule.target === target) {
-          oldRule.tools[entry.toolIndex] = tool;
-          return;
-        }
-
-        oldRule.tools.splice(entry.toolIndex, 1);
-        if (oldRule.tools.length === 0) {
-          c.openers.splice(entry.ruleIndex, 1);
-        }
-        const newRuleIdx = c.openers.findIndex((r) => r.target === target);
-        if (newRuleIdx >= 0) {
-          c.openers[newRuleIdx].tools.push(tool);
-        } else {
-          c.openers.push({ target, tools: [tool] });
-        }
-      });
-      closeModal();
-      return;
+      entries.splice(fi, 1);
+      const mergeIndex = entries.findIndex((entry) => isSameGroupedOpener(entry, nextEntry));
+      if (mergeIndex >= 0) {
+        entries[mergeIndex] = mergeGroupedOpenerEntries(entries[mergeIndex], nextEntry);
+      } else {
+        entries.splice(Math.min(fi, entries.length), 0, nextEntry);
+      }
+    } else {
+      const mergeIndex = entries.findIndex((entry) => isSameGroupedOpener(entry, nextEntry));
+      if (mergeIndex >= 0) {
+        entries[mergeIndex] = mergeGroupedOpenerEntries(entries[mergeIndex], nextEntry);
+      } else {
+        entries.push(nextEntry);
+      }
     }
 
     updateDraft((c) => {
-      const existingRuleIdx = c.openers.findIndex((r) => r.target === target);
-      if (existingRuleIdx >= 0) {
-        c.openers[existingRuleIdx].tools.push(tool);
-      } else {
-        c.openers.push({ target, tools: [tool] });
-      }
+      c.openers = serializeGroupedOpeners(entries);
     });
     closeModal();
   }
@@ -149,24 +148,33 @@ const SettingsOpener: Component = () => {
   function deleteEntry() {
     const fi = editingFlat();
     if (fi === null) return;
-    const entry = flatList()[fi];
-    if (!entry) return;
+    const entries = flatList().map((entry) =>
+      cloneGroupedOpenerEntry({
+        targetKind: entry.targetKind,
+        extensions: entry.extensions,
+        tool: entry.tool,
+      }),
+    );
+    if (!entries[fi]) return;
+    entries.splice(fi, 1);
     updateDraft((c) => {
-      c.openers[entry.ruleIndex].tools.splice(entry.toolIndex, 1);
-      if (c.openers[entry.ruleIndex].tools.length === 0) {
-        c.openers.splice(entry.ruleIndex, 1);
-      }
+      c.openers = serializeGroupedOpeners(entries);
     });
     closeModal();
   }
 
   function moveUpAt(fi: number) {
-    const entry = flatList()[fi];
-    if (!entry || entry.toolIndex === 0) return;
-    const { ruleIndex: ri, toolIndex: ti } = entry;
+    if (fi <= 0) return;
+    const entries = flatList().map((entry) =>
+      cloneGroupedOpenerEntry({
+        targetKind: entry.targetKind,
+        extensions: entry.extensions,
+        tool: entry.tool,
+      }),
+    );
     updateDraft((c) => {
-      const tools = c.openers[ri].tools;
-      [tools[ti - 1], tools[ti]] = [tools[ti], tools[ti - 1]];
+      [entries[fi - 1], entries[fi]] = [entries[fi], entries[fi - 1]];
+      c.openers = serializeGroupedOpeners(entries);
     });
     if (editingFlat() === fi) {
       setEditingFlat(fi - 1);
@@ -174,14 +182,17 @@ const SettingsOpener: Component = () => {
   }
 
   function moveDownAt(fi: number) {
-    const entry = flatList()[fi];
-    if (!entry) return;
-    const { ruleIndex: ri, toolIndex: ti } = entry;
-    const toolCount = d().openers[ri]?.tools.length ?? 0;
-    if (ti >= toolCount - 1) return;
+    const entries = flatList().map((entry) =>
+      cloneGroupedOpenerEntry({
+        targetKind: entry.targetKind,
+        extensions: entry.extensions,
+        tool: entry.tool,
+      }),
+    );
+    if (fi < 0 || fi >= entries.length - 1) return;
     updateDraft((c) => {
-      const tools = c.openers[ri].tools;
-      [tools[ti], tools[ti + 1]] = [tools[ti + 1], tools[ti]];
+      [entries[fi], entries[fi + 1]] = [entries[fi + 1], entries[fi]];
+      c.openers = serializeGroupedOpeners(entries);
     });
     if (editingFlat() === fi) {
       setEditingFlat(fi + 1);
@@ -201,14 +212,11 @@ const SettingsOpener: Component = () => {
   }
 
   function canMoveUpAt(fi: number): boolean {
-    const entry = flatList()[fi] ?? null;
-    return entry !== null && entry.toolIndex > 0;
+    return fi > 0;
   }
 
   function canMoveDownAt(fi: number): boolean {
-    const entry = flatList()[fi] ?? null;
-    if (!entry) return false;
-    return entry.toolIndex < (d().openers[entry.ruleIndex]?.tools.length ?? 0) - 1;
+    return fi < flatList().length - 1;
   }
 
   return (
@@ -289,7 +297,7 @@ const SettingsOpener: Component = () => {
                   type="text"
                   value={editTargetExt()}
                   onInput={(e) => setEditTargetExt(e.currentTarget.value)}
-                  placeholder="png,jpg,gif"
+                  placeholder=".png,.jpg,.gif"
                   style={{ flex: "1" }}
                 />
               </Show>

--- a/ui/src/lib/openerGroups.test.ts
+++ b/ui/src/lib/openerGroups.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildGroupedOpeners,
+  cloneGroupedOpenerEntry,
+  isSameGroupedOpener,
+  mergeGroupedOpenerEntries,
+  serializeGroupedOpeners,
+} from "./openerGroups";
+import type { GroupedOpenerEntry } from "./openerGroups";
+import type { OpenerRule } from "./types";
+
+function makeExtEntry(
+  extensions: string[],
+  name: string,
+  exe: string,
+  args = "",
+): GroupedOpenerEntry {
+  return {
+    targetKind: "ext",
+    extensions,
+    tool: { name, exe, args },
+  };
+}
+
+function makeFolderEntry(name: string, exe: string, args = ""): GroupedOpenerEntry {
+  return {
+    targetKind: "folder",
+    extensions: [],
+    tool: { name, exe, args },
+  };
+}
+
+describe("opener grouping", () => {
+  it("groups ext rules by exe path and args", () => {
+    const openers: OpenerRule[] = [
+      {
+        target: "ext:.png",
+        tools: [{ name: "Viewer", exe: "C:/Tools/viewer.exe", args: "" }],
+      },
+      {
+        target: "ext:.jpg",
+        tools: [{ name: "Viewer", exe: "c:\\tools\\VIEWER.exe", args: "" }],
+      },
+      {
+        target: "ext:.jpg",
+        tools: [{ name: "Viewer Alt", exe: "C:\\Tools\\viewer.exe", args: "/alt" }],
+      },
+    ];
+
+    const grouped = buildGroupedOpeners(openers);
+
+    expect(grouped).toHaveLength(2);
+    expect(grouped[0].extensions).toEqual([".jpg", ".png"]);
+    expect(grouped[1].extensions).toEqual([".jpg"]);
+  });
+
+  it("keeps folder and ext entries separate even with the same tool", () => {
+    const openers: OpenerRule[] = [
+      {
+        target: "folder",
+        tools: [{ name: "Explorer", exe: "explorer.exe", args: "" }],
+      },
+      {
+        target: "ext:.zip",
+        tools: [{ name: "Explorer", exe: "explorer.exe", args: "" }],
+      },
+    ];
+
+    const grouped = buildGroupedOpeners(openers);
+
+    expect(grouped).toHaveLength(2);
+    expect(grouped[0].targetKind).toBe("folder");
+    expect(grouped[1].targetKind).toBe("ext");
+  });
+
+  it("serializes grouped entries into ext rules with matching tool lists", () => {
+    const rules = serializeGroupedOpeners([
+      makeExtEntry([".jpg"], "Viewer B", "b.exe"),
+      makeExtEntry([".jpg", ".png"], "Viewer A", "a.exe"),
+      makeFolderEntry("Explorer", "explorer.exe"),
+    ]);
+
+    expect(rules).toEqual<OpenerRule[]>([
+      {
+        target: "ext:.jpg",
+        tools: [
+          { name: "Viewer B", exe: "b.exe", args: "" },
+          { name: "Viewer A", exe: "a.exe", args: "" },
+        ],
+      },
+      {
+        target: "ext:.png",
+        tools: [{ name: "Viewer A", exe: "a.exe", args: "" }],
+      },
+      {
+        target: "folder",
+        tools: [{ name: "Explorer", exe: "explorer.exe", args: "" }],
+      },
+    ]);
+  });
+
+  it("round-trips grouped entries through raw rules", () => {
+    const entries = [
+      makeExtEntry([".jpg"], "Viewer B", "b.exe"),
+      makeExtEntry([".jpg", ".png"], "Viewer A", "a.exe"),
+      makeFolderEntry("Explorer", "explorer.exe"),
+    ];
+
+    const roundTrip = buildGroupedOpeners(serializeGroupedOpeners(entries));
+
+    expect(roundTrip).toEqual(entries);
+  });
+
+  it("merges ext entries with the same tool identity", () => {
+    const left = makeExtEntry([".png"], "Viewer", "a.exe");
+    const right = makeExtEntry([".jpg"], "Viewer Updated", "A.exe");
+
+    expect(isSameGroupedOpener(left, right)).toBe(true);
+    expect(mergeGroupedOpenerEntries(left, right)).toEqual(
+      makeExtEntry([".jpg", ".png"], "Viewer Updated", "A.exe"),
+    );
+  });
+
+  it("keeps the existing folder name when merging the same tool", () => {
+    const left = makeFolderEntry("First Name", "explorer.exe");
+    const right = makeFolderEntry("Second Name", "explorer.exe");
+
+    expect(isSameGroupedOpener(left, right)).toBe(true);
+    expect(mergeGroupedOpenerEntries(left, right)).toEqual(
+      makeFolderEntry("First Name", "explorer.exe"),
+    );
+  });
+
+  it("clones grouped entries without sharing references", () => {
+    const original = makeExtEntry([".png"], "Viewer", "a.exe");
+    const clone = cloneGroupedOpenerEntry(original);
+
+    clone.extensions.push(".jpg");
+    clone.tool.name = "Changed";
+
+    expect(original.extensions).toEqual([".png"]);
+    expect(original.tool.name).toBe("Viewer");
+  });
+});

--- a/ui/src/lib/openerGroups.ts
+++ b/ui/src/lib/openerGroups.ts
@@ -1,0 +1,208 @@
+import { normalizeOpenerTarget } from "./openerTarget";
+import type { OpenerRule, OpenerTool } from "./types";
+
+export type GroupedOpenerEntry = {
+  targetKind: "folder" | "ext";
+  extensions: string[];
+  tool: OpenerTool;
+};
+
+function cloneTool(tool: OpenerTool): OpenerTool {
+  return {
+    name: tool.name,
+    exe: tool.exe,
+    args: tool.args,
+  };
+}
+
+export function cloneGroupedOpenerEntry(entry: GroupedOpenerEntry): GroupedOpenerEntry {
+  return {
+    targetKind: entry.targetKind,
+    extensions: [...entry.extensions],
+    tool: cloneTool(entry.tool),
+  };
+}
+
+function normalizeToolPathKey(path: string): string {
+  return path.trim().replace(/\//g, "\\").toLowerCase();
+}
+
+function normalizeToolArgsKey(args: string): string {
+  return args.trim();
+}
+
+function buildToolIdentity(tool: OpenerTool): string {
+  return `${normalizeToolPathKey(tool.exe)}\n${normalizeToolArgsKey(tool.args)}`;
+}
+
+function mergeExtensions(current: string[], next: string[]): string[] {
+  return [...new Set([...current, ...next])].sort();
+}
+
+function extractExtensions(target: string): string[] {
+  const normalized = normalizeOpenerTarget(target);
+  if (!normalized.startsWith("ext:")) {
+    return normalized === "folder" ? [] : [normalized];
+  }
+  const raw = normalized.slice(4);
+  if (!raw) {
+    return [];
+  }
+  return raw.split(",").filter((ext) => ext.length > 0);
+}
+
+function buildGroupedIdentity(entry: GroupedOpenerEntry): string {
+  return `${entry.targetKind}\n${buildToolIdentity(entry.tool)}`;
+}
+
+export function isSameGroupedOpener(
+  left: GroupedOpenerEntry,
+  right: GroupedOpenerEntry,
+): boolean {
+  return buildGroupedIdentity(left) === buildGroupedIdentity(right);
+}
+
+export function mergeGroupedOpenerEntries(
+  current: GroupedOpenerEntry,
+  next: GroupedOpenerEntry,
+): GroupedOpenerEntry {
+  const useCurrentName =
+    current.targetKind === "folder"
+      ? current.tool.name.trim().length > 0
+      : next.tool.name.trim().length === 0;
+  const tool = cloneTool(next.tool);
+  if (useCurrentName) {
+    tool.name = current.tool.name;
+  }
+
+  return {
+    targetKind: current.targetKind,
+    extensions:
+      current.targetKind === "ext"
+        ? mergeExtensions(current.extensions, next.extensions)
+        : [],
+    tool,
+  };
+}
+
+export function buildGroupedOpeners(openers: OpenerRule[]): GroupedOpenerEntry[] {
+  const entries: GroupedOpenerEntry[] = [];
+
+  for (const rule of openers) {
+    const normalizedTarget = normalizeOpenerTarget(rule.target);
+    const targetKind = normalizedTarget === "folder" ? "folder" : "ext";
+    const extensions = targetKind === "ext" ? extractExtensions(normalizedTarget) : [];
+
+    for (const tool of rule.tools) {
+      const nextEntry: GroupedOpenerEntry = {
+        targetKind,
+        extensions,
+        tool: cloneTool(tool),
+      };
+      const existingIndex = entries.findIndex((entry) => isSameGroupedOpener(entry, nextEntry));
+      if (existingIndex >= 0) {
+        entries[existingIndex] = mergeGroupedOpenerEntries(entries[existingIndex], nextEntry);
+      } else {
+        entries.push(nextEntry);
+      }
+    }
+  }
+
+  return entries;
+}
+
+type IndexedGroupedEntry = GroupedOpenerEntry & { index: number };
+
+function buildExtToolListSignature(indices: number[]): string {
+  return indices.join(",");
+}
+
+export function serializeGroupedOpeners(entries: GroupedOpenerEntry[]): OpenerRule[] {
+  const indexedEntries: IndexedGroupedEntry[] = entries.map((entry, index) => ({
+    ...cloneGroupedOpenerEntry(entry),
+    index,
+  }));
+
+  const folderEntries = indexedEntries.filter((entry) => entry.targetKind === "folder");
+  const extEntries = indexedEntries.filter((entry) => entry.targetKind === "ext");
+
+  const extBuckets = new Map<
+    string,
+    { firstIndex: number; extensions: string[]; toolIndices: number[] }
+  >();
+  const extToToolIndices = new Map<string, number[]>();
+  const extToFirstIndex = new Map<string, number>();
+  const emptyExtEntries = extEntries.filter((entry) => entry.extensions.length === 0);
+
+  for (const entry of extEntries) {
+    for (const ext of entry.extensions) {
+      const toolIndices = extToToolIndices.get(ext) ?? [];
+      toolIndices.push(entry.index);
+      extToToolIndices.set(ext, toolIndices);
+      if (!extToFirstIndex.has(ext)) {
+        extToFirstIndex.set(ext, entry.index);
+      }
+    }
+  }
+
+  for (const [ext, toolIndices] of extToToolIndices) {
+    const signature = buildExtToolListSignature(toolIndices);
+    const existing = extBuckets.get(signature);
+    if (existing) {
+      existing.extensions.push(ext);
+    } else {
+      extBuckets.set(signature, {
+        firstIndex: extToFirstIndex.get(ext) ?? Number.MAX_SAFE_INTEGER,
+        extensions: [ext],
+        toolIndices: [...toolIndices],
+      });
+    }
+  }
+
+  const extRules: { firstIndex: number; rule: OpenerRule }[] = [];
+  for (const bucket of extBuckets.values()) {
+    extRules.push({
+      firstIndex: bucket.firstIndex,
+      rule: {
+        target: `ext:${bucket.extensions.sort().join(",")}`,
+        tools: bucket.toolIndices.map((index) => cloneTool(indexedEntries[index].tool)),
+      },
+    });
+  }
+
+  if (emptyExtEntries.length > 0) {
+    extRules.push({
+      firstIndex: emptyExtEntries[0].index,
+      rule: {
+        target: "ext:",
+        tools: emptyExtEntries.map((entry) => cloneTool(entry.tool)),
+      },
+    });
+  }
+
+  extRules.sort((left, right) => left.firstIndex - right.firstIndex);
+
+  const folderRule = folderEntries.length
+    ? {
+        firstIndex: folderEntries[0].index,
+        rule: {
+          target: "folder",
+          tools: folderEntries.map((entry) => cloneTool(entry.tool)),
+        },
+      }
+    : null;
+
+  if (!folderRule) {
+    return extRules.map((entry) => entry.rule);
+  }
+
+  if (extRules.length === 0) {
+    return [folderRule.rule];
+  }
+
+  if (folderRule.firstIndex < extRules[0].firstIndex) {
+    return [folderRule.rule, ...extRules.map((entry) => entry.rule)];
+  }
+
+  return [...extRules.map((entry) => entry.rule), folderRule.rule];
+}

--- a/ui/src/lib/openerTarget.test.ts
+++ b/ui/src/lib/openerTarget.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  getOpenerTargetExtensions,
+  getOpenerTargetLabel,
+  normalizeOpenerTarget,
+} from "./openerTarget";
+
+describe("opener target normalization", () => {
+  it("normalizes ext targets with dotted lowercase extensions", () => {
+    expect(normalizeOpenerTarget("ext: png, .JPG, gif, png")).toBe(
+      "ext:.gif,.jpg,.png",
+    );
+  });
+
+  it("normalizes folder target casing", () => {
+    expect(normalizeOpenerTarget(" Folder ")).toBe("folder");
+  });
+
+  it("returns normalized extension list for editing", () => {
+    expect(getOpenerTargetExtensions("ext:png,.JPG")).toBe(".jpg,.png");
+  });
+
+  it("returns folder label for folder targets", () => {
+    expect(getOpenerTargetLabel("folder")).toBe("フォルダ");
+  });
+});

--- a/ui/src/lib/openerTarget.ts
+++ b/ui/src/lib/openerTarget.ts
@@ -1,0 +1,43 @@
+function normalizeExtensionToken(ext: string): string {
+  const trimmed = ext.trim().replace(/^\.+/, "");
+  if (!trimmed) {
+    return "";
+  }
+  return `.${trimmed.toLowerCase()}`;
+}
+
+export function normalizeOpenerTarget(target: string): string {
+  const trimmed = target.trim();
+  if (trimmed.toLowerCase() === "folder") {
+    return "folder";
+  }
+
+  const separatorIndex = trimmed.indexOf(":");
+  if (
+    separatorIndex >= 0 &&
+    trimmed.slice(0, separatorIndex).toLowerCase() === "ext"
+  ) {
+    const exts = trimmed
+      .slice(separatorIndex + 1)
+      .split(",")
+      .map(normalizeExtensionToken)
+      .filter((ext) => ext.length > 0);
+    const normalized = [...new Set(exts)].sort();
+    return `ext:${normalized.join(",")}`;
+  }
+
+  return trimmed;
+}
+
+export function getOpenerTargetExtensions(target: string): string {
+  const normalized = normalizeOpenerTarget(target);
+  return normalized.startsWith("ext:") ? normalized.slice(4) : normalized;
+}
+
+export function getOpenerTargetLabel(target: string): string {
+  const normalized = normalizeOpenerTarget(target);
+  if (normalized === "folder") {
+    return "フォルダ";
+  }
+  return normalized.startsWith("ext:") ? normalized.slice(4) : normalized;
+}


### PR DESCRIPTION
## 対応Issue
- Closes #92

## 変更内容

- オープナーの拡張子入力を . 付きへ正規化し、既存設定もロード時・保存時に統一
- 設定画面のオープナー一覧を「実行ファイルのパス + args」単位でグルーピング
- 同じフォルダオープナーが統合される場合は既存の「名前」を優先
- オープナーの正規化・グルーピングのテストを追加し、typecheck/build を確認