### PR TITLE
docs: WebView2 COM パターンとビルド注意事項を追記

### DIFF
--- a/docs/build-commands.md
+++ b/docs/build-commands.md
@@ -21,7 +21,7 @@ npm run smoke:startup             # 起動時ウィンドウ生成スモーク�
 npm run e2e:tauri:setup           # Tauri Driver E2E 用セットアップ
 npm run e2e:tauri                 # Playwright + Tauri Driver E2E
 npm run tauri dev                # 開発実行（ホットリロード付き）
-npm run tauri build              # リリースビルド
+npm run tauri build              # リリースビルド（フロント+Rust 一括。cargo build --release 単体は UI が壊れる）
 ```
 
 ## E2E/スモーク運用メモ

--- a/src-tauri/CLAUDE.md
+++ b/src-tauri/CLAUDE.md
@@ -59,6 +59,8 @@ NOTIFYICON_VERSION_4 では、キーボード操作（Shift+F10 / Application �
 - Win32 関連の不具合では、まず `config.toml`（テーマ含む）を確認し、次にウィンドウライフサイクル順序、最後に API 呼び出しを調査する（白画面バグの真因がテーマ設定だった事例あり）
 - Rust クレートをバージョン昇格する際は、対象バージョンが crates.io に実在・正当であることを確認する。大版ジャンプを前提にしない（例: `bincode 3.0.0` は `compile_error!` のみを含むジョークパッケージでコンパイル不能）
 - `windows` クレート（現在 v0.62）はバージョンごとに API シグネチャが変わる（`Result` 型の有無、ハンドル型の変更など）。コードを書く前に、使用中のバージョンで対象 API が利用可能か・型が一致するかを確認する
+- `webview2-com` は `windows-core 0.61` に依存するが、プロジェクトの `windows` クレート（v0.62）は `windows-core 0.62` を使う。`Interface::cast()` 等を呼ぶ際は `windows-core_0_61 = { package = "windows-core", version = "0.61" }` のエイリアス依存を使い、`use windows_core_0_61::Interface` とする
+- WebView2 COM インターフェース（`ICoreWebView2_3` 等）は `!Send + !Sync`（内部が `NonNull<c_void>`）。Tauri managed state（`Send + Sync` 必須）に保持できない。`with_webview()` コールバック内でインラインにキャストして使う
 - 必要な feature フラグ（`Win32_UI_WindowsAndMessaging` 等）が `Cargo.toml` に宣言されているか確認してから実装する
 - `UpdateWindow` など一部 API は windows クレートのバージョンによっては未提供。代替 API（`RedrawWindow` 等）の存在を事前に調べる
 - Windows パスの正規化では `C:` と `C:\` の違いに注意する（ドライブルートは末尾 `\` が必須）


### PR DESCRIPTION
## Summary
- `webview2-com` と `windows-core` のバージョン競合パターン（エイリアス依存の使い方）を `src-tauri/CLAUDE.md` に追記
- COM インターフェースが `!Send + !Sync` のため `with_webview()` インラインアクセスが必須な旨を追記
- `cargo build --release` 単体では UI が壊れる注記を `docs/build-commands.md` に追記

## Test plan
- [ ] ドキュメントのみの変更のため、ビルド・テストへの影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)