### PR TITLE
fix: リリースビルドで localhost 接続拒否が発生する問題を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,14 +37,11 @@ jobs:
         id: date
         run: echo "BUILD_DATE=$(Get-Date -Format 'yyyyMMdd')" >> $env:GITHUB_ENV
 
-      - name: Build frontend
-        run: npm run build
+      - name: Build Windows executable (release)
+        run: npx tauri build --no-bundle
         env:
           VITE_APP_VERSION: ${{ github.ref_name }}
           VITE_APP_BUILD_NUMBER: ${{ env.BUILD_DATE }}
-
-      - name: Build Windows executable (release)
-        run: cargo build --release -p snotra
 
       - name: Package as ZIP
         run: |


### PR DESCRIPTION
cargo build --release は Tauri CLI を経由しないため custom-protocol feature が 有効にならず、フロントエンド資産が埋め込まれずに devUrl (localhost:5173) へ 接続しようとしていた。npx tauri build --no-bundle に変更することで資産を正しく 埋め込み、beforeBuildCommand でフロントエンドビルドも統合した。
