### PR TITLE
feat: リリース時にバージョン+ビルド日付を About タブに自動埋め込み

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,14 @@ jobs:
 
       - name: Get Build Date
         id: date
-        run: echo "BUILD_DATE=$(Get-Date -Format 'yyyyMMdd')" >> $env:GITHUB_ENV
+        run: echo "BUILD_DATE=$(Get-Date -Format 'yyyyMMddHHmm')" >> $env:GITHUB_ENV
+
+      - name: Set version from tag
+        run: |
+          $ver = "${{ github.ref_name }}".TrimStart('v')
+          (Get-Content Cargo.toml -Raw -Encoding utf8) `
+            -replace '(?m)^version = "[\d.]+"', "version = `"$ver`"" |
+            Set-Content Cargo.toml -Encoding utf8 -NoNewline
 
       - name: Build Windows executable (release)
         run: npx tauri build --no-bundle
@@ -45,6 +52,8 @@ jobs:
 
       - name: Build snotra-settings (release)
         run: cargo build --release -p snotra-settings
+        env:
+          BUILD_DATE: ${{ env.BUILD_DATE }}
 
       - name: Verify release artifacts
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 members = ["snotra-core", "src-tauri", "snotra-settings"]
 resolver = "2"
 
+[workspace.package]
+version = "0.1.0"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/snotra-core/Cargo.toml
+++ b/snotra-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snotra-core"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [dependencies]

--- a/snotra-settings/Cargo.toml
+++ b/snotra-settings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snotra-settings"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [[bin]]

--- a/snotra-settings/build.rs
+++ b/snotra-settings/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let build_date = std::env::var("BUILD_DATE").unwrap_or_else(|_| "local".to_string());
+    println!("cargo:rustc-env=APP_BUILD_DATE={build_date}");
+    println!("cargo:rerun-if-env-changed=BUILD_DATE");
+}

--- a/snotra-settings/src/app.rs
+++ b/snotra-settings/src/app.rs
@@ -308,7 +308,8 @@ impl eframe::App for SettingsApp {
                         ui.add_space(8.0);
 
                         let version = env!("CARGO_PKG_VERSION");
-                        ui.label(format!("v{version}"));
+                        let build_date = env!("APP_BUILD_DATE");
+                        ui.label(format!("v{version}(Build {build_date})"));
                         ui.add_space(24.0);
 
                         ui.label("Fine Lagusaz");

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snotra"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [build-dependencies]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,9 @@ import solid from "vite-plugin-solid";
 import process from "process";
 import packageJson from "./package.json";
 
-// 開発（ローカル）時にプロセス環境変数が無い場合、YYYYMMDD形式の日付をフォールバックとして設定
-const fallbackDate = new Date().toISOString().split('T')[0].replace(/-/g, '');
+// 開発（ローカル）時にプロセス環境変数が無い場合、YYYYMMDDHHmm形式の日付をフォールバックとして設定
+const now = new Date();
+const fallbackDate = now.toISOString().replace(/[-:T]/g, '').slice(0, 12);
 
 export default defineConfig({
   plugins: [solid()],


### PR DESCRIPTION
## Summary

- `[workspace.package]` で全 crate のバージョンを一元管理し、リリース時に PowerShell で `Cargo.toml` を書き換えることで `env!(\"CARGO_PKG_VERSION\")` がタグと一致するようにした
- `snotra-settings/build.rs` を新規追加し、`BUILD_DATE` 環境変数をコンパイル時定数 `APP_BUILD_DATE` として注入
- About タブの表示を `v{version}(Build {yyyyMMddHHmm})` 形式に変更（例: `v1.2.0(Build 202603251024)`）
- ローカルビルド時は `v0.1.0(Build local)` と表示される（許容済み）

## Test plan

- [ ] `cargo check -p snotra-core -p snotra -p snotra-settings` が通ること
- [ ] `v*` タグを push してリリースワークフローが成功し、`snotra-settings.exe` の About タブにタグ名とビルド日時が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)