### PR TITLE
perf: アイコン抽出を rayon で並列化

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 png = "0.18"
 tokio = { version = "1", features = ["time"] }
+rayon = "1"
 notify = "8"
 
 [target.'cfg(windows)'.dependencies]

--- a/src-tauri/src/commands/icon.rs
+++ b/src-tauri/src/commands/icon.rs
@@ -1,3 +1,4 @@
+use rayon::prelude::*;
 use tauri::State;
 use tauri::ipc::Response;
 
@@ -50,8 +51,9 @@ pub fn get_icons_batch(
     }
 
     // Step 2: extract missing icons outside the lock (SHGetFileInfoW + PNG encode)
+    // rayon で並列化: extract_png は各スレッドで独立した Win32 ハンドルを取得・破棄するためスレッドセーフ
     let extracted: Vec<(usize, String, Vec<u8>)> = misses
-        .into_iter()
+        .into_par_iter()
         .filter_map(|(i, path)| extract_png(&path).map(|png| (i, path, png)))
         .collect();
 


### PR DESCRIPTION
## Summary
- Stage 2 のキャッシュミス分アイコン抽出を `into_par_iter()` で並列化
- `src-tauri/Cargo.toml` に `rayon = "1"` を追加（`snotra-core` は既に依存済み）
- `extract_png` はスレッドセーフ（各スレッドで独立した Win32 ハンドル取得・破棄）

Closes #192

## Test plan
- [x] `cargo check -p snotra-core -p snotra -p snotra-settings` 通過
- [x] `cargo clippy -p snotra` warnings なし
- [ ] Windows 実機で初回起動時のアイコン読み込み速度を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)