### PR TITLE
refactor: settings IA改善 — Appearance項目をVisualへ移動・Aboutタブをサイドバーに統合

### DIFF
--- a/snotra-settings/src/app.rs
+++ b/snotra-settings/src/app.rs
@@ -64,7 +64,6 @@ pub enum TabId {
     Opener,
     InstantCommand,
     Backup,
-    About,
 }
 
 impl TabId {
@@ -76,7 +75,6 @@ impl TabId {
         TabId::Opener,
         TabId::InstantCommand,
         TabId::Backup,
-        TabId::About,
     ];
 
     fn label(self, tr: &Tr) -> &'static str {
@@ -88,7 +86,6 @@ impl TabId {
             TabId::Opener => tr.tab_opener(),
             TabId::InstantCommand => tr.tab_instant_command(),
             TabId::Backup => tr.tab_backup(),
-            TabId::About => tr.tab_about(),
         }
     }
 
@@ -101,7 +98,6 @@ impl TabId {
             "opener" => Some(TabId::Opener),
             "instant_command" => Some(TabId::InstantCommand),
             "backup" => Some(TabId::Backup),
-            "about" => Some(TabId::About),
             _ => None,
         }
     }
@@ -251,6 +247,8 @@ impl eframe::App for SettingsApp {
             .frame(egui::Frame::NONE.fill(SIDEBAR_BG).inner_margin(egui::Margin::symmetric(8, 8)))
             .show(ctx, |ui| {
                 let available_width = ui.available_width();
+
+                // Tab list
                 for &tab in TabId::ALL {
                     let selected = self.active_tab == tab;
                     let (rect, response) = ui.allocate_exact_size(
@@ -285,6 +283,23 @@ impl eframe::App for SettingsApp {
                         self.active_tab = tab;
                     }
                 }
+
+                // Version info at the bottom of sidebar
+                ui.with_layout(egui::Layout::bottom_up(egui::Align::LEFT), |ui| {
+                    ui.add_space(4.0);
+                    ui.horizontal(|ui| {
+                        if ui.link(egui::RichText::new("Web").small()).clicked() {
+                            let _ = open::that("https://blankrune.sakura.ne.jp/");
+                        }
+                        if ui.link(egui::RichText::new("Mail").small()).clicked() {
+                            let _ = open::that("mailto:algiz.rune@gmail.com?subject=Snotra%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6");
+                        }
+                    });
+                    ui.label(egui::RichText::new("Fine Lagusaz").small().color(TEXT_SECONDARY));
+                    let version = env!("CARGO_PKG_VERSION");
+                    ui.label(egui::RichText::new(format!("v{version}")).small().color(TEXT_SECONDARY));
+                    ui.label(egui::RichText::new("Snotra").small().color(TEXT_SECONDARY));
+                });
             });
 
         // Footer (hide action buttons on About tab)
@@ -299,7 +314,7 @@ impl eframe::App for SettingsApp {
                         ui.separator();
                     }
 
-                    if self.active_tab != TabId::About && self.active_tab != TabId::Backup {
+                    if self.active_tab != TabId::Backup {
                         // Spacer
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                             ui.spacing_mut().button_padding = egui::vec2(12.0, 4.0);
@@ -344,28 +359,6 @@ impl eframe::App for SettingsApp {
                         self.saved = result.imported_config;
                         self.tr = Tr(self.draft.general.language);
                     }
-                }
-                TabId::About => {
-                    ui.vertical_centered(|ui| {
-                        ui.add_space(24.0);
-                        ui.heading("Snotra");
-                        ui.add_space(8.0);
-
-                        let version = env!("CARGO_PKG_VERSION");
-                        let build_date = env!("APP_BUILD_DATE");
-                        ui.label(format!("v{version}(Build {build_date})"));
-                        ui.add_space(24.0);
-
-                        ui.label("Fine Lagusaz");
-                        ui.add_space(8.0);
-
-                        if ui.link("algiz.rune@gmail.com").clicked() {
-                            let _ = open::that("mailto:algiz.rune@gmail.com?subject=Snotra%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6");
-                        }
-                        if ui.link("https://blankrune.sakura.ne.jp/").clicked() {
-                            let _ = open::that("https://blankrune.sakura.ne.jp/");
-                        }
-                    });
                 }
             }
         });

--- a/snotra-settings/src/i18n.rs
+++ b/snotra-settings/src/i18n.rs
@@ -54,13 +54,6 @@ impl Tr {
         }
     }
 
