### PR TITLE
fix: 検索結果行のテキスト下端が切れる問題を修正

### DIFF
--- a/ui/src/styles/global.css
+++ b/ui/src/styles/global.css
@@ -140,7 +140,7 @@ html, body, #root {
 
 .result-path-single {
   font-size: inherit;
-  line-height: 1;
+  line-height: normal;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary
- `.result-path-single` の `line-height: 1` を `line-height: normal` に変更
- `overflow: hidden` との組み合わせで g, p, y 等のディセンダーが切り取られていた問題を解消

## Test plan
- [x] 検索結果にディセンダーを含む文字（g, p, y, q）が表示されるクエリで下端が切れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)