### PR TITLE
fix(search): フォルダモード中の indexing ガードを条件付きに変更

### DIFF
--- a/ui/src/stores/search.ts
+++ b/ui/src/stores/search.ts
@@ -39,7 +39,7 @@ let activationInFlight = false;
 let suppressNextQueryEffectRefresh = false;
 
 /** 結果を表示すべきかの派生シグナル。MainApp がリアクティブにウィンドウ高さを変更するために使用 */
-const shouldShowResults = createMemo(() => results().length > 0 && (!indexing() || instantCommandMode()));
+const shouldShowResults = createMemo(() => results().length > 0 && (!indexing() || instantCommandMode() || folderState() !== null));
 
 function clearLaunchNotice() {
   if (launchNoticeTimer !== undefined) {
@@ -136,23 +136,21 @@ async function refreshResults() {
     setSelected(0);
     return;
   }
-  const pathQuery = fs ? null : parsePathQuery(q);
-  const source = indexing()
-    ? "indexing"
-    : trimmed === "/r"
-      ? "history"
-      : fs || pathQuery
-      ? "folder"
-      : "query";
-  perfStartSearch(requestId, source);
-
-  if (indexing() && !folderState()) {
+  if (indexing() && !fs) {
     updateResults([]);
     setSelected(0);
     trace("search:refresh:done", { requestId, branch: "indexing_guard", count: 0 });
     perfMarkSearchDone(requestId, 0);
     return;
   }
+
+  const pathQuery = fs ? null : parsePathQuery(q);
+  const source = trimmed === "/r"
+    ? "history"
+    : fs || pathQuery
+    ? "folder"
+    : "query";
+  perfStartSearch(requestId, source);
 
   let items: SearchResult[];
   if (fs) {


### PR DESCRIPTION
## Summary

- `refreshResults()` の `indexing()` ガードを `fs`（フォルダモード）が null のときのみ適用するよう修正
- `shouldShowResults` メモに `folderState() !== null` 条件を追加し、フォルダモード中はウィンドウ高さ・表示制御を正しく維持
- `source` ラベルをガード評価後に計算するよう順序を変更し、perf 計測の誤分類を解消

### 修正した問題

| 優先度 | 問題 | 修正 |
|--------|------|------|
| 高 | `shouldShowResults` が `indexing()` 中に false → フォルダ一覧が非表示になる | `\|\| folderState() !== null` を追加 |
| 中 | `source = "indexing"` でフォルダ処理の perf ラベルが誤分類 | ガードを先に評価し `"indexing"` 分岐を削除 |

## Test plan

- [ ] 通常検索中に再インデックスが走ると結果がクリアされることを確認
- [ ] フォルダモード中に再インデックスが走っても一覧が継続表示されることを確認
- [ ] インスタントコマンドモード・ツール選択モードへのリグレッションがないことを確認
- [ ] `npm run typecheck` / `npm run build` 通過済み

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)