### PR TITLE
fix: オープナーメニューで Explorer のアイコンがフォールバック絵文字になる問題を修正

### DIFF
--- a/src-tauri/src/icon.rs
+++ b/src-tauri/src/icon.rs
@@ -7,7 +7,7 @@ use windows::Win32::Graphics::Gdi::{
     BI_RGB, BITMAPINFO, BITMAPINFOHEADER, CreateCompatibleDC, DIB_RGB_COLORS, DeleteDC,
     DeleteObject, GetDIBits, SelectObject,
 };
-use windows::Win32::Storage::FileSystem::FILE_FLAGS_AND_ATTRIBUTES;
+use windows::Win32::Storage::FileSystem::{FILE_FLAGS_AND_ATTRIBUTES, SearchPathW};
 use windows::Win32::UI::Shell::{SHFILEINFOW, SHGFI_ICON, SHGFI_SMALLICON, SHGetFileInfoW};
 use windows::Win32::UI::WindowsAndMessaging::{DestroyIcon, GetIconInfo, HICON, ICONINFO};
 
@@ -124,9 +124,34 @@ struct IconData {
     bgra: Vec<u8>,
 }
 
-fn extract_icon(path: &str) -> Option<IconData> {
+/// bare name ("explorer.exe") を PATH から検索してフルパスに解決する。
+/// パス区切り文字やドライブレターを含む場合はそのまま返す。
+fn resolve_to_full_path(path: &str) -> String {
+    if path.contains('\\') || path.contains('/') || path.contains(':') {
+        return path.to_string();
+    }
     unsafe {
-        let wide_path: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
+        let wide: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
+        let mut buffer = vec![0u16; 512];
+        let len = SearchPathW(
+            windows::core::PCWSTR::null(),
+            windows::core::PCWSTR(wide.as_ptr()),
+            windows::core::PCWSTR::null(),
+            Some(&mut buffer),
+            None,
+        );
+        if len > 0 {
+            String::from_utf16_lossy(&buffer[..len as usize])
+        } else {
+            path.to_string()
+        }
+    }
+}
+
+fn extract_icon(path: &str) -> Option<IconData> {
+    let resolved = resolve_to_full_path(path);
+    unsafe {
+        let wide_path: Vec<u16> = resolved.encode_utf16().chain(std::iter::once(0)).collect();
 
         let mut shfi = SHFILEINFOW::default();
         let result = SHGetFileInfoW(


### PR DESCRIPTION
## 問題

オープナーメニューを開いた際、Explorer のアイコンが 📄 のフォールバック絵文字で表示されていた。VS Code など絶対パスで登録されたツールは正常に表示されていた。

## 根本原因

`explorer.exe` が設定ファイルに bare name（フルパスなし）で保存されているため、`SHGetFileInfoW("explorer.exe", ...)` がファイルを見つけられずアイコン取得に失敗していた。

## 修正内容

- **`src-tauri/src/icon.rs`**: `extract_icon` の前に `resolve_to_full_path` で `SearchPathW` を呼び、bare name を PATH から解決してフルパスに変換。`explorer.exe` を含む任意の bare name exe に汎用的に対応
- **`snotra-core/src/config.rs`**: `detect_opener_presets` で Explorer を `find_in_path` でフルパスに解決して登録（新規ユーザー向け）
- **`snotra-core/src/config.rs`**: `is_preset_already_added` をファイル名のみ比較に変更し、bare name とフルパスが混在しても重複追加されないよう対応

## Test plan

- [ ] オープナーメニューを開いて Explorer のアイコンが正しく表示されることを確認
- [ ] `cargo test -p snotra-core -- config::tests::is_preset_already_added config::tests::detect_opener_presets` がパスすること
- [ ] VS Code など既存ツールのアイコン表示に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)