### PR TITLE
feat: WebView2 非表示時に MemoryUsageTargetLevel を Low に設定しメモリ削減

### DIFF
--- a/src-tauri/CLAUDE.md
+++ b/src-tauri/CLAUDE.md
@@ -5,7 +5,7 @@ Tauri v2 バイナリ crate。Win32 API 統合とフロントエンドとの IPC
 ## モジュール構成
 
 - `main.rs`: エントリポイント、Tauri セットアップ、イベントリスナー登録
-- `state.rs`: `AppState` 定義（`Mutex<Engine>` + `AtomicBool` × 3: `indexing` / `index_build_started` / `main_visible`）。`Engine` は `snotra-core` の facade で、検索・履歴・設定を単一ロックに統合。`main_visible` は Win32 `is_visible()` の 35ms レイテンシを回避するためのキャッシュ
+- `state.rs`: `AppState` 定義（`Mutex<Engine>` + `AtomicBool` × 3: `indexing` / `index_build_started` / `main_visible`）。`Engine` は `snotra-core` の facade で、検索・履歴・設定を単一ロックに統合。`main_visible` は Win32 `is_visible()` の 35ms レイテンシを回避するためのキャッシュ。`WebViewMemoryControl`（`ICoreWebView2_6` の COM ポインタ保持、setup フェーズで取得）と `set_webview_memory_low()` / `set_webview_memory_normal()` ヘルパーで hide/show 時のメモリレベル切り替えを提供
 - `icon.rs`: アイコンのオンデマンド抽出（`SHGetFileInfoW` → PNG → base64）、検索時に遅延ロードしキャッシュ永続化
 - `indexing.rs`: バックグラウンドインデックス構築
 - `config_watcher.rs`: `notify` クレートで `config.toml` 変更を監視（100ms debounce）し、差分検出後にホットキー・トレイ・インデックス・テーマ・ウィンドウ幅・言語を反映する `apply_config_change()` を実行。**不変条件: 言語変更とホットキー変更が同時に発生した場合、`language-changed` イベントをホットキー失敗通知より先に発火する**（フロントエンドが正しい言語でエラー文字列を組み立てるため）。発火するイベント: `language-changed` / `hotkey-registration-failed` / `visual-config-changed` / `show-icons-changed` / `max-results-changed` / `instant-prefix-changed` / `indexing-started`（indexing.rs から）/ `indexing-complete`（indexing.rs から）
@@ -21,7 +21,7 @@ Tauri v2 バイナリ crate。Win32 API 統合とフロントエンドとの IPC
 - 設定ウィンドウは `WebviewWindowBuilder` で同一プロセス内の第2ウィンドウとして生成
 - `commands/` は薄いラッパーに保ち、実処理は `snotra-core` に寄せる（KISS）
 - `AppState` は `Mutex<Engine>` で検索エンジン・履歴・設定を一括管理。Phase 2.3 以前の 3重ロック（`Mutex<SearchEngine>` / `Mutex<HistoryStore>` / `Mutex<Config>`）は Engine facade に統合済み
-- Managed state として `IconCacheState`（`Mutex<Option<IconCache>>`、初回アイコン要求で遅延初期化）と `SettingsProcessState`（`Mutex<Option<Child>>`、設定プロセスのハンドル管理）を保持
+- Managed state として `IconCacheState`（`Mutex<Option<IconCache>>`、初回アイコン要求で遅延初期化）、`SettingsProcessState`（`Mutex<Option<Child>>`、設定プロセスのハンドル管理）、`WebViewMemoryControl`（`ICoreWebView2_6`、hide 時に `MemoryUsageTargetLevel::Low`、show 時に `Normal` を設定）を保持
 - **`show_main_and_emit` の操作順序制約**: 高さリセット（52px）→ `position_on_target_monitor` → `show()` の順。位置計算はウィンドウサイズ（`outer_size()`）でクランプするため、高さリセット前に位置を決めると展開時の高さでクランプされ、折りたたみ時に位置がずれる
 
 ## Win32 メッセージ配送の注意

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -42,5 +42,9 @@ pub fn notify_main_shown(state: State<AppState>) {
 #[tauri::command]
 pub fn notify_main_hidden(state: State<AppState>, app: AppHandle) {
     state.main_visible.store(false, Ordering::SeqCst);
+    // Reduce WebView2 memory while hidden (symmetric pair: set_normal in show_main_and_emit).
+    // This covers hide paths triggered from JS (focus-lost, Enter launch, Escape, /s command).
+    #[cfg(windows)]
+    crate::state::set_webview_memory_low(&app);
     let _ = app.emit("window-hidden", ());
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -230,11 +230,9 @@ fn show_main_and_emit(app_handle: &AppHandle, ime_control: bool) {
         position_on_target_monitor(app_handle, &main);
 
         // Restore WebView2 memory usage to Normal before showing.
-        // Symmetric pair: set_low() is called on hide in the hotkey listener.
+        // Symmetric pair: set_low() is called in hotkey hide and notify_main_hidden.
         #[cfg(windows)]
-        if let Some(mem) = app_handle.try_state::<Mutex<crate::state::WebViewMemoryControl>>() {
-            if let Ok(m) = mem.lock() { m.set_normal(); }
-        }
+        crate::state::set_webview_memory_normal(app_handle);
 
         // show() is idempotent — call unconditionally to skip the costly
         // is_visible() pre-check (61ms + 71ms gap on first invocation).
@@ -479,9 +477,9 @@ fn main() {
                         unsafe { controller.CoreWebView2() };
                     if let Ok(core) = core {
                         if let Ok(core6) = core.cast::<ICoreWebView2_6>() {
-                            handle_for_mem.manage(Mutex::new(
+                            handle_for_mem.manage(
                                 crate::state::WebViewMemoryControl::new(core6),
-                            ));
+                            );
                         }
                     }
                 }).expect("WebView memory control must initialize in setup phase");
@@ -542,9 +540,7 @@ fn main() {
                     // Reduce WebView2 memory usage while hidden (best-effort, async internally).
                     // Symmetric pair: set_normal() is called in show_main_and_emit.
                     #[cfg(windows)]
-                    if let Some(mem) = handle_for_hotkey.try_state::<Mutex<crate::state::WebViewMemoryControl>>() {
-                        if let Ok(m) = mem.lock() { m.set_low(); }
-                    }
+                    crate::state::set_webview_memory_low(&handle_for_hotkey);
                     // Notify JS side so mainVisible signal updates and Blob URLs are released.
                     // Symmetric pair: window-shown is emitted in show_main_and_emit.
                     let _ = handle_for_hotkey.emit("window-hidden", ());

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -16,6 +16,9 @@ pub struct AppState {
 ///
 /// The COM pointer is obtained via `with_webview()` (safe only in setup phase) and stored
 /// here for later use in event-loop callbacks where `with_webview()` would deadlock.
+///
+/// `ICoreWebView2_6` is a COM smart pointer (`Send + Sync`) and `set_low`/`set_normal`
+/// take `&self`, so no Mutex is needed.
 #[cfg(windows)]
 pub struct WebViewMemoryControl {
     inner: webview2_com::Microsoft::Web::WebView2::Win32::ICoreWebView2_6,
@@ -43,5 +46,23 @@ impl WebViewMemoryControl {
         unsafe {
             let _ = self.inner.SetMemoryUsageTargetLevel(COREWEBVIEW2_MEMORY_USAGE_TARGET_LEVEL_NORMAL);
         }
+    }
+}
+
+/// Set WebView2 memory usage to Low. No-op if WebViewMemoryControl is not registered.
+#[cfg(windows)]
+pub fn set_webview_memory_low(app: &tauri::AppHandle) {
+    use tauri::Manager;
+    if let Some(mem) = app.try_state::<WebViewMemoryControl>() {
+        mem.set_low();
+    }
+}
+
+/// Set WebView2 memory usage to Normal. No-op if WebViewMemoryControl is not registered.
+#[cfg(windows)]
+pub fn set_webview_memory_normal(app: &tauri::AppHandle) {
+    use tauri::Manager;
+    if let Some(mem) = app.try_state::<WebViewMemoryControl>() {
+        mem.set_normal();
     }
 }


### PR DESCRIPTION
ランチャーは大半の時間が非表示のため、hide 時に WebView2 の
MemoryUsageTargetLevel を Low に切り替え、show 時に Normal に戻す。
ICoreWebView2_6 の COM インターフェースを setup フェーズで取得・保持し、
イベントループ中の with_webview() デッドロックを回避する。

https://claude.ai/code/session_01TxHifftwBk2wXh1nEao7Yd