-    pub fn tab_about(&self) -> &'static str {
-        match self.0 {
-            Language::Ja => "Snotra について",
-            Language::En => "About Snotra",
-        }
-    }
-
     // Footer buttons
     pub fn btn_save(&self) -> &'static str {
         match self.0 {

--- a/snotra-settings/src/tabs/general.rs
+++ b/snotra-settings/src/tabs/general.rs
@@ -47,27 +47,6 @@ pub fn ui(ui: &mut egui::Ui, config: &mut Config, hotkey_state: &mut HotkeyInput
 
         ui.add_space(12.0);
 
-        // -- Appearance --
-        ui.heading(tr.heading_appearance());
-        ui.add_space(4.0);
-
-        egui::Grid::new("display_grid").num_columns(2).spacing([8.0, 4.0]).show(ui, |ui| {
-            ui.label(tr.label_max_results());
-            ui.add_sized([60.0, ui.spacing().interact_size.y], egui::DragValue::new(&mut config.appearance.max_results).range(1..=50));
-            ui.end_row();
-
-            ui.label(tr.label_window_width());
-            ui.horizontal(|ui| {
-                ui.add_sized([60.0, ui.spacing().interact_size.y], egui::DragValue::new(&mut config.appearance.window_width).range(300..=1200));
-                ui.label("px");
-            });
-            ui.end_row();
-        });
-
-        ui.checkbox(&mut config.appearance.show_icons, tr.cb_show_icons());
-
-        ui.add_space(12.0);
-
         // -- Behavior --
         ui.heading(tr.heading_behavior());
         ui.add_space(4.0);

--- a/snotra-settings/src/tabs/visual.rs
+++ b/snotra-settings/src/tabs/visual.rs
@@ -137,6 +137,27 @@ pub fn ui(ui: &mut egui::Ui, config: &mut Config, fonts: &[String], tr: &Tr) {
             ui.add_sized([60.0, ui.spacing().interact_size.y], egui::DragValue::new(&mut config.visual.font_size).range(8..=48));
             ui.end_row();
         });
+
+        ui.add_space(12.0);
+
+        // -- Window --
+        ui.heading(tr.heading_appearance());
+        ui.add_space(4.0);
+
+        egui::Grid::new("window_grid").num_columns(2).spacing([8.0, 4.0]).show(ui, |ui| {
+            ui.label(tr.label_max_results());
+            ui.add_sized([60.0, ui.spacing().interact_size.y], egui::DragValue::new(&mut config.appearance.max_results).range(1..=50));
+            ui.end_row();
+
+            ui.label(tr.label_window_width());
+            ui.horizontal(|ui| {
+                ui.add_sized([60.0, ui.spacing().interact_size.y], egui::DragValue::new(&mut config.appearance.window_width).range(300..=1200));
+                ui.label("px");
+            });
+            ui.end_row();
+        });
+
+        ui.checkbox(&mut config.appearance.show_icons, tr.cb_show_icons());
     });
 }
 


### PR DESCRIPTION
## Summary

- **General タブの整理**: Appearance セクション（`max_results` / `window_width` / `show_icons`）を Visual タブ末尾の Window セクションへ移動。表示設定を一箇所に集約し、General タブを「起動・操作系」に絞る
- **About タブを廃止**: バージョン・作者・Web/Mail リンクをサイドバー下部に常時表示。設定変更を伴わない情報閲覧ページをタブから除き、タブ数を 8 → 7 に削減
- **フッター整理**: `active_tab != About` の条件分岐を削除（Backup のみ特殊扱いに統一）
- **i18n**: デッドコードになった `tab_about()` を削除

## 変更後のタブ構成

| タブ | 内容 |
|---|---|
| 全般 | 言語 / ホットキー / 動作 |
| 検索 | 検索モード / 表示 / 履歴 / 履歴スコア / Migemo |
| インデックス | スキャンパス管理 |
| ビジュアル | テーマ / カラー / フォント / **ウィンドウ（新）** |
| オープナー | ルール管理 / プリセット |
| インスタント | プレフィックス / コマンド管理 |
| バックアップ | エクスポート / インポート / フォルダを開く |

## Test plan

- [x] General タブに Appearance セクションが表示されないこと
- [x] Visual タブ末尾に max_results / window_width / show_icons が表示されること
- [x] サイドバー下部に Snotra / バージョン / Fine Lagusaz / Web・Mail リンクが表示されること
- [x] Web リンククリックでブラウザが開くこと
- [x] Mail リンククリックでメーラーが開くこと
- [x] About タブが存在しないこと
- [x] `cargo check` 警告ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)