### PR TITLE
fix(ci): workflow_call で Build Release を呼び出す方式に修正

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -60,7 +60,8 @@ jobs:
             <!-- ここにユーザー向けサマリを記入してください -->
             <!-- 例: * 🖼️ シングルウィンドウに切り替えました -->
 
-      - name: Trigger Build Release
-        run: gh workflow run release.yml -f tag="v${{ inputs.version }}"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  build-release:
+    needs: create-release
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: v${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
+  workflow_call:
     inputs:
       tag:
         description: 'Tag name (例: v0.12.0-alpha7)'


### PR DESCRIPTION
## Summary
- `release.yml`: `workflow_dispatch` → `workflow_call` に変更（GITHUB_TOKEN で呼び出し可能に）
- `create-release.yml`: `gh workflow run` → `uses: ./.github/workflows/release.yml` に変更（reusable workflow として直接呼び出し）

前回の PR #207 がスカッシュマージ時に正しく反映されなかったため、改めて修正。

## Test plan
- [ ] Create Release を実行し、Build Release ジョブが連鎖起動されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)