### PR TITLE
fix(ui): カーソル連打時の検索結果行ぶれを修正

### DIFF
--- a/ui/src/components/ResultsSection.tsx
+++ b/ui/src/components/ResultsSection.tsx
@@ -30,19 +30,6 @@ const ResultsSection: Component<ResultsSectionProps> = (props) => {
   let iconRequestId = 0;   // アイコン取得の世代カウンタ（staleness guard 用）
   let listGeneration = 0;  // スクロール追従の世代カウンタ（results 変化時のみ更新）
 
-  function ensureRowVisible(container: HTMLDivElement, row: HTMLElement) {
-    const cRect = container.getBoundingClientRect();
-    const rRect = row.getBoundingClientRect();
-
-    if (rRect.top < cRect.top) {
-      container.scrollTop -= cRect.top - rRect.top;
-      return;
-    }
-    if (rRect.bottom > cRect.bottom) {
-      container.scrollTop += rRect.bottom - cRect.bottom;
-    }
-  }
-
   /** Parse length-prefixed binary batch into per-path Blob URLs.
    *  Format: [count:u32 LE] then per icon: [status:u8] [if 1: png_len:u32 LE, png_bytes] */
   function parseBinaryBatch(
@@ -203,7 +190,7 @@ const ResultsSection: Component<ResultsSectionProps> = (props) => {
         if (!listRef) return;
         const row = listRef.children[selectedIdx] as HTMLElement | undefined;
         if (!row) return;
-        ensureRowVisible(listRef, row);
+        row.scrollIntoView({ block: "nearest", inline: "nearest" });
       });
     }
   }

--- a/ui/src/styles/global.css
+++ b/ui/src/styles/global.css
@@ -64,6 +64,7 @@ html, body, #root {
 .result-list-standalone {
   flex: 1;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .result-list-standalone::-webkit-scrollbar {
@@ -138,7 +139,7 @@ html, body, #root {
 
 .result-path-single {
   font-size: inherit;
-  line-height: 1.3;
+  line-height: 1;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary

- `ResultsSection`: `ensureRowVisible`（手動 `scrollTop` 操作）を削除し `row.scrollIntoView({ block: \"nearest\", inline: \"nearest\" })` に置き換え
- `global.css`: `.result-path-single` の `line-height: 1.3`（= 19.5px 非整数）を `line-height: 1`（font-size に追従する整数値）に変更
- `global.css`: `.result-list-standalone` に `overflow-x: hidden` を明示

## 原因

`getBoundingClientRect`（浮動小数点）を `scrollTop` に直接加算していたため非整数スクロール位置が発生し、`line-height: 1.3` による非整数テキスト位置と組み合わさってサブピクセルレンダリングが変化、行が上下にぶれて見えていた。

## Test plan

- [ ] カーソルキー押しっぱなしで行ぶれが消えていること（目視）
- [ ] 画面外の行にカーソルが移動したときスクロール追従すること
- [ ] フォントサイズを変更してもテキストが正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)