### PR TITLE
fix: リリースノートの What's New 二重挿入を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,5 +105,4 @@ jobs:
           tag_name: ${{ env.TAG_NAME }}
           name: ${{ env.TAG_NAME }}
           prerelease: ${{ steps.meta.outputs.prerelease }}
-          generate_release_notes: true
           files: Snotra-${{ env.TAG_NAME }}.zip


### PR DESCRIPTION
## Summary

- `release.yml` の `Upload to GitHub Release` ステップから `generate_release_notes: true` を削除
- `create-release.yml` がドラフト作成時にすでに生成しているため、アーティファクトアップロード時に再生成すると既存本文に追記され What's New が二重に挿入されていた

## Test plan

- [ ] Create Release ワークフローを実行し、リリースノートの What's New が1回だけ挿入されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)