### PR TITLE
chore: bincode 依存を削除し旧フォーマットフォールバックを廃止

### DIFF
--- a/snotra-core/Cargo.toml
+++ b/snotra-core/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2024"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 postcard = { version = "1", features = ["alloc"] }
-bincode = "1"  # 旧形式マイグレーション読み込み用
 toml = "1"
 nucleo-matcher = "0.3"
 rayon = "1"

--- a/snotra-core/src/binfmt.rs
+++ b/snotra-core/src/binfmt.rs
@@ -45,16 +45,14 @@ impl BinFile {
 
     /// Load data, trying the current version first, then each fallback in order.
     ///
-    /// `fallbacks` is a slice of `(version, is_bincode)` pairs. Each entry
-    /// specifies a legacy version number and whether it was serialized with
-    /// bincode (`true`) or postcard (`false`).
+    /// `fallbacks` is a slice of legacy version numbers (all postcard format).
     ///
     /// Returns `Some((data, version))` where `version` is the version that
     /// succeeded, so the caller can apply version-specific migrations.
     #[allow(deprecated)]
     pub fn load_with_fallback<T: DeserializeOwned>(
         &self,
-        fallbacks: &[(u32, bool)],
+        fallbacks: &[u32],
     ) -> Option<(T, u32)> {
         let bytes = fs::read(&self.path).ok()?;
 
@@ -64,13 +62,8 @@ impl BinFile {
         }
 
         // Try each fallback
-        for &(ver, is_bincode) in fallbacks {
-            let result = if is_bincode {
-                deserialize_bincode_with_header(&bytes, self.magic, ver)
-            } else {
-                deserialize_with_header(&bytes, self.magic, ver)
-            };
-            if let Some(data) = result {
+        for &ver in fallbacks {
+            if let Some(data) = deserialize_with_header(&bytes, self.magic, ver) {
                 return Some((data, ver));
             }
         }
@@ -133,40 +126,6 @@ pub fn try_serialize_with_header<T: Serialize>(
     buf.extend_from_slice(&version.to_le_bytes());
     buf.extend_from_slice(&payload_bytes);
     Ok(buf)
-}
-
-/// Legacy bincode deserializer for migration from pre-postcard format.
-pub fn deserialize_bincode_with_header<T: DeserializeOwned>(
-    bytes: &[u8],
-    magic: [u8; 4],
-    version: u32,
-) -> Option<T> {
-    if bytes.len() < HEADER_LEN {
-        return None;
-    }
-    if bytes[0..4] != magic {
-        return None;
-    }
-    let mut ver = [0u8; 4];
-    ver.copy_from_slice(&bytes[4..8]);
-    if u32::from_le_bytes(ver) != version {
-        return None;
-    }
-    bincode::deserialize(&bytes[HEADER_LEN..]).ok()
-}
-
-#[cfg(test)]
-pub fn serialize_bincode_with_header<T: Serialize>(
-    magic: [u8; 4],
-    version: u32,
-    payload: &T,
-) -> Option<Vec<u8>> {
-    let body = bincode::serialize(payload).ok()?;
-    let mut out = Vec::with_capacity(HEADER_LEN + body.len());
-    out.extend_from_slice(&magic);
-    out.extend_from_slice(&version.to_le_bytes());
-    out.extend_from_slice(&body);
-    Some(out)
 }
 
 #[deprecated(note = "use try_deserialize_with_header for Result-based error handling")]
@@ -232,29 +191,6 @@ mod tests {
         let bytes = serialize_with_header(*b"TEST", 1, &input).expect("serialize");
         let output: Dummy = deserialize_with_header(&bytes, *b"TEST", 1).expect("deserialize");
         assert_eq!(input, output);
-    }
-
-    #[test]
-    fn roundtrip_bincode_with_header() {
-        let input = Dummy { value: 99 };
-        let bytes =
-            serialize_bincode_with_header(*b"TEST", 1, &input).expect("serialize bincode");
-        let output: Dummy =
-            deserialize_bincode_with_header(&bytes, *b"TEST", 1).expect("deserialize bincode");
-        assert_eq!(input, output);
-    }
-
-    #[test]
-    fn bincode_data_not_readable_by_postcard() {
-        // u32::MAX is encoded as 4 bytes (ff ff ff ff) by bincode.
-        // postcard reads it as a varint where all 4 bytes have the continuation
-        // bit set, so it requires a 5th byte that never comes → decode error → None.
-        let input = Dummy { value: u32::MAX };
-        let bytes =
-            serialize_bincode_with_header(*b"TEST", 1, &input).expect("serialize bincode");
-        // postcard cannot decode the 4-byte LE payload as a complete varint
-        let output: Option<Dummy> = deserialize_with_header(&bytes, *b"TEST", 1);
-        assert!(output.is_none());
     }
 
     #[test]
@@ -377,7 +313,7 @@ mod tests {
         assert!(bf.save(&input));
 
         let (output, ver): (Dummy, u32) =
-            bf.load_with_fallback(&[(2, false), (1, true)]).expect("load");
+            bf.load_with_fallback(&[2]).expect("load");
         assert_eq!(output, input);
         assert_eq!(ver, 3);
 
@@ -395,27 +331,9 @@ mod tests {
         // Create a BinFile expecting v3 as current
         let bf = bin_file_in(&dir, *b"TEST", 3, "data.bin");
         let (output, ver): (Dummy, u32) =
-            bf.load_with_fallback(&[(2, false), (1, true)]).expect("load v2 fallback");
+            bf.load_with_fallback(&[2]).expect("load v2 fallback");
         assert_eq!(output, Dummy { value: 55 });
         assert_eq!(ver, 2);
-
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    #[test]
-    fn binfile_load_with_fallback_bincode_legacy() {
-        let dir = temp_dir("binfile_fb_bincode");
-        // Write a v1 bincode file
-        let path = dir.join("data.bin");
-        let bytes = serialize_bincode_with_header(*b"TEST", 1, &Dummy { value: 77 }).unwrap();
-        std::fs::write(&path, &bytes).unwrap();
-
-        // Create a BinFile expecting v3 as current
-        let bf = bin_file_in(&dir, *b"TEST", 3, "data.bin");
-        let (output, ver): (Dummy, u32) =
-            bf.load_with_fallback(&[(2, false), (1, true)]).expect("load v1 fallback");
-        assert_eq!(output, Dummy { value: 77 });
-        assert_eq!(ver, 1);
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -429,7 +347,7 @@ mod tests {
         std::fs::write(&path, &bytes).unwrap();
 
         let bf = bin_file_in(&dir, *b"TEST", 3, "data.bin");
-        let result: Option<(Dummy, u32)> = bf.load_with_fallback(&[(2, false), (1, true)]);
+        let result: Option<(Dummy, u32)> = bf.load_with_fallback(&[2]);
         assert!(result.is_none());
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/snotra-core/src/history.rs
+++ b/snotra-core/src/history.rs
@@ -9,14 +9,9 @@ use crate::query::normalize_query;
 const HISTORY_MAGIC: [u8; 4] = *b"HIST";
 const HISTORY_VERSION: u32 = 3; // postcard (現行, ms timestamp)
 const HISTORY_VERSION_POSTCARD_V2: u32 = 2; // postcard (旧, sec timestamp)
-const HISTORY_VERSION_LEGACY: u32 = 1; // bincode (旧, sec timestamp)
 
-/// Fallback chain for loading legacy history formats.
-/// (version, is_bincode): v2 = postcard (false), v1 = bincode (true)
-const HISTORY_FALLBACKS: &[(u32, bool)] = &[
-    (HISTORY_VERSION_POSTCARD_V2, false),
-    (HISTORY_VERSION_LEGACY, true),
-];
+/// Fallback chain for loading legacy history formats (all postcard).
+const HISTORY_FALLBACKS: &[u32] = &[HISTORY_VERSION_POSTCARD_V2];
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct GlobalEntry {
@@ -275,9 +270,7 @@ fn migrate_normalize_keys(data: HistoryData) -> HistoryData {
 #[allow(deprecated)]
 mod tests {
     use super::*;
-    use crate::binfmt::{
-        deserialize_with_header, serialize_bincode_with_header, serialize_with_header,
-    };
+    use crate::binfmt::{deserialize_with_header, serialize_with_header};
     use crate::query::normalize_query;
     use std::path::Path;
 
@@ -495,51 +488,6 @@ mod tests {
         assert_eq!(recent.len(), 2);
         assert_eq!(recent[0], "C:\\alpha.lnk");
         assert_eq!(recent[1], "C:\\zeta.lnk");
-    }
-
-    #[test]
-    fn legacy_bincode_v1_migrates_to_current_format() {
-        let dir = temp_dir("v1_migrate");
-        let mut data = HistoryData::default();
-        data.global.insert(
-            "C:\\legacy.lnk".to_string(),
-            GlobalEntry {
-                launch_count: 7,
-                last_launched: 1_600_000_000,
-            },
-        );
-        data.query
-            .entry("leg".to_string())
-            .or_default()
-            .insert("C:\\legacy.lnk".to_string(), 4);
-        data.folder_expansion
-            .insert("C:\\LegacyFolder".to_string(), 3);
-
-        // Simulate a bincode V1 file written before postcard migration
-        let bytes = serialize_bincode_with_header(HISTORY_MAGIC, HISTORY_VERSION_LEGACY, &data)
-            .expect("serialize bincode v1");
-
-        // Should be unreadable by current postcard V3 deserializer
-        let v3_attempt: Option<HistoryData> =
-            deserialize_with_header(&bytes, HISTORY_MAGIC, HISTORY_VERSION);
-        assert!(v3_attempt.is_none());
-
-        // Write to disk and load via BinFile
-        let bf = bin_file_in(&dir);
-        std::fs::write(bf.path(), &bytes).unwrap();
-        let (loaded, version): (HistoryData, u32) =
-            bf.load_with_fallback(HISTORY_FALLBACKS).expect("load v1 fallback");
-        assert_eq!(version, HISTORY_VERSION_LEGACY);
-        let migrated = migrate_time_unit_if_legacy(version, loaded);
-        assert_eq!(migrated.global["C:\\legacy.lnk"].launch_count, 7);
-        assert_eq!(
-            migrated.global["C:\\legacy.lnk"].last_launched,
-            1_600_000_000_000
-        );
-        assert_eq!(migrated.query["leg"]["C:\\legacy.lnk"], 4);
-        assert_eq!(migrated.folder_expansion["C:\\LegacyFolder"], 3);
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/snotra-core/src/window_data.rs
+++ b/snotra-core/src/window_data.rs
@@ -1,25 +1,14 @@
 use serde::{Deserialize, Serialize};
 
-#[allow(deprecated)]
-use crate::binfmt::{deserialize_bincode_with_header, deserialize_with_header, BinFile};
+use crate::binfmt::BinFile;
 
 const WINDOW_MAGIC: [u8; 4] = *b"WNDW";
-const WINDOW_VERSION_V1: u32 = 1;
-const WINDOW_VERSION_V2: u32 = 2;
-const WINDOW_VERSION_V3: u32 = 3;
 const WINDOW_VERSION_V4: u32 = 4; // postcard (現行)
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WindowPlacement {
     pub x: i32,
     pub y: i32,
-}
-
-/// Kept for backward-compatible deserialization of window.bin (V3/V4).
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-struct WindowSize {
-    width: i32,
-    height: i32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -29,10 +18,10 @@ struct WindowPlacementState {
     settings_size: Option<WindowSize>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-struct WindowPlacementStateV2 {
-    search: Option<WindowPlacement>,
-    settings: Option<WindowPlacement>,
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+struct WindowSize {
+    width: i32,
+    height: i32,
 }
 
 pub fn load_search_placement() -> Option<WindowPlacement> {
@@ -55,48 +44,9 @@ pub fn save_settings_placement(placement: WindowPlacement) {
     save_state(&state);
 }
 
-#[allow(deprecated)]
 fn load_state() -> Option<WindowPlacementState> {
     let bf = bin_file()?;
-    // V2/V1 deserialize different types, so we use load_bytes + manual fallback.
-    let bytes = bf.load_bytes()?;
-
-    // V4: postcard (current)
-    if let Some(state) =
-        deserialize_with_header::<WindowPlacementState>(&bytes, WINDOW_MAGIC, WINDOW_VERSION_V4)
-    {
-        return Some(state);
-    }
-
-    // V3: bincode (legacy, written before postcard migration)
-    if let Some(state) = deserialize_bincode_with_header::<WindowPlacementState>(
-        &bytes,
-        WINDOW_MAGIC,
-        WINDOW_VERSION_V3,
-    ) {
-        return Some(state);
-    }
-
-    // V2: bincode (legacy, different struct type)
-    if let Some(state) = deserialize_bincode_with_header::<WindowPlacementStateV2>(
-        &bytes,
-        WINDOW_MAGIC,
-        WINDOW_VERSION_V2,
-    ) {
-        return Some(WindowPlacementState {
-            search: state.search,
-            settings: state.settings,
-            settings_size: None,
-        });
-    }
-
-    // V1: bincode (legacy, search window position only)
-    deserialize_bincode_with_header::<WindowPlacement>(&bytes, WINDOW_MAGIC, WINDOW_VERSION_V1)
-        .map(|search| WindowPlacementState {
-            search: Some(search),
-            settings: None,
-            settings_size: None,
-        })
+    bf.load()
 }
 
 fn save_state(state: &WindowPlacementState) {
@@ -113,7 +63,7 @@ fn bin_file() -> Option<BinFile> {
 #[allow(deprecated)]
 mod tests {
     use super::*;
-    use crate::binfmt::{serialize_bincode_with_header, serialize_with_header};
+    use crate::binfmt::{deserialize_with_header, serialize_with_header};
 
     #[test]
     fn placement_state_roundtrip_header_v4() {
@@ -130,109 +80,5 @@ mod tests {
         let restored: WindowPlacementState =
             deserialize_with_header(&bytes, WINDOW_MAGIC, WINDOW_VERSION_V4).expect("deserialize");
         assert_eq!(state, restored);
-    }
-
-    #[test]
-    fn load_state_reads_v3_bincode_payload() {
-        let state = WindowPlacementState {
-            search: Some(WindowPlacement { x: 100, y: 200 }),
-            settings: Some(WindowPlacement { x: 300, y: 400 }),
-            settings_size: Some(WindowSize {
-                width: 800,
-                height: 600,
-            }),
-        };
-        // Simulate a bincode V3 file written before postcard migration
-        let bytes = serialize_bincode_with_header(WINDOW_MAGIC, WINDOW_VERSION_V3, &state)
-            .expect("serialize bincode v3");
-
-        // V4 postcard should not read bincode data
-        let v4_attempt: Option<WindowPlacementState> =
-            deserialize_with_header(&bytes, WINDOW_MAGIC, WINDOW_VERSION_V4);
-        assert!(v4_attempt.is_none());
-
-        let restored = load_state_from_bytes(&bytes).expect("mapped v3 bincode");
-        assert_eq!(state, restored);
-    }
-
-    #[test]
-    fn load_state_reads_v2_payload() {
-        let state = WindowPlacementStateV2 {
-            search: Some(WindowPlacement { x: 120, y: 340 }),
-            settings: Some(WindowPlacement { x: 640, y: 480 }),
-        };
-        let bytes = serialize_bincode_with_header(WINDOW_MAGIC, WINDOW_VERSION_V2, &state)
-            .expect("serialize bincode v2");
-
-        let state_v4: Option<WindowPlacementState> =
-            deserialize_with_header(&bytes, WINDOW_MAGIC, WINDOW_VERSION_V4);
-        assert!(state_v4.is_none());
-
-        let restored = load_state_from_bytes(&bytes).expect("mapped v2");
-        assert_eq!(
-            restored,
-            WindowPlacementState {
-                search: state.search,
-                settings: state.settings,
-                settings_size: None,
-            }
-        );
-    }
-
-    #[test]
-    fn load_state_reads_v1_payload() {
-        let placement = WindowPlacement { x: 120, y: 340 };
-        let bytes = serialize_bincode_with_header(WINDOW_MAGIC, WINDOW_VERSION_V1, &placement)
-            .expect("serialize bincode v1");
-
-        let state_v4: Option<WindowPlacementState> =
-            deserialize_with_header(&bytes, WINDOW_MAGIC, WINDOW_VERSION_V4);
-        assert!(state_v4.is_none());
-
-        let mapped = load_state_from_bytes(&bytes).expect("mapped v1");
-        assert_eq!(
-            mapped,
-            WindowPlacementState {
-                search: Some(placement),
-                settings: None,
-                settings_size: None,
-            }
-        );
-    }
-
-    fn load_state_from_bytes(bytes: &[u8]) -> Option<WindowPlacementState> {
-        // V4: postcard (current)
-        if let Some(state) =
-            deserialize_with_header::<WindowPlacementState>(bytes, WINDOW_MAGIC, WINDOW_VERSION_V4)
-        {
-            return Some(state);
-        }
-        // V3: bincode (legacy)
-        if let Some(state) = deserialize_bincode_with_header::<WindowPlacementState>(
-            bytes,
-            WINDOW_MAGIC,
-            WINDOW_VERSION_V3,
-        ) {
-            return Some(state);
-        }
-        // V2: bincode (legacy)
-        if let Some(state) = deserialize_bincode_with_header::<WindowPlacementStateV2>(
-            bytes,
-            WINDOW_MAGIC,
-            WINDOW_VERSION_V2,
-        ) {
-            return Some(WindowPlacementState {
-                search: state.search,
-                settings: state.settings,
-                settings_size: None,
-            });
-        }
-        // V1: bincode (legacy)
-        deserialize_bincode_with_header::<WindowPlacement>(bytes, WINDOW_MAGIC, WINDOW_VERSION_V1)
-            .map(|search| WindowPlacementState {
-                search: Some(search),
-                settings: None,
-                settings_size: None,
-            })
     }
 }


### PR DESCRIPTION
## Summary
- bincode 1.x 依存と全レガシーフォールバック経路（history V1, window V1/V2/V3）を削除
- `load_with_fallback` の API を `&[(u32, bool)]` → `&[u32]` に簡素化
- 4ファイル変更、17行追加 / 306行削除

Closes #178

## Test plan
- [x] `cargo check -p snotra-core -p snotra -p snotra-settings` 通過
- [x] `cargo test -p snotra-core` 全242テスト通過
- [x] `cargo clippy` warnings なし
- [x] `npm run build` フロントエンドビルド通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)