### PR TITLE
feat(settings): インスタントコマンド名フィールドにヒントテキストを追加

### DIFF
--- a/snotra-settings/src/i18n.rs
+++ b/snotra-settings/src/i18n.rs
@@ -772,6 +772,13 @@ impl Tr {
         }
     }
 
+    pub fn hint_instant_name(&self) -> &'static str {
+        match self.0 {
+            Language::Ja => "プレフィックスの後に入力する文字列です（例: \"g\" と設定すると \"@g\" で呼び出し）",
+            Language::En => "Text typed after the prefix to invoke this command (e.g. name \"g\" → type \"@g\")",
+        }
+    }
+
     pub fn label_instant_command(&self) -> &'static str {
         match self.0 {
             Language::Ja => "コマンド:",

--- a/snotra-settings/src/tabs/instant.rs
+++ b/snotra-settings/src/tabs/instant.rs
@@ -193,6 +193,11 @@ fn show_modal(
         // Name
         ui.label(tr.label_instant_name());
         ui.text_edit_singleline(&mut state.modal.edit_name);
+        ui.label(
+            egui::RichText::new(tr.hint_instant_name())
+                .small()
+                .color(crate::app::TEXT_SECONDARY),
+        );
 
         ui.add_space(4.0);
 


### PR DESCRIPTION
## Summary

- コマンド編集ダイアログの「名前」フィールド下に、プレフィックス後に入力する文字列であることを示すヒントを追加
- 日英両言語対応（例: `"g"` と設定すると `"@g"` で呼び出し）
- コマンドフィールドの既存ヒントと同スタイルで統一

## Test plan

- [x] 設定画面 → インスタントタブ → 追加/編集ダイアログを開き、名前フィールド下にヒントが表示されることを確認
- [x] 日本語・英語それぞれの言語設定で表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)