### PR TITLE
fix(ci): Create Release から Build Release を直接トリガーする

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -59,3 +59,8 @@ jobs:
 
             <!-- ここにユーザー向けサマリを記入してください -->
             <!-- 例: * 🖼️ シングルウィンドウに切り替えました -->
+
+      - name: Trigger Build Release
+        run: gh workflow run release.yml -f tag="v${{ inputs.version }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,18 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag name (例: v0.12.0-alpha7)'
+        required: true
+        type: string
 
 permissions:
   contents: write
+
+env:
+  TAG_NAME: ${{ inputs.tag || github.ref_name }}
 
 jobs:
   build-and-release:
@@ -15,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG_NAME }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -39,7 +50,7 @@ jobs:
 
       - name: Set version from tag
         run: |
-          $ver = "${{ github.ref_name }}".TrimStart('v')
+          $ver = "${{ env.TAG_NAME }}".TrimStart('v')
 
           # Cargo.toml (workspace)
           (Get-Content Cargo.toml -Raw -Encoding utf8) `
@@ -59,7 +70,7 @@ jobs:
       - name: Build Windows executable (release)
         run: npx tauri build --no-bundle
         env:
-          VITE_APP_VERSION: ${{ github.ref_name }}
+          VITE_APP_VERSION: ${{ env.TAG_NAME }}
           VITE_APP_BUILD_NUMBER: ${{ env.BUILD_DATE }}
 
       - name: Build snotra-settings (release)
@@ -75,13 +86,13 @@ jobs:
 
       - name: Package as ZIP
         run: |
-          Compress-Archive -Path "target/release/snotra.exe","target/release/snotra-settings.exe" -DestinationPath "Snotra-${{ github.ref_name }}.zip"
+          Compress-Archive -Path "target/release/snotra.exe","target/release/snotra-settings.exe" -DestinationPath "Snotra-${{ env.TAG_NAME }}.zip"
 
       - name: Detect prerelease
         id: meta
         shell: bash
         run: |
-          if [[ "${{ github.ref_name }}" == *-* ]]; then
+          if [[ "${{ env.TAG_NAME }}" == *-* ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
@@ -90,8 +101,8 @@ jobs:
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
+          tag_name: ${{ env.TAG_NAME }}
+          name: ${{ env.TAG_NAME }}
           prerelease: ${{ steps.meta.outputs.prerelease }}
           generate_release_notes: true
-          files: Snotra-${{ github.ref_name }}.zip
+          files: Snotra-${{ env.TAG_NAME }}.zip


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN` で作成されたタグは GitHub の再帰防止により別ワークフローをトリガーしない問題を修正
- `create-release.yml` の末尾で `gh workflow run release.yml` を呼び出す方式に変更
- `release.yml` に `workflow_dispatch` トリガーを追加し、タグ名を入力パラメータで受け取れるようにした

## Test plan
- [ ] Create Release を `workflow_dispatch` で実行し、Build Release が連鎖起動されることを確認
- [ ] Build Release が正しいタグのコミットをチェックアウトしてビルドすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)