### PR TITLE
refactor(ui): アイコン Show を flatten しオーバーレイを Switch に統合

### DIFF
--- a/ui/src/components/ResultRow.tsx
+++ b/ui/src/components/ResultRow.tsx
@@ -42,27 +42,18 @@ const ResultRow: Component<ResultRowProps> = (rawProps) => {
     >
       <Show when={props.showIcons}>
         <div class="result-icon">
-          <Show when={props.icon !== undefined}>
-            <Show
-              when={props.icon}
-              fallback={
-                <span class="icon-fallback">
+          {props.icon === undefined
+            ? null
+            : props.icon
+              ? <img src={props.icon} alt="" width="16" height="16" />
+              : <span class="icon-fallback">
                   {props.result.isError
                     ? "\u26A0\uFE0F"
                     : props.result.isFolder
                       ? "\u{1F4C1}"
                       : "\u{1F4C4}"}
                 </span>
-              }
-            >
-              <img
-                src={props.icon!}
-                alt=""
-                width="16"
-                height="16"
-              />
-            </Show>
-          </Show>
+          }
         </div>
       </Show>
       <div class="result-text" ref={textRef}>

--- a/ui/src/components/SearchWindow.tsx
+++ b/ui/src/components/SearchWindow.tsx
@@ -1,4 +1,4 @@
-import { type Component, onCleanup, onMount, Show } from "solid-js";
+import { type Component, onCleanup, onMount, Show, Switch, Match } from "solid-js";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { listen } from "@tauri-apps/api/event";
 import {
@@ -286,23 +286,25 @@ const SearchWindow: Component = () => {
         onInput={handleInput}
         autofocus
       />
-      <Show when={indexing()}>
-        <div class="search-overlay indexing-message" data-tauri-drag-region>
-          {t("search.status.indexing")}
-        </div>
-      </Show>
-      <Show when={launching() || launchNotice()}>
-        <div
-          class="search-overlay indexing-message"
-          classList={{ "indexing-message--error": !launching() && launchNotice() !== null }}
-          data-tauri-drag-region
-        >
-          {launching() ? t("search.status.launching") : launchNotice() ?? ""}
-        </div>
-      </Show>
-      <Show when={noResults()}>
-        <span class="no-results-hint">{t("search.status.no_results")}</span>
-      </Show>
+      <Switch>
+        <Match when={indexing()}>
+          <div class="search-overlay indexing-message" data-tauri-drag-region>
+            {t("search.status.indexing")}
+          </div>
+        </Match>
+        <Match when={launching() || launchNotice()}>
+          <div
+            class="search-overlay indexing-message"
+            classList={{ "indexing-message--error": !launching() && launchNotice() !== null }}
+            data-tauri-drag-region
+          >
+            {launching() ? t("search.status.launching") : launchNotice() ?? ""}
+          </div>
+        </Match>
+        <Match when={noResults()}>
+          <span class="no-results-hint">{t("search.status.no_results")}</span>
+        </Match>
+      </Switch>
     </div>
   );
 };


### PR DESCRIPTION
## 概要

アニメーション・ちらつきの原因となっていた 2 箇所の条件レンダリングを改善する。

## 変更内容

### P2-A: ResultRow のアイコン 3 層 `<Show>` を flatten

`icon` prop の 3 段階状態（`undefined` → `null` → `string`）を処理する `<Show>` の 3 層ネストを、インライン三項式に置き換える。

**変更前**: 各 `<Show>` が独立した DOM アンマウント/マウントを行うため、状態遷移時にちらつきが発生しやすかった。

**変更後**: SolidJS の reconciler による差分更新になり、中間フレームでの空白が生じない。

### P2-B: SearchWindow のオーバーレイを `<Switch>/<Match>` に統合

`indexing` / `launching + launchNotice` / `noResults` の 3 つの独立した `<Show>` を `<Switch>` に統合する。

**変更前**: 3 つの `<Show>` が独立して評価されるため、状態遷移の中間期に複数オーバーレイが同時に表示される可能性があった。

**変更後**: `<Switch>` により最初に一致した `<Match>` のみがレンダリングされ、中間状態フラッシュを防止する。

## 確認済み

- `npm run typecheck` ✅
- `npm run build` ✅
- `npm test` (180/180) ✅
- 目視確認: アイコンちらつきなし・オーバーレイ切り替え正常 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)