### PR TITLE
ci: リリース自動化（ドラフトリリース方式）

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,61 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'リリースバージョン (例: 0.12.0, 0.12.0-alpha7)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate version format
+        run: |
+          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Invalid version format: ${{ inputs.version }}"
+            exit 1
+          fi
+
+      - name: Check tag does not exist
+        run: |
+          if git rev-parse "v${{ inputs.version }}" >/dev/null 2>&1; then
+            echo "::error::Tag v${{ inputs.version }} already exists"
+            exit 1
+          fi
+
+      - name: Detect prerelease
+        id: meta
+        run: |
+          if [[ "${{ inputs.version }}" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        run: |
+          git tag "v${{ inputs.version }}"
+          git push origin "v${{ inputs.version }}"
+
+      - name: Create draft release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ inputs.version }}
+          name: v${{ inputs.version }}
+          draft: true
+          prerelease: ${{ steps.meta.outputs.prerelease }}
+          generate_release_notes: true
+          body: |
+            # ざっくり
+
+            <!-- ここにユーザー向けサマリを記入してください -->
+            <!-- 例: * 🖼️ シングルウィンドウに切り替えました -->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Build Release
 
 on:
   push:
@@ -40,9 +40,21 @@ jobs:
       - name: Set version from tag
         run: |
           $ver = "${{ github.ref_name }}".TrimStart('v')
+
+          # Cargo.toml (workspace)
           (Get-Content Cargo.toml -Raw -Encoding utf8) `
             -replace '(?m)^version = "[\d.]+"', "version = `"$ver`"" |
             Set-Content Cargo.toml -Encoding utf8 -NoNewline
+
+          # package.json
+          $pkg = Get-Content package.json -Raw -Encoding utf8 | ConvertFrom-Json
+          $pkg.version = $ver
+          $pkg | ConvertTo-Json -Depth 10 | Set-Content package.json -Encoding utf8
+
+          # tauri.conf.json
+          $conf = Get-Content src-tauri/tauri.conf.json -Raw -Encoding utf8 | ConvertFrom-Json
+          $conf.version = $ver
+          $conf | ConvertTo-Json -Depth 10 | Set-Content src-tauri/tauri.conf.json -Encoding utf8
 
       - name: Build Windows executable (release)
         run: npx tauri build --no-bundle
@@ -65,11 +77,21 @@ jobs:
         run: |
           Compress-Archive -Path "target/release/snotra.exe","target/release/snotra-settings.exe" -DestinationPath "Snotra-${{ github.ref_name }}.zip"
 
-      - name: Create GitHub Release
+      - name: Detect prerelease
+        id: meta
+        shell: bash
+        run: |
+          if [[ "${{ github.ref_name }}" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
-          draft: false
-          prerelease: false
+          prerelease: ${{ steps.meta.outputs.prerelease }}
           generate_release_notes: true
           files: Snotra-${{ github.ref_name }}.zip


### PR DESCRIPTION
## Summary
- `create-release.yml` を新規追加: `workflow_dispatch` でバージョン入力 → タグ作成 + ドラフトリリース生成
- `release.yml` をビルド専任に改修: `package.json` / `tauri.conf.json` のバージョン書き換え追加、prerelease 自動判定
- 手動タグ push のフォールバックも維持し、既存運用を壊さない

## Test plan
- [ ] `create-release.yml`: 不正バージョン形式（`abc`, `1.2`）で失敗すること
- [ ] `create-release.yml`: 正常バージョン（`0.12.0`, `0.12.0-alpha7`）でドラフトリリースが作成されること
- [ ] `release.yml`: タグ push で `package.json` / `tauri.conf.json` が正しく書き換わること
- [ ] prerelease 判定: `-alpha` 付きは `prerelease=true`、なしは `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)