### PR TITLE
fix: リリースビルドで localhost 接続拒否が発生する問題を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,14 +37,11 @@ jobs:
         id: date
         run: echo "BUILD_DATE=$(Get-Date -Format 'yyyyMMdd')" >> $env:GITHUB_ENV
 
-      - name: Build frontend
-        run: npm run build
+      - name: Build Windows executable (release)
+        run: npx tauri build --no-bundle
         env:
           VITE_APP_VERSION: ${{ github.ref_name }}
           VITE_APP_BUILD_NUMBER: ${{ env.BUILD_DATE }}
-
-      - name: Build Windows executable (release)
-        run: cargo build --release -p snotra
 
       - name: Package as ZIP
         run: |


### PR DESCRIPTION
## Summary

- `cargo build --release` を `npx tauri build --no-bundle` に変更し、Tauri CLI 経由でビルドするよう修正
- `custom-protocol` feature が有効になりフロントエンド資産が実行ファイルに埋め込まれる
- `beforeBuildCommand` (`npm run build`) がフロントエンドビルドを担うため、重複していた "Build frontend" ステップを削除

## Root Cause

`cargo build --release` は Tauri CLI を経由しないため `custom-protocol` feature が無効のまま。結果として `devUrl` (`http://localhost:5173`) への接続を試みるバイナリが生成され、リリース環境で "localhost connection refused" が発生していた。

## Test plan

- [ ] タグ `v*` をプッシュして GitHub Actions の Release ワークフローが成功することを確認
- [ ] 生成された `snotra.exe` を起動し、検索ウィンドウ・設定ウィンドウが正しく描画されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)