### PR TITLE
perf: IconCache の Mutex 直列化を解消し並列アイコン取得を実現する

### DIFF
--- a/src-tauri/src/commands/icon.rs
+++ b/src-tauri/src/commands/icon.rs
@@ -1,7 +1,7 @@
 use tauri::ipc::Response;
 use tauri::State;
 
-use crate::icon::{IconCache, IconCacheState};
+use crate::icon::{extract_png, IconCache, IconCacheState};
 use crate::state::AppState;
 
 fn ensure_icon_cache_loaded_if_enabled(state: &State<AppState>, icons: &State<IconCacheState>) {
@@ -24,10 +24,28 @@ pub fn get_icon_png(
     icons: State<IconCacheState>,
 ) -> Result<Response, ()> {
     ensure_icon_cache_loaded_if_enabled(&state, &icons);
+
+    // Step 1: check cache under minimal lock
+    {
+        let cache = icons.lock().unwrap();
+        match cache.as_ref() {
+            None => return Err(()), // icons disabled
+            Some(c) => {
+                if let Some(png) = c.get(&path) {
+                    return Ok(Response::new(png));
+                }
+            }
+        }
+    }
+
+    // Step 2: extract outside the lock (SHGetFileInfoW + PNG encode)
+    let png = extract_png(&path).ok_or(())?;
+
+    // Step 3: insert into cache under minimal lock and return
+    // A concurrent request for the same path may have already inserted; overwrite is benign.
     let mut cache = icons.lock().unwrap();
-    cache
-        .as_mut()
-        .and_then(|c| c.get_or_extract(&path))
-        .map(Response::new)
-        .ok_or(())
+    if let Some(c) = cache.as_mut() {
+        c.insert(path, png.clone());
+    }
+    Ok(Response::new(png))
 }

--- a/src-tauri/src/icon.rs
+++ b/src-tauri/src/icon.rs
@@ -38,16 +38,15 @@ impl IconCache {
         }
     }
 
-    /// Get PNG bytes for a path, extracting on-demand if not cached.
-    pub fn get_or_extract(&mut self, path: &str) -> Option<Vec<u8>> {
-        if let Some(png) = self.data.png.get(path) {
-            return Some(png.clone());
-        }
-        let icon_data = extract_icon(path)?;
-        let png = bgra_to_png(&icon_data)?;
-        self.data.png.insert(path.to_string(), png.clone());
+    /// Get cached PNG bytes for a path (read-only, no extraction).
+    pub fn get(&self, path: &str) -> Option<Vec<u8>> {
+        self.data.png.get(path).cloned()
+    }
+
+    /// Insert extracted PNG bytes into the cache and mark dirty.
+    pub fn insert(&mut self, path: String, png: Vec<u8>) {
+        self.data.png.insert(path, png);
         self.dirty = true;
-        Some(png)
     }
 
     /// Save to disk if there are new entries since last save.
@@ -71,6 +70,12 @@ impl IconCache {
             bf.remove();
         }
     }
+}
+
+/// Extract PNG bytes for a path without holding any lock.
+pub fn extract_png(path: &str) -> Option<Vec<u8>> {
+    let icon_data = extract_icon(path)?;
+    bgra_to_png(&icon_data)
 }
 
 /// Managed state for icon cache


### PR DESCRIPTION
closes #98

## Summary

- `IconCache::get_or_extract` を `get(&self)` / `insert(&mut self)` に分割し、読み取りを `&self` に格下げ
- `extract_png(path)` を Mutex を保持しない free 関数として公開
- `get_icon_png` コマンドを3ステップ設計に変更し、`SHGetFileInfoW` + GDI + PNG エンコードを Mutex のクリティカルセクション外で実行

## 並列化の仕組み

```
Before: [lock -------- SHGetFileInfoW + PNG encode + cache write --------]
After:  [lock - cache read -] ... SHGetFileInfoW + PNG encode ... [lock - cache write -]
```

N 件の並列 IPC リクエストがフロントの `Promise.allSettled` から来たとき、キャッシュミス分は Rust 側でも並列実行される。

同一パスへの重複抽出（TOCTOU）は許容設計: `HashMap::insert` による上書きは等価なため無害。

## Test plan

- [x] `cargo check -p snotra` が通ること（実施済み）
- [x] アイコン表示が正常に動作すること（手動確認）
- [x] 複数アイテムのアイコンが並列で取得されること（体感確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)