### PR TITLE
fix(settings): 全タブのスクロールバーをウィンドウ右端に移動

### DIFF
--- a/snotra-settings/src/tabs/backup.rs
+++ b/snotra-settings/src/tabs/backup.rs
@@ -66,7 +66,7 @@ pub fn ui(
         }
     }
 
-    egui::ScrollArea::vertical().scroll_source(egui::scroll_area::ScrollSource { drag: false, ..Default::default() }).show(ui, |ui| {
+    egui::ScrollArea::vertical().auto_shrink([false, false]).scroll_source(egui::scroll_area::ScrollSource { drag: false, ..Default::default() }).show(ui, |ui| {
         ui.spacing_mut().interact_size.y = 24.0;
 
         // Export section

--- a/snotra-settings/src/tabs/general.rs
+++ b/snotra-settings/src/tabs/general.rs
@@ -5,7 +5,7 @@ use crate::hotkey_input::{self, HotkeyInputState};
 use crate::i18n::Tr;
 
 pub fn ui(ui: &mut egui::Ui, config: &mut Config, hotkey_state: &mut HotkeyInputState, tr: &Tr) {
-    egui::ScrollArea::vertical().scroll_source(egui::scroll_area::ScrollSource { drag: false, ..Default::default() }).show(ui, |ui| {
+    egui::ScrollArea::vertical().auto_shrink([false, false]).scroll_source(egui::scroll_area::ScrollSource { drag: false, ..Default::default() }).show(ui, |ui| {
         // Consistent row height so checkboxes and DragValue inputs align vertically
         ui.spacing_mut().interact_size.y = 24.0;
 

--- a/snotra-settings/src/tabs/index.rs
+++ b/snotra-settings/src/tabs/index.rs
@@ -81,7 +81,7 @@ pub fn ui(ui: &mut egui::Ui, ctx: &egui::Context, config: &mut Config, state: &m
         }
     }
 
-    egui::ScrollArea::vertical().scroll_source(egui::scroll_area::ScrollSource { drag: false, ..Default::default() }).show(ui, |ui| {
+    egui::ScrollArea::vertical().auto_shrink([false, false]).scroll_source(egui::scroll_area::ScrollSource { drag: false, ..Default::default() }).show(ui, |ui| {
         ui.spacing_mut().interact_size.y = 24.0;
 
         ui.heading(tr.heading_scan_targets());

--- a/snotra-settings/src/tabs/instant.rs
+++ b/snotra-settings/src/tabs/instant.rs
@@ -54,7 +54,7 @@ pub fn ui(
     state: &mut InstantTabState,
     tr: &Tr,
 ) {
-    egui::ScrollArea::vertical().scroll_source(egui::scroll_area::ScrollSource { drag: false, ..Default::default() }).show(ui, |ui| {
+    egui::ScrollArea::vertical().auto_shrink([false, false]).scroll_source(egui::scroll_area::ScrollSource { drag: false, ..Default::default() }).show(ui, |ui| {
         ui.spacing_mut().interact_size.y = 24.0;
 
         // Prefix setting

--- a/snotra-settings/src/tabs/opener.rs
+++ b/snotra-settings/src/tabs/opener.rs
@@ -112,7 +112,7 @@ pub fn ui(ui: &mut egui::Ui, ctx: &egui::Context, config: &mut Config, state: &m
         }
     }
 
-    egui::ScrollArea::vertical().scroll_source(egui::scroll_area::ScrollSource { drag: false, ..Default::default() }).show(ui, |ui| {
+    egui::ScrollArea::vertical().auto_shrink([false, false]).scroll_source(egui::scroll_area::ScrollSource { drag: false, ..Default::default() }).show(ui, |ui| {
         ui.spacing_mut().interact_size.y = 24.0;
 
         ui.heading(tr.heading_opener_rules());

--- a/snotra-settings/src/tabs/search.rs
+++ b/snotra-settings/src/tabs/search.rs
@@ -6,7 +6,7 @@ use crate::app::TEXT_SECONDARY;
 use crate::i18n::Tr;
 
 pub fn ui(ui: &mut egui::Ui, config: &mut Config, tr: &Tr) {
-    egui::ScrollArea::vertical().scroll_source(egui::scroll_area::ScrollSource { drag: false, ..Default::default() }).show(ui, |ui| {
+    egui::ScrollArea::vertical().auto_shrink([false, false]).scroll_source(egui::scroll_area::ScrollSource { drag: false, ..Default::default() }).show(ui, |ui| {
         ui.spacing_mut().interact_size.y = 24.0;
 
         // -- Search mode --

--- a/snotra-settings/src/tabs/visual.rs
+++ b/snotra-settings/src/tabs/visual.rs
@@ -56,7 +56,7 @@ const PRESETS: &[PresetDef] = &[
 const SWATCH_SIZE: f32 = 16.0;
 
 pub fn ui(ui: &mut egui::Ui, config: &mut Config, fonts: &[String], tr: &Tr) {
-    egui::ScrollArea::vertical().scroll_source(egui::scroll_area::ScrollSource { drag: false, ..Default::default() }).show(ui, |ui| {
+    egui::ScrollArea::vertical().auto_shrink([false, false]).scroll_source(egui::scroll_area::ScrollSource { drag: false, ..Default::default() }).show(ui, |ui| {
         ui.spacing_mut().interact_size.y = 24.0;
 
         // -- Theme presets --


### PR DESCRIPTION
## Summary

- 設定UIの全タブ（general / search / index / visual / opener / instant / backup）で、スクロールバーがコンテンツ幅の右端に表示されていた問題を修正
- `ScrollArea::vertical()` に `.auto_shrink([false, false])` を追加し、`CentralPanel` の全幅にスクロールエリアを広げることでウィンドウ右端にスクロールバーが表示されるよう変更

## Test plan

- [ ] 各タブを開き、コンテンツがウィンドウに収まらない場合にスクロールバーがウィンドウ右端に表示されることを確認
- [ ] スクロール動作が正常に機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)