### PR TITLE
fix(e2e): ツール選択テストの英語ロケール CI 失敗を修正

### DIFF
--- a/e2e/tauri.slash.e2e.ts
+++ b/e2e/tauri.slash.e2e.ts
@@ -44,6 +44,7 @@ modifier = "Alt"
 key = "Q"
 
 [general]
+language = "ja"
 hotkey_toggle = true
 show_on_startup = true
 auto_hide_on_focus_lost = false


### PR DESCRIPTION
## Summary
- E2E config に `language = "ja"` が未設定だったため、英語ロケールの CI 環境で Shift+Enter ツール選択テストが `TimeoutError` で失敗していた
- placeholder が `"Select a tool..."` になり、テストが期待する `"ツールを選択..."` と不一致

## Test plan
- [ ] `npm run e2e:tauri` で全13テストが pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)