### PR TITLE
fix(ResultsSection): offscreen アイコン取得を可視行完了後に遅延開始する

### DIFF
--- a/ui/src/components/ResultsSection.tsx
+++ b/ui/src/components/ResultsSection.tsx
@@ -106,14 +106,14 @@ const ResultsSection: Component<ResultsSectionProps> = (props) => {
     if (!props.showIcons || props.skipIcons) return;
     // 呼び出し時点の値を固定し、await 中の設定変更でスライス境界がずれるのを防ぐ
     const visibleCount = props.maxResults;
-    // 可視行と非可視行を並列取得。可視行の完了を先に await して即時表示を最速化。
-    // stale guard は各バッチが独立して保持する generation 値で判定するため並列実行でも安全。
-    const visible = fetchIconBatch(items.slice(0, visibleCount), generation);
-    const hidden = items.length > visibleCount
-      ? fetchIconBatch(items.slice(visibleCount), generation)
-      : undefined;
-    await visible;
-    if (hidden !== undefined) await hidden;
+    // 可視行を先に await し、世代が変わっていなければ非表示行を開始する。
+    // 逐次実行にすることで、連続入力で世代がすぐ変わるケースに
+    // offscreen バッチ（Rust 側の rayon 処理を含む）を開始せずに済む。
+    await fetchIconBatch(items.slice(0, visibleCount), generation);
+    if (generation !== latestDataGeneration) return;
+    if (items.length > visibleCount) {
+      await fetchIconBatch(items.slice(visibleCount), generation);
+    }
   }
 
   // visible prop が false になったとき Blob URL を解放する


### PR DESCRIPTION
## Summary

- 並列実行（`fetchIconBatch` × 2 同時開始）を逐次実行に戻す
- 可視行の `await` 完了後に `generation !== latestDataGeneration` を確認し、stale なら offscreen バッチを開始しない
- 連続入力で世代がすぐ変わるケースで Rust 側の rayon ワーカーに余計な負荷をかけなくなる

## Background

PR #257 のレビュー指摘（P2）への対応。  
並列化により offscreen バッチが即座に走るようになり、stale なクエリでも Rust 側のアイコン抽出が最後まで実行されていた。これが可視行バッチの rayon リソースと競合し、可視アイコンの表示を逆に遅らせるパフォーマンス退行となっていた。

## Test plan

- [ ] 検索結果が `maxResults` を超える状態で連続入力し、可視行のアイコンが素早く表示されること
- [ ] スクロールで非表示行まで移動したとき、アイコンが遅れて表示されること（offscreen 取得が遅延開始されるため）
- [ ] `visible=false` 切り替え時に Blob URL リークがないこと（既存の stale guard が機能）

🤖 Generated with [Claude Code](https://claude.com/claude-code)