### PR TITLE
refactor(search): RAF debounce を setTimeout(150ms) に変更

### DIFF
--- a/ui/src/stores/search.ts
+++ b/ui/src/stores/search.ts
@@ -30,7 +30,8 @@ function updateResults(items: SearchResult[], isNormalSearch = false) {
 /** インスタントコマンドモード中のコマンド一覧（activateSelected で参照） */
 let instantCommandItems: InstantCommand[] = [];
 
-let debounceTimer: ReturnType<typeof requestAnimationFrame> | undefined;
+const DEBOUNCE_MS = 150;
+let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 let launchNoticeTimer: ReturnType<typeof setTimeout> | undefined;
 let refreshInFlight: Promise<void> | undefined;
 let searchGeneration = 0;
@@ -82,17 +83,17 @@ function clearCommandModeState() {
 
 function cancelDebounce() {
   if (debounceTimer !== undefined) {
-    cancelAnimationFrame(debounceTimer);
+    clearTimeout(debounceTimer);
     debounceTimer = undefined;
   }
 }
 
 function debouncedRefresh() {
   cancelDebounce();
-  debounceTimer = requestAnimationFrame(() => {
+  debounceTimer = setTimeout(() => {
     debounceTimer = undefined;
     void runRefresh();
-  });
+  }, DEBOUNCE_MS);
 }
 
 // Folder expansion state — signals live in ./folder.ts


### PR DESCRIPTION
## 概要

`debouncedRefresh` の `requestAnimationFrame` ベースの debounce を `setTimeout(150ms)` に変更する。

## 背景と問題

RAF debounce は「次のフレームまで待つ」（~16ms at 60fps）のみで、高速タイピング時に各キーストロークで検索 IPC が発火しやすかった。`setTimeout(150ms)` に変えることで通常タイピング時（1文字 ~100ms）の IPC 呼び出しを大幅に削減できる。

## 変更内容

- `DEBOUNCE_MS = 150` 定数を追加
- `debounceTimer` 型を `ReturnType<typeof setTimeout>` に変更
- `cancelAnimationFrame` → `clearTimeout`
- `requestAnimationFrame` → `setTimeout(..., DEBOUNCE_MS)`

## 確認済み

- `npm run typecheck` ✅
- `npm run build` ✅
- `npm test` (180/180) ✅
- 目視確認: タイピング追従に問題なし ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)