### PR TITLE
ci: workflow_dispatch 専用の E2E ワークフローを追加

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,40 @@
+name: E2E
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build app and setup E2E
+        run: npm run e2e:tauri:setup
+
+      - name: Run E2E tests
+        run: npm run e2e:tauri


### PR DESCRIPTION
## Summary

- `workflow_dispatch` トリガー専用の E2E ワークフロー（`.github/workflows/e2e.yml`）を追加
- Windows ランナーで `npm run e2e:tauri:setup` → `npm run e2e:tauri` を実行
- Phase 1 of 3: 手動実行で安定性を確認後、段階的に自動トリガーへ拡張予定

## Phase plan

1. **Phase 1（本 PR）**: `workflow_dispatch` のみ — 手動で安定性を検証
2. **Phase 2**: PR ラベル `run-e2e` トリガーを追加
3. **Phase 3**: 全 PR で自動実行

Refs #145

## Test plan

- [x] PR の CI（`frontend-check` + `rust-check`）が通ること
- [ ] マージ後、Actions タブから手動で E2E ワークフローを実行して成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)