### PR TITLE
fix(ResultsSection): アイコンライフサイクルを統合管理し Blob URL リークと IC モード復帰時の取得漏れを修正

### DIFF
--- a/ui/src/components/ResultsSection.tsx
+++ b/ui/src/components/ResultsSection.tsx
@@ -124,7 +124,7 @@ const ResultsSection: Component<ResultsSectionProps> = (props) => {
   // enabled=false → キャッシュ破棄（visible 非表示・アイコン無効）
   // skip=true     → 何もしない（IC モード中: キャッシュ保持・取得抑制）
   // enabled かつ非 skip → 取得開始（results 変化・再表示・skipIcons 復帰すべてをカバー）
-  createEffect(on([results, iconsEnabled, () => props.skipIcons] as const, ([items, enabled, skip]) => {
+  createEffect(on([results, iconsEnabled, () => props.skipIcons] as const, ([items, enabled, skip], prev) => {
     if (!enabled) {
       latestIconRequestId = ++iconRequestId;
       iconCache.revokeAll();
@@ -135,7 +135,10 @@ const ResultsSection: Component<ResultsSectionProps> = (props) => {
     if (skip) return;
     const id = ++iconRequestId;
     latestIconRequestId = id;
-    fetchedNone.clear();
+    // results が変化したときのみクリア。skipIcons 切替だけの場合は「アイコンなし」確定済み情報を保持する
+    if (prev === undefined || prev[0] !== items) {
+      fetchedNone.clear();
+    }
     requestAnimationFrame(() => void fetchIcons(items, id));
   }));
 


### PR DESCRIPTION
## Summary

- `iconsEnabled = createMemo(() => visible && showIcons)` でアイコン取得条件を一元管理
- `createEffect(on([results, iconsEnabled, () => skipIcons], ...))` の単一 effect にアイコンライフサイクル（破棄・取得・抑制）を統合
- `show-icons-changed` の個別リスナーを削除（`props.showIcons` の変化は `iconsEnabled` メモ経由で effect が自動反応）
- IC モード（`skipIcons=true`）中はキャッシュ保持・取得抑制のみ、離脱時にアイコン取得を自動再開
- `fetchedNone.clear()` を `results` 変化時のみに限定（`skipIcons` 切替だけでは消去しない）

Closes #258

## Test plan

- [ ] アイコン表示設定 ON/OFF を切り替えてもアイコンキャッシュが正しく破棄・再取得される
- [ ] インスタントコマンドモード（`@`）入力中はアイコン取得が抑制され、離脱後に再取得される
- [ ] ウィンドウを連続で開閉してもアイコン Blob URL が増え続けない（DevTools Memory タブで確認）
- [ ] `npm run typecheck` パス
- [ ] `npx vite build` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)