### PR TITLE
fix(ci): Cargo.toml バージョン置換をプレリリース版にも対応

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
 
           # Cargo.toml (workspace)
           (Get-Content Cargo.toml -Raw -Encoding utf8) `
-            -replace '(?m)^version = "[\d.]+"', "version = `"$ver`"" |
+            -replace '(?m)^version = "[^"]+"', "version = `"$ver`"" |
             Set-Content Cargo.toml -Encoding utf8 -NoNewline
 
           # package.json


### PR DESCRIPTION
## Summary
- `release.yml` の Cargo.toml バージョン置換 regex を `[\d.]+` → `[^"]+` に変更
- 既存バージョンが `0.12.0-alpha7` 等のプレリリース版でも正しく上書きされるようにする

## Test plan
- [ ] プレリリースタグ（例: `v0.12.1-alpha1`）でビルドが正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)