### PR TITLE
chore: ビルド・検証コマンドを docs/build-commands.md に SSOT 統合

### DIFF
--- a/.claude/skills/health-check/SKILL.md
+++ b/.claude/skills/health-check/SKILL.md
@@ -47,26 +47,26 @@ allowed-tools:
    - **記載あり・実ファイルなし**: 削除されたのに architecture.md が未更新
    - **実ファイルあり・記載なし**: 追加されたのに architecture.md が未更新
 
-## Check 3 -- AGENTS.md ドキュメント参照・コマンドの整合性
+## Check 3 -- AGENTS.md ドキュメント参照の実在性
 
-### 3a. ドキュメント参照の実在性
 `AGENTS.md` の「ドキュメント参照」セクションに記載されたファイルパスが実在するか検証する。
 存在しないファイルへの参照を報告する。
 
-### 3b. 検証コマンドの整合性
-`AGENTS.md` の「変更後の検証」（ステップ 8）に記載された npm コマンド（`npm run XXX`）が `package.json` の `scripts` に定義されているか検証する。
-定義されていないコマンドを報告する。
+> **Note:** 検証コマンドの整合性は SSOT である `docs/build-commands.md` を対象とする Check 5 で一括検証する（AGENTS.md は Step 8 で `docs/build-commands.md` を参照する形式に統合済み）。
 
 ## Check 4 -- SPEC.md セクション番号の連続性
 
 `SPEC.md` を読み、`## N.` と `### N.x` の番号が連続しているか確認する。
 飛び・重複・親子の不整合があれば報告する。
 
-## Check 5 -- docs/build-commands.md コマンドの実在性
+## Check 5 -- docs/build-commands.md コマンドの実在性（SSOT）
 
-`docs/build-commands.md` に記載された `npm run XXX` / `npm XXX` コマンドが `package.json` の `scripts` に定義されているか検証する。
+`docs/build-commands.md` はビルド／検証コマンドの単一の真実源（SSOT）。記載された `npm run XXX` / `npm XXX` コマンドが `package.json` の `scripts` に定義されているか検証する。
 `cargo` コマンドは `Cargo.toml` のワークスペースメンバーと照合する（`-p <crate>` のクレート名が存在するか）。
 定義されていないコマンドを報告する。
+
+加えて、SSOT ドリフトの検知として以下も確認する:
+- `AGENTS.md` Step 8 や `.claude/skills/*/SKILL.md` に **コマンド本体**（`cargo XXX` / `npm XXX` / `npx XXX` の具体的な引数を含む実行コマンド）が直書きされていないか grep する。`docs/build-commands.md` の SSOT を迂回している箇所を報告する（コマンド名への言及や参照リンク自体は許容）。
 
 ## Check 6 -- docs/development-principles.md 参照の実在性
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 argument-hint: "[機能の説明]"
 allowed-tools:
   - Bash(cargo *)
-  - Bash(npx vite build)
+  - Bash(npm *)
   - Bash(git *)
   - Read
   - Edit
@@ -46,16 +46,10 @@ allowed-tools:
 
 ## Step 4 -- 検証（最大5サイクル）
 
-以下のチェックを順に実行する。失敗した場合、修正して失敗したステップから再実行:
+`docs/build-commands.md` の「変更後の検証チェックリスト」を SSOT として、変更したファイルの種類に該当するカテゴリ A〜D をすべて実行する。失敗した場合、修正して失敗したステップから再実行する。
 
-1. Rust 検証（チェーン実行 — 最初の失敗で停止）:
-   ```bash
-   cargo check -p snotra-core -p snotra && cargo clippy -p snotra-core -p snotra -- -D warnings && cargo test -p snotra-core
-   ```
-2. フロントエンド検証（TypeScript/フロントエンドファイルを変更した場合のみ）:
-   ```bash
-   npx vite build
-   ```
+- カテゴリ A（Rust 変更）の追加検証（`cargo clippy` / `cargo test`）は本スキルでは**必須として扱う**（最初の失敗で停止するチェーン実行を推奨）
+- 具体的なコマンド文字列は `docs/build-commands.md` を参照（二重メンテを避けるためこの SKILL に書かない）
 
 5サイクル後もエラーが残る場合、中止して診断サマリーを書く:
 - 試みた内容

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,9 +57,8 @@
 6. 最小実装で通す（Green）
 7. テストが通るまで 6 を反復する
 8. 変更後の検証を実行する（スキップ不可）
