### PR TITLE
perf: クリーン状態での resetForShow 呼び出し時に runRefresh をスキップ

### DIFF
--- a/ui/src/stores/search.test.ts
+++ b/ui/src/stores/search.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
 // ── Tauri 依存をモック（search.ts のモジュールロード前に宣言） ──────────────
 
@@ -20,6 +20,7 @@ vi.mock("../lib/invoke", () => ({
 
 // ── モック確立後にインポート ─────────────────────────────────────────────────
 
+import * as eventApi from "@tauri-apps/api/event";
 import * as api from "../lib/invoke";
 import type { OpenerTool, SearchResult } from "../lib/types";
 import {
@@ -238,6 +239,32 @@ describe("resetForShow", () => {
     expect(query()).toBe("");
     expect(folderFilter()).toBe("");
     expect(selected()).toBe(0);
+  });
+
+  it("クリーン状態では emit('results-sync') を呼ばない", async () => {
+    // 初期状態: query="", folderState=null, toolSelectionState=null
+    const emitMock = eventApi.emit as Mock;
+    emitMock.mockClear();
+
+    resetForShow();
+
+    // runRefresh() がスキップされるため results-sync IPC は発生しない
+    await vi.runAllTimersAsync();
+    const resultsSyncCalls = emitMock.mock.calls.filter((args) => args[0] === "results-sync");
+    expect(resultsSyncCalls).toHaveLength(0);
+  });
+
+  it("クエリが非空なら emit('results-sync') を呼ぶ", async () => {
+    setQuery("hello");
+    const emitMock = eventApi.emit as Mock;
+    emitMock.mockClear();
+
+    resetForShow();
+
+    // runRefresh() が走るため results-sync IPC が発生する
+    await vi.runAllTimersAsync();
+    const resultsSyncCalls = emitMock.mock.calls.filter((args) => args[0] === "results-sync");
+    expect(resultsSyncCalls.length).toBeGreaterThan(0);
   });
 });
 

--- a/ui/src/stores/search.ts
+++ b/ui/src/stores/search.ts
@@ -635,6 +635,10 @@ async function activateSelectedByIndex(index: number): Promise<boolean> {
 
 function resetForShow() {
   trace("search:reset_for_show", { query: query() });
+  // すでにクリーン状態なら runRefresh() をスキップ（results ウィンドウへの不要な IPC を削減）。
+  // リセット前に確認する（setFolderState / setToolSelectionState が呼ばれる前）。
+  // indexing() は含めない: indexing=true 時も results は既に非表示のため、スキップしても問題ない。
+  const skipRefresh = query() === "" && folderState() === null && toolSelectionState() === null;
   setLaunching(false);
   clearLaunchNotice();
   setToolSelectionState(null);
@@ -646,7 +650,9 @@ function resetForShow() {
   setFolderFilter("");
   setCommandMatches([]);
   setSelected(0);
-  void runRefresh();
+  if (!skipRefresh) {
+    void runRefresh();
+  }
 }
 
 let unlistenIndexingComplete: (() => void) | undefined;


### PR DESCRIPTION
## Summary

- `resetForShow()` は表示イベント（`window-shown`）のたびに無条件で `runRefresh()` → `emitResults()` → IPC emit を呼んでいた
- `query`・`folderState`・`toolSelectionState` がすべてデフォルト値の「クリーン状態」では、results ウィンドウは既に非表示でかつ結果は空なので、この IPC チェーンは不要
- クリーン状態を事前に判定し `runRefresh()` をスキップするガードを追加（特に「ホットキーで開く → すぐ閉じる → すぐ開く」パターンで効果）

## Test plan

- [ ] `npm test` — 既存 76 テスト通過、新規 2 テスト（クリーン状態スキップ確認・非クリーン状態では IPC 発生確認）追加
- [ ] `npx vite build` — ビルド成功確認
- [ ] 実機でウィンドウ表示ラグの体感確認（issue 優先度 Low）

closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)