-   - Rust ファイルを触った場合: `cargo check -p snotra-core -p snotra -p snotra-settings`（必須）、追加で `cargo test / clippy` も検討
-   - TS ファイルを触った場合: `npm run typecheck` + `npm run build`（必須・プロジェクトルートから実行）
-   - ウィンドウ生成/表示順・ホットキー・スラッシュコマンドを触った場合: `npm test` + `npm run smoke:startup` + `npm run e2e:tauri` を必須で実行
+   - 変更したファイルの種類に応じて、`docs/build-commands.md` の「変更後の検証チェックリスト」のカテゴリ A〜D から該当するものをすべて実行する
+   - コマンド本体は SSOT である `docs/build-commands.md` を参照（このリストとの二重メンテを避けるため、コマンド文字列はこのファイルに書かない）
 9. 報告は「追加/更新テスト名 + 検証した不変条件」を必ず含める
 
 ## 環境制約

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,22 +42,15 @@ git push origin v0.9.1
   - Visual Studio 2022（または Build Tools）で「Desktop development with C++」ワークロードと Windows SDK を有効にする
 - **Node.js** >= 22
 
-### 起動
+### 起動・開発コマンド
 
-```bash
-npm ci
-npm run tauri dev
-```
+開発実行・依存インストール・設定 GUI の単独起動・テスト・E2E など、すべてのビルド／実行コマンドは [docs/build-commands.md](docs/build-commands.md) を SSOT として参照する。
 
-### snotra-settings（設定 GUI）の単独確認
+最初のセットアップから開発実行までの最短経路は以下の通り（コマンドの詳細・補足は SSOT を参照）:
 
-```bash
-cargo run -p snotra-settings
-```
-
-### テスト
-
-テストコマンドの一覧は [docs/build-commands.md](docs/build-commands.md) を参照。
+1. `npm ci` で依存をインストール
+2. `npm run tauri dev` で開発実行
+3. 設定 GUI のみ確認したい場合は `cargo run -p snotra-settings`
 
 ## アーキテクチャ
 

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -80,9 +80,8 @@ opt-level = "s"
 - 計測は **DEV かつ `localStorage.snotra_perf === "1"`** のときのみ有効化する
 - 有効化手順: DevTools で `localStorage.setItem("snotra_perf","1")` → アプリ再起動
 - 無効化手順: `localStorage.removeItem("snotra_perf")` → アプリ再起動
-- コアロジックのマイクロベンチは `ignored` テストとして保持する。実行例:
-  `cargo test -p snotra-core bench_ -- --ignored --nocapture`
-- フォルダ列挙のホットパス確認には `cargo test -p snotra-core bench_folder_ -- --ignored --nocapture` を使う
+- コアロジックのマイクロベンチは `ignored` テストとして保持する。実行コマンドは [docs/build-commands.md](docs/build-commands.md) の「検索パフォーマンス計測」を SSOT として参照
+- フォルダ列挙のホットパス確認には bench フィルタを絞る: `cargo test -p snotra-core bench_folder_ -- --ignored --nocapture`（SSOT の bench コマンドに対するフィルタ違いとして個別記載）
 - `bench_folder_narrow_filter` は「大量エントリ + 狭いフィルタ」で、非一致エントリに不要な文字列化や属性判定をしていないかを確認する
 - `bench_folder_hidden_filter_all` は `show_hidden_system = false` 相当で、`metadata()` を伴う属性判定コスト込みの回帰を確認する
 - Tauri Driver E2E でウィンドウ可視性を判定するとき、`document.visibilityState` は誤判定し得るため性能判定の根拠に使わない。`plugin:window|is_visible` を優先する

--- a/docs/build-commands.md
+++ b/docs/build-commands.md
@@ -2,6 +2,44 @@
 
 **環境を確認の上、実行してください。**
 
+このドキュメントは Snotra のビルド／検証コマンドの単一の真実源（SSOT）です。`AGENTS.md` の開発ワークフローや `.claude/skills/*/SKILL.md` の検証ステップは、コマンド本体をここに集約して参照します。コマンドを追加・変更するときはこのファイルのみを更新してください。
+
+## 変更後の検証チェックリスト（必須・スキップ不可）
+
+変更したファイルの種類に応じて、以下のカテゴリの必須コマンドを実行する。複数カテゴリに該当する場合はすべて実行する。
+
+### A. Rust ファイル（`*.rs`）を変更した場合
+
+```bash
+cargo check -p snotra-core -p snotra -p snotra-settings     # 必須: Rust 全 crate 型チェック
+```
+
+- 追加検証: `cargo clippy -p snotra-core -p snotra -p snotra-settings -- -D warnings`、`cargo test -p snotra-core`
+- `snotra-settings` を含めるのは egui ネイティブウィンドウ側の型壊れも検知するため
+
+### B. TypeScript／フロントエンドファイル（`ui/src/**/*.{ts,tsx}` 等）を変更した場合
+
+```bash
+npm run typecheck    # 必須: TypeScript 型チェック
+npm run build        # 必須: typecheck → vite build（プロジェクトルートから実行）
+```
+
+- `npm run build` は内部で `typecheck` を呼びますが、型エラーを早期に切り分けるため別途実行を推奨
+
+### C. ウィンドウ生成／表示順・ホットキー・スラッシュコマンドに触れた場合（A／B に追加）
+
+```bash
+npm test                 # 必須: フロントユニットテスト（Vitest）
+npm run smoke:startup    # 必須: 起動時ウィンドウ生成スモーク（trace 検証）
+npm run e2e:tauri        # 必須: Playwright + Tauri Driver E2E
+```
+
+- 初回のみ `npm run e2e:tauri:setup` でセットアップが必要
+
+### D. UI のスタイル・レイアウト・テキスト表示に影響する変更（A／B／C に追加）
+
+`npm run tauri dev` で起動し、目視で overflow／clipping／フォントレンダリングを確認する。PR 作成前に必須。
+
 ## Windows/macOS/Linux で実行可能
 
 ```bash
@@ -12,10 +50,12 @@ npm run build                    # フロントエンドビルド（typecheck �
 ## Windows のみ実行可能（`windows` クレートや Win32 API・実行バイナリに依存）
 
 ```bash
+npm ci                           # 依存インストール（初回セットアップ・CI）
 cargo test -p snotra-core        # ユニットテスト
-cargo test --release -p snotra-core bench_ -- --ignored --nocapture  # 検索パフォーマンス計測
+cargo test --release -p snotra-core bench_ -- --ignored --nocapture  # 検索パフォーマンス計測（詳細: PERFORMANCE.md）
 cargo check -p snotra-core -p snotra -p snotra-settings  # Rust 全 crate 型チェック
 cargo clippy -p snotra-core -p snotra -p snotra-settings  # lint チェック
+cargo run -p snotra-settings     # snotra-settings（egui ネイティブ設定 GUI）の単独起動
 npm run verify                   # Rust + フロントエンド一括検証（cargo check + npm run build）
 npm run smoke:startup             # 起動時ウィンドウ生成スモーク（trace検証）
 npm run e2e:tauri:setup           # Tauri Driver E2E 用セットアップ


### PR DESCRIPTION
## Summary

- `AGENTS.md` Step 8・`implement/SKILL.md` Step 4・`health-check/SKILL.md`・`CONTRIBUTING.md`・`PERFORMANCE.md` に分散していたビルド／検証コマンド本体を `docs/build-commands.md` を SSOT として参照する形に統一
- `implement/SKILL.md` に残っていた古い記述（`snotra-settings` クレート欠落・`npx vite build` による typecheck スキップ）を SSOT 参照に置き換えてドリフト解消。`allowed-tools` を `Bash(npx vite build)` から `Bash(npm *)` に拡張
- `health-check/SKILL.md` の Check 3b（AGENTS.md コマンド整合）と Check 5（build-commands.md コマンド整合）を統合し、Check 5 に**SSOT 迂回 grep 検知**を追加してドリフト再発を防止

## SSOT 統合の判断

意図的に SSOT 参照に**しなかった**コマンド:

- `PERFORMANCE.md` の計測ベースライン環境注釈 — 計測時点のコマンドスナップショットとして再現性を担保
- `PERFORMANCE.md` の `bench_folder_` フィルタ — SSOT のベンチに対するフィルタ違いの個別記載として差分情報を残す
- `CONTRIBUTING.md` の E2E トラブルシュート内 `npm run e2e:tauri:setup` — トラブル解決の即応性として個別記載が妥当
- `CONTRIBUTING.md` の onboarding 最短経路 — 外部コントリビュータ向け初回起動を SSOT への 1 ホップで止めない

## Test plan

- [ ] `docs/build-commands.md` の「変更後の検証チェックリスト」セクション（A〜D）が冒頭に存在する
- [ ] `AGENTS.md` Step 8 が `docs/build-commands.md` 参照のみで構成される
- [ ] `.claude/skills/implement/SKILL.md` Step 4 が SSOT 参照に置き換わり、`allowed-tools` に `Bash(npm *)` が含まれる
- [ ] `.claude/skills/health-check/SKILL.md` の Check 3b が削除され、Check 5 に SSOT 迂回 grep 検知が追加されている
- [ ] `CONTRIBUTING.md` の「起動・開発コマンド」セクションが SSOT 参照 + onboarding 最短経路の構成
- [ ] `PERFORMANCE.md` のコアロジック bench コマンドが SSOT 参照に置き換わる

🤖 Generated with [Claude Code](https://claude.com/claude-code)