### PR TITLE
fix: インデックス・アイコン処理の並行性競合（①②③）を解消

### DIFF
--- a/.claude/rules/snotra-core.md
+++ b/.claude/rules/snotra-core.md
@@ -12,4 +12,5 @@ paths:
 - **ビットマスクは `query.rs::char_bitmask()` に一元化済み**: `search.rs` と `indexer.rs` の両方が import して使用。変更は `query.rs` の1箇所のみ
 - **incremental cache 変更時は `/cache-check`** で単調性を検証する
 - **`index.bin` を書く新経路は `INDEX_WRITE_LOCK` 経由**: `with_index_write_lock`（権威的書き手・blocking）/ `try_with_index_write_lock`（背景再スキャン・try_lock）。`save_cache_sorted` 自身はロックを取らない（呼び出し側が保持）
+- **`icons.bin` に触れない**: アイコンキャッシュは `src-tauri` の資源。背景再スキャンは `RescanOutcome` で結果を伝え、無効化は呼び出し側が行う
 - **UI 表示文字列を持たない**: エラーは `is_error: true` フラグで伝え、表示は UI 層の責務

--- a/.claude/rules/snotra-core.md
+++ b/.claude/rules/snotra-core.md
@@ -11,4 +11,5 @@ paths:
 - **normalize_entry_key を変更したら 3 点確認**: 新規記録（`record_launch` 等）・既存データ移行（`migrate_normalize_keys`）・ルックアップ API の 3 者が揃っているか
 - **ビットマスクは `query.rs::char_bitmask()` に一元化済み**: `search.rs` と `indexer.rs` の両方が import して使用。変更は `query.rs` の1箇所のみ
 - **incremental cache 変更時は `/cache-check`** で単調性を検証する
+- **`index.bin` を書く新経路は `INDEX_WRITE_LOCK` 経由**: `with_index_write_lock`（権威的書き手・blocking）/ `try_with_index_write_lock`（背景再スキャン・try_lock）。`save_cache_sorted` 自身はロックを取らない（呼び出し側が保持）
 - **UI 表示文字列を持たない**: エラーは `is_error: true` フラグで伝え、表示は UI 層の責務

--- a/.claude/rules/src-tauri.md
+++ b/.claude/rules/src-tauri.md
@@ -8,6 +8,7 @@ paths:
 詳細は `src-tauri/CLAUDE.md` を参照。
 
 - **engine ロックを async/blocking 境界またぎで保持しない**: データ抽出 → 即解放 → 処理の順
+- **index-build フラグは `AppState::try_begin_index_build` / `finish_index_build` 経由**: `indexing` / `index_build_started` を直接 `store()` しない（外部からの force-reset は走行中ビルドのガードを踏み倒す）
 - **子プロセス spawn → exit handler kill はペア**: `main.rs` の exit ハンドラに `.kill()` を忘れない
 - **`WebviewWindowBuilder::build()` は setup フェーズのみ**: イベントループ中・IPC ハンドラからはデッドロック。ランタイムは show/hide のみ
 - **Win32 API は PlatformBridge 経由**: IPC ハンドラから直接呼ばない。platform スレッドのメッセージループで実行する

--- a/snotra-core/CLAUDE.md
+++ b/snotra-core/CLAUDE.md
@@ -106,9 +106,18 @@ raw なデータ構造（`FxHashMap<String, u32>` など）を返す pub API は
 
 新しい Engine メソッドを追加するとき、I/O やインデックス構築をロック内で行わないよう注意する。
 
+## index.bin 書き込みの排他（INDEX_WRITE_LOCK）
+
+`index.bin` を scan+save する経路は**すべて `INDEX_WRITE_LOCK`（`indexer.rs` の module-level `static Mutex<()>`）を経由する**。`BinFile::save` の tmp→rename は固定 tmp 名（`index.bin.tmp`）での原子的置換であり、単一書き手が前提。複数経路が同時に書くと tmp ファイルを食い合い破損する。
+
+- 権威的書き手（`rebuild_and_save` / `load_or_scan_with_stats` の cache-miss 枝）: `with_index_write_lock`（blocking）で取得
+- 日和見的書き手（`try_background_rescan`）: `try_with_index_write_lock`（`try_lock`、競合時スキップ）。本式ビルドが走っていれば再スキャンは不要
+- `save_cache_sorted` 自身はロックを取らない（呼び出し側が保持する契約）。ロック取得済みのクロージャ内から呼ぶ。`save_cache_sorted` がロックを取ると自己デッドロックする
+- **`index.bin` を書く新しい経路を追加するときは、必ず `with_index_write_lock` / `try_with_index_write_lock` を経由させる**
+
 ## indexer.rs の背景再スキャン
 
-`spawn_background_rescan` はキャッシュヒット時に低優先度スレッドでファイルシステムを再スキャンし、キャッシュの新鮮さを保つ。エントリが変わった場合は `save_cache_sorted` + `invalidate_icon_cache` を実行する。スキャンロジック（`scan_all` / `sort_entries_canonical` / `entries_equal`）を変更するとき、このバックグラウンドパスにも影響することを意識する。
+`spawn_background_rescan` はキャッシュヒット時に低優先度スレッドでファイルシステムを再スキャンし、キャッシュの新鮮さを保つ。本体は `try_background_rescan`（`try_with_index_write_lock` 経由）。エントリが変わった場合は `save_cache_sorted` + `invalidate_icon_cache` を実行する。スキャンロジック（`scan_all` / `sort_entries_canonical` / `entries_equal`）を変更するとき、このバックグラウンドパスにも影響することを意識する。
 
 ## エントリ名の導出ルール
 

--- a/snotra-core/CLAUDE.md
+++ b/snotra-core/CLAUDE.md
@@ -117,7 +117,11 @@ raw なデータ構造（`FxHashMap<String, u32>` など）を返す pub API は
 
 ## indexer.rs の背景再スキャン
 
-`spawn_background_rescan` はキャッシュヒット時に低優先度スレッドでファイルシステムを再スキャンし、キャッシュの新鮮さを保つ。本体は `try_background_rescan`（`try_with_index_write_lock` 経由）。エントリが変わった場合は `save_cache_sorted` + `invalidate_icon_cache` を実行する。スキャンロジック（`scan_all` / `sort_entries_canonical` / `entries_equal`）を変更するとき、このバックグラウンドパスにも影響することを意識する。
+`load_or_scan_with_stats` はキャッシュヒット時、再スキャンを*その場で spawn せず* `LoadOrScanResult.rescan_task`（`Some(BackgroundRescanTask)`）として返す。`src-tauri` が `AppHandle` を持った状態で低優先度スレッドで `task.run()` し、`RescanOutcome::Changed` ならアイコンキャッシュを無効化する。
+
+- ロジック（lock 取得・`scan_all` / `sort_entries_canonical` / `entries_equal` 比較・`save_cache_sorted`）は `snotra-core`、spawn とアイコン無効化は `src-tauri`。`index.bin` は snotra-core の資源、`icons.bin` は src-tauri の資源——所有者に責務を寄せている
+- `try_background_rescan` はアイコンキャッシュに触れない。`RescanOutcome::{Skipped, Unchanged, Changed}` で結果を伝え、呼び出し側が `Changed` を見て無効化する
+- スキャンロジックを変更するとき、このバックグラウンドパスにも影響することを意識する
 
 ## エントリ名の導出ルール
 

--- a/snotra-core/src/indexer.rs
+++ b/snotra-core/src/indexer.rs
@@ -4,6 +4,7 @@ use std::fs::Metadata;
 use std::hash::{Hash, Hasher};
 use std::os::windows::fs::MetadataExt;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 use std::thread;
 use std::time::Instant;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -308,17 +309,24 @@ pub fn load_or_scan_with_stats(
     }
     let cache_load_ms = cache_load_started.elapsed().as_millis();
 
-    let scan_started = Instant::now();
-    let mut entries = scan_all(scan, show_hidden_system);
-    let scan_ms = scan_started.elapsed().as_millis();
+    // 権威的書き手: scan + sort + save を書き込みロック保持下で行い、
+    // 背景再スキャン / 別ビルドとの index.bin 同時書き込みを防ぐ。
+    // フェーズ計測はクロージャの戻り値として持ち出す。
+    let (entries, scan_ms, sort_ms, cache_save_ms) = with_index_write_lock(|| {
+        let scan_started = Instant::now();
+        let mut entries = scan_all(scan, show_hidden_system);
+        let scan_ms = scan_started.elapsed().as_millis();
 
-    let sort_started = Instant::now();
-    sort_entries_canonical(&mut entries);
-    let sort_ms = sort_started.elapsed().as_millis();
+        let sort_started = Instant::now();
+        sort_entries_canonical(&mut entries);
+        let sort_ms = sort_started.elapsed().as_millis();
 
-    let cache_save_started = Instant::now();
-    save_cache_sorted(&entries, current_hash);
-    let cache_save_ms = cache_save_started.elapsed().as_millis();
+        let cache_save_started = Instant::now();
+        save_cache_sorted(&entries, current_hash);
+        let cache_save_ms = cache_save_started.elapsed().as_millis();
+
+        (entries, scan_ms, sort_ms, cache_save_ms)
+    });
 
     let stats = LoadOrScanStats {
         cache_hit: false,
@@ -402,11 +410,15 @@ fn save_cache_sorted(entries: &[AppEntry], config_hash: u64) {
 /// Force rebuild: scan and save cache, regardless of existing cache.
 /// Called from settings dialog (Phase 5).
 pub fn rebuild_and_save(scan: &[ScanPath], show_hidden_system: bool) -> Vec<AppEntry> {
-    let mut entries = scan_all(scan, show_hidden_system);
-    sort_entries_canonical(&mut entries);
-    let config_hash = compute_config_hash(scan, show_hidden_system);
-    save_cache_sorted(&entries, config_hash);
-    entries
+    // 権威的書き手: scan + sort + save を書き込みロック保持下で行い、
+    // 背景再スキャン / 別の rebuild との index.bin 同時書き込みを防ぐ。
+    with_index_write_lock(|| {
+        let mut entries = scan_all(scan, show_hidden_system);
+        sort_entries_canonical(&mut entries);
+        let config_hash = compute_config_hash(scan, show_hidden_system);
+        save_cache_sorted(&entries, config_hash);
+        entries
+    })
 }
 
 /// キャッシュ読み込み結果。v3 ヒット時はマスク付き、v2 ヒット時はマスクなし。
@@ -469,6 +481,49 @@ fn load_cache(config_hash: u64) -> Option<LoadCacheResult> {
     None
 }
 
+/// `index.bin` の scan + save 区間を直列化する書き込みロック。
+/// 権威的ビルド（`rebuild_and_save` / cache-miss save）と背景再スキャンが共有する。
+/// `save_cache_sorted` 自体はロックを取らない（呼び出し側が保持する契約）。
+static INDEX_WRITE_LOCK: Mutex<()> = Mutex::new(());
+
+/// 書き込みロックを非ブロッキングで取得し、取れたらクロージャを実行して `Some(結果)` を返す。
+/// 取得できなければクロージャを実行せず `None` を返す。背景再スキャン等の日和見的書き手が使う。
+fn try_with_index_write_lock<R>(f: impl FnOnce() -> R) -> Option<R> {
+    let _guard = INDEX_WRITE_LOCK.try_lock().ok()?;
+    Some(f())
+}
+
+/// 書き込みロックをブロッキングで取得し、クロージャを実行して結果を返す。
+/// 権威的書き手（`rebuild_and_save` / cache-miss save）が使う。
+fn with_index_write_lock<R>(f: impl FnOnce() -> R) -> R {
+    // Mutex<()> は保持する状態を持たないため、poison しても into_inner で回復して継続する。
+    // （`.unwrap()` だと一度の panic 以降、全 index 書き込みが永久に panic する）
+    let _guard = INDEX_WRITE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    f()
+}
+
+/// 背景再スキャン本体。`spawn_background_rescan` のスレッドから呼ぶ。
+/// 書き込みロックを取得できなければ（権威的ビルドが進行中）スキャン・保存をせず
+/// `false` を返す。再スキャンは日和見的な鮮度維持であり、本式ビルドが走っていれば不要。
+fn try_background_rescan(
+    scan: &[ScanPath],
+    show_hidden_system: bool,
+    config_hash: u64,
+    cached_entries: &[AppEntry],
+) -> bool {
+    // 権威的ビルド（rebuild_and_save / cache-miss save）が書き込み中ならスキップする。
+    // 背景再スキャンは日和見的な鮮度維持であり、本式ビルドが走っていれば不要。
+    try_with_index_write_lock(|| {
+        let mut scanned = scan_all(scan, show_hidden_system);
+        sort_entries_canonical(&mut scanned);
+        if !entries_equal(cached_entries, &scanned) {
+            save_cache_sorted(&scanned, config_hash);
+            invalidate_icon_cache();
+        }
+    })
+    .is_some()
+}
+
 fn spawn_background_rescan(
     scan: Vec<ScanPath>,
     show_hidden_system: bool,
@@ -479,12 +534,7 @@ fn spawn_background_rescan(
         .name("snotra-index-rescan".to_string())
         .spawn(move || {
             lower_current_thread_priority();
-            let mut scanned = scan_all(&scan, show_hidden_system);
-            sort_entries_canonical(&mut scanned);
-            if !entries_equal(&cached_entries, &scanned) {
-                save_cache_sorted(&scanned, config_hash);
-                invalidate_icon_cache();
-            }
+            let _ = try_background_rescan(&scan, show_hidden_system, config_hash, &cached_entries);
         });
 }
 
@@ -733,6 +783,12 @@ mod tests {
     use super::*;
     use crate::binfmt::{deserialize_with_header, serialize_with_header, try_deserialize_with_header};
     use std::fs;
+
+    /// `INDEX_WRITE_LOCK` に触れるテストを直列化するガード。
+    /// `cargo test` は同一ファイル内のテストを並列実行するため、「ロック空き」を
+    /// 期待するテストと「ロック保持中」を作るテストが食い合わないよう、
+    /// これらのテストは先頭でこのガードを取得する。
+    static INDEX_LOCK_TEST_GUARD: Mutex<()> = Mutex::new(());
 
     fn temp_dir(tag: &str) -> std::path::PathBuf {
         let dir = std::env::temp_dir().join(format!("snotra_idx_test_{}", tag));
@@ -1183,6 +1239,74 @@ mod tests {
         assert!(
             entries.is_empty(),
             "scan_all with no paths should return empty"
+        );
+    }
+
+    #[test]
+    fn try_background_rescan_skips_when_write_lock_held() {
+        let _serial = INDEX_LOCK_TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        // 権威的なインデックスビルドが書き込みロックを保持している状況を再現する。
+        let _held = INDEX_WRITE_LOCK.lock().unwrap();
+        // 背景再スキャンは書き込みロックを取得できないため、
+        // スキャンも保存もせず false（スキップ）を返さねばならない。
+        let ran = try_background_rescan(&[], false, 0, &[]);
+        assert!(
+            !ran,
+            "background rescan must skip (return false) when the index write lock is held"
+        );
+    }
+
+    #[test]
+    fn try_with_index_write_lock_skips_closure_when_lock_held() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        let _serial = INDEX_LOCK_TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        // 権威的なインデックスビルドが書き込みロックを保持している状況を再現する。
+        let _held = INDEX_WRITE_LOCK.lock().unwrap();
+        // ロックを取得できないので、クロージャは実行されず None が返らねばならない。
+        let ran = AtomicBool::new(false);
+        let result = try_with_index_write_lock(|| ran.store(true, Ordering::SeqCst));
+        assert!(
+            !ran.load(Ordering::SeqCst),
+            "closure must not run while the index write lock is held"
+        );
+        assert!(
+            result.is_none(),
+            "try_with_index_write_lock must return None when the lock is held"
+        );
+    }
+
+    #[test]
+    fn with_index_write_lock_holds_lock_during_closure() {
+        let _serial = INDEX_LOCK_TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        // with_index_write_lock がクロージャ実行中ずっとロックを保持していることを、
+        // 「クロージャ内から try_lock すると失敗する」という形で決定論的に検証する。
+        // ブロッキング取得なので、他テストがロック保持中でも待つだけで flaky にならない。
+        let observed_locked = with_index_write_lock(|| INDEX_WRITE_LOCK.try_lock().is_err());
+        assert!(
+            observed_locked,
+            "with_index_write_lock must hold INDEX_WRITE_LOCK while running the closure"
+        );
+    }
+
+    #[test]
+    fn try_with_index_write_lock_runs_closure_when_lock_free() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        let _serial = INDEX_LOCK_TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        // ロックが空いていればクロージャを実行し、Some(結果) を返す。
+        // 回帰テスト: 「スキップ」を通した最小実装が同じ2行でこの経路も満たすため即パスする。
+        let ran = AtomicBool::new(false);
+        let result = try_with_index_write_lock(|| {
+            ran.store(true, Ordering::SeqCst);
+            42
+        });
+        assert!(
+            ran.load(Ordering::SeqCst),
+            "closure must run when the index write lock is free"
+        );
+        assert_eq!(
+            result,
+            Some(42),
+            "try_with_index_write_lock must return Some(closure result) when the lock is free"
         );
     }
 

--- a/snotra-core/src/indexer.rs
+++ b/snotra-core/src/indexer.rs
@@ -3,9 +3,8 @@ use std::collections::hash_map::DefaultHasher;
 use std::fs::Metadata;
 use std::hash::{Hash, Hasher};
 use std::os::windows::fs::MetadataExt;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Mutex;
-use std::thread;
 use std::time::Instant;
 use std::time::{SystemTime, UNIX_EPOCH};
 use windows::Win32::Storage::FileSystem::{FILE_ATTRIBUTE_HIDDEN, FILE_ATTRIBUTE_SYSTEM};
@@ -15,7 +14,7 @@ use windows::Win32::System::Threading::{
 };
 
 use crate::binfmt::{BinFile, try_deserialize_with_header};
-use crate::config::{Config, ScanPath};
+use crate::config::ScanPath;
 use crate::query::{char_bitmask, to_lower_folded};
 
 const INDEX_MAGIC: [u8; 4] = *b"INDX";
@@ -196,6 +195,21 @@ pub struct LoadOrScanStats {
     pub total_ms: u128,
 }
 
+/// `load_or_scan_with_stats` の戻り値。
+pub struct LoadOrScanResult {
+    /// ロード or スキャンされたエントリ集合。
+    pub entries: Vec<AppEntry>,
+    /// キャッシュが無く（または stale で）フルスキャンが走った場合 true。
+    pub cache_changed: bool,
+    /// 各フェーズの所要時間。
+    pub stats: LoadOrScanStats,
+    /// v3/v4 キャッシュヒット時の事前計算データ。
+    pub cached_masks: Option<CachedMasks>,
+    /// キャッシュヒット時のみ `Some`。`src-tauri` が低優先度スレッドで `run()` し、
+    /// `RescanOutcome::Changed` ならアイコンキャッシュを無効化する。
+    pub rescan_task: Option<BackgroundRescanTask>,
+}
+
 /// v4 フォーマット: ビットマスクに加えて lower_names / lower_file_names / normalized_keys を保存。
 /// 起動時に SearchEngine の Wave 1（to_lower_folded / normalize_entry_key）を完全スキップできる。
 #[derive(Serialize, Deserialize)]
@@ -248,37 +262,20 @@ fn cache_bin_file() -> Option<BinFile> {
     BinFile::new(INDEX_MAGIC, INDEX_CACHE_VERSION, "index.bin")
 }
 
-fn icon_cache_path() -> Option<PathBuf> {
-    Config::config_dir().map(|p| p.join("icons.bin"))
-}
-
-fn invalidate_icon_cache_at(path: &Path) {
-    let _ = std::fs::remove_file(path);
-}
-
-fn invalidate_icon_cache() {
-    let Some(path) = icon_cache_path() else {
-        return;
-    };
-    invalidate_icon_cache_at(&path);
-}
-
-/// Scan filesystem every startup; compare with cache to detect changes.
-/// Returns (entries, changed) where changed=true means the entry set differs from cache.
+/// Load cached entries or scan the filesystem. Returns `(entries, cache_changed)`
+/// where `cache_changed = true` means the cache was missing/stale and a full scan ran.
 pub fn load_or_scan(scan: &[ScanPath], show_hidden_system: bool) -> (Vec<AppEntry>, bool) {
-    let (entries, changed, _, _) = load_or_scan_with_stats(scan, show_hidden_system);
-    (entries, changed)
+    let result = load_or_scan_with_stats(scan, show_hidden_system);
+    (result.entries, result.cache_changed)
 }
 
-/// Same as `load_or_scan`, but also returns timing stats and optional cached bitmasks.
-///
-/// The 4th return value is `Some(CachedMasks)` when a v3 cache was hit, or `None`
-/// (v2 cache or cache miss). Callers can pass the masks to
-/// `Engine::new_from_cache()` to skip bitmask recomputation in SearchEngine.
+/// Same as `load_or_scan`, but returns the full `LoadOrScanResult`: timing stats,
+/// cached bitmasks, and—on cache hit—a `BackgroundRescanTask` for the caller to
+/// run on a background thread.
 pub fn load_or_scan_with_stats(
     scan: &[ScanPath],
     show_hidden_system: bool,
-) -> (Vec<AppEntry>, bool, LoadOrScanStats, Option<CachedMasks>) {
+) -> LoadOrScanResult {
     let total_started = Instant::now();
 
     let hash_started = Instant::now();
@@ -290,12 +287,14 @@ pub fn load_or_scan_with_stats(
         let cache_load_ms = cache_load_started.elapsed().as_millis();
         let return_entries = result.entries;
         let cached_masks = result.cached_masks;
-        spawn_background_rescan(
-            scan.to_vec(),
+        // 背景再スキャンはここでは spawn しない。タスクとして返し、`src-tauri` が
+        // `AppHandle` を持った状態で spawn する（`Changed` 時のアイコン無効化のため）。
+        let rescan_task = BackgroundRescanTask {
+            scan: scan.to_vec(),
             show_hidden_system,
-            current_hash,
-            return_entries.clone(),
-        );
+            config_hash: current_hash,
+            cached_entries: return_entries.clone(),
+        };
         let stats = LoadOrScanStats {
             cache_hit: true,
             hash_ms,
@@ -305,7 +304,13 @@ pub fn load_or_scan_with_stats(
             cache_save_ms: 0,
             total_ms: total_started.elapsed().as_millis(),
         };
-        return (return_entries, false, stats, cached_masks);
+        return LoadOrScanResult {
+            entries: return_entries,
+            cache_changed: false,
+            stats,
+            cached_masks,
+            rescan_task: Some(rescan_task),
+        };
     }
     let cache_load_ms = cache_load_started.elapsed().as_millis();
 
@@ -338,7 +343,13 @@ pub fn load_or_scan_with_stats(
         total_ms: total_started.elapsed().as_millis(),
     };
 
-    (entries, true, stats, None)
+    LoadOrScanResult {
+        entries,
+        cache_changed: true,
+        stats,
+        cached_masks: None,
+        rescan_task: None,
+    }
 }
 
 fn entries_equal(a: &[AppEntry], b: &[AppEntry]) -> bool {
@@ -502,51 +513,80 @@ fn with_index_write_lock<R>(f: impl FnOnce() -> R) -> R {
     f()
 }
 
-/// 背景再スキャン本体。`spawn_background_rescan` のスレッドから呼ぶ。
-/// 書き込みロックを取得できなければ（権威的ビルドが進行中）スキャン・保存をせず
-/// `false` を返す。再スキャンは日和見的な鮮度維持であり、本式ビルドが走っていれば不要。
+/// 背景再スキャンの結果。`src-tauri` 側はこれを見てアイコン無効化等の後始末を行う。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RescanOutcome {
+    /// 権威的ビルドが書き込み中でロックを取得できず、再スキャンをスキップした。
+    Skipped,
+    /// 再スキャンしたが、エントリ集合はキャッシュと同一だった。
+    Unchanged,
+    /// エントリ集合がキャッシュと異なり、`index.bin` を更新した。
+    /// 呼び出し側はアイコンキャッシュの無効化を行うこと。
+    Changed,
+}
+
+/// 背景再スキャン本体。書き込みロックを取得できなければ（権威的ビルドが進行中）
+/// スキャン・保存をせず `Skipped` を返す。再スキャンは日和見的な鮮度維持であり、
+/// 本式ビルドが走っていれば不要。アイコンキャッシュには触れない（`icons.bin` は
+/// `src-tauri` の資源 — 呼び出し側が `Changed` を見て無効化する）。
 fn try_background_rescan(
     scan: &[ScanPath],
     show_hidden_system: bool,
     config_hash: u64,
     cached_entries: &[AppEntry],
-) -> bool {
-    // 権威的ビルド（rebuild_and_save / cache-miss save）が書き込み中ならスキップする。
-    // 背景再スキャンは日和見的な鮮度維持であり、本式ビルドが走っていれば不要。
-    try_with_index_write_lock(|| {
+) -> RescanOutcome {
+    // 権威的ビルド（rebuild_and_save / cache-miss save）が書き込み中なら Skipped。
+    let changed = try_with_index_write_lock(|| {
         let mut scanned = scan_all(scan, show_hidden_system);
         sort_entries_canonical(&mut scanned);
-        if !entries_equal(cached_entries, &scanned) {
+        if entries_equal(cached_entries, &scanned) {
+            false
+        } else {
             save_cache_sorted(&scanned, config_hash);
-            invalidate_icon_cache();
+            true
         }
-    })
-    .is_some()
+    });
+    match changed {
+        None => RescanOutcome::Skipped,
+        Some(false) => RescanOutcome::Unchanged,
+        Some(true) => RescanOutcome::Changed,
+    }
 }
 
-fn spawn_background_rescan(
+/// 背景再スキャンのタスク。所有データを抱え、`src-tauri` 側のスレッドへ `move` できる。
+/// `load_or_scan_with_stats` がキャッシュヒット時に `Some` で返す。
+pub struct BackgroundRescanTask {
     scan: Vec<ScanPath>,
     show_hidden_system: bool,
     config_hash: u64,
     cached_entries: Vec<AppEntry>,
-) {
-    let _ = thread::Builder::new()
-        .name("snotra-index-rescan".to_string())
-        .spawn(move || {
-            lower_current_thread_priority();
-            let _ = try_background_rescan(&scan, show_hidden_system, config_hash, &cached_entries);
-        });
 }
 
+impl BackgroundRescanTask {
+    /// 再スキャンを実行し、結果を返す。`Changed` のときは呼び出し側が
+    /// アイコンキャッシュを無効化すること。
+    pub fn run(self) -> RescanOutcome {
+        try_background_rescan(
+            &self.scan,
+            self.show_hidden_system,
+            self.config_hash,
+            &self.cached_entries,
+        )
+    }
+}
+
+/// 呼び出し元スレッドの優先度を下げる。背景再スキャン等のバックグラウンドスレッドが
+/// 起動直後のユーザー操作と CPU を奪い合わないようにする。`src-tauri` が rescan
+/// スレッドの先頭で呼ぶ。
 #[cfg(windows)]
-fn lower_current_thread_priority() {
+pub fn lower_current_thread_priority() {
     unsafe {
         let _ = SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_BELOW_NORMAL);
     }
 }
 
 #[cfg(not(windows))]
-fn lower_current_thread_priority() {}
+pub fn lower_current_thread_priority() {}
 
 /// レジストリキーの RAII ガード。Drop 時に自動で RegCloseKey を呼ぶ。
 #[cfg(windows)]
@@ -1209,31 +1249,6 @@ mod tests {
     }
 
     #[test]
-    fn invalidate_icon_cache_removes_icons_bin_if_present() {
-        let dir = temp_dir("icons_cache_remove");
-        let icon_path = dir.join("icons.bin");
-        fs::write(&icon_path, b"dummy").unwrap();
-        assert!(icon_path.exists());
-
-        invalidate_icon_cache_at(&icon_path);
-        assert!(!icon_path.exists());
-
-        let _ = fs::remove_dir_all(&dir);
-    }
-
-    #[test]
-    fn invalidate_icon_cache_is_noop_when_missing() {
-        let dir = temp_dir("icons_cache_missing");
-        let icon_path = dir.join("icons.bin");
-        assert!(!icon_path.exists());
-
-        invalidate_icon_cache_at(&icon_path);
-        assert!(!icon_path.exists());
-
-        let _ = fs::remove_dir_all(&dir);
-    }
-
-    #[test]
     fn scan_all_empty_when_no_paths() {
         let entries = scan_all(&[], false);
         assert!(
@@ -1248,12 +1263,26 @@ mod tests {
         // 権威的なインデックスビルドが書き込みロックを保持している状況を再現する。
         let _held = INDEX_WRITE_LOCK.lock().unwrap();
         // 背景再スキャンは書き込みロックを取得できないため、
-        // スキャンも保存もせず false（スキップ）を返さねばならない。
-        let ran = try_background_rescan(&[], false, 0, &[]);
-        assert!(
-            !ran,
-            "background rescan must skip (return false) when the index write lock is held"
+        // スキャンも保存もせず Skipped を返さねばならない。
+        let outcome = try_background_rescan(&[], false, 0, &[]);
+        assert_eq!(
+            outcome,
+            RescanOutcome::Skipped,
+            "background rescan must return Skipped when the index write lock is held"
         );
+    }
+
+    #[test]
+    fn background_rescan_task_run_reports_unchanged_for_empty_inputs() {
+        let _serial = INDEX_LOCK_TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        // 空のスキャン対象 → scan_all は空 → 空のキャッシュと一致 → Unchanged。
+        let task = BackgroundRescanTask {
+            scan: Vec::new(),
+            show_hidden_system: false,
+            config_hash: 0,
+            cached_entries: Vec::new(),
+        };
+        assert_eq!(task.run(), RescanOutcome::Unchanged);
     }
 
     #[test]

--- a/src-tauri/CLAUDE.md
+++ b/src-tauri/CLAUDE.md
@@ -4,9 +4,9 @@ Tauri v2 バイナリ crate。Win32 API 統合とフロントエンドとの IPC
 
 ## モジュール構成
 
-- `main.rs`: エントリポイント、Tauri セットアップ、イベントリスナー登録
+- `main.rs`: エントリポイント、Tauri セットアップ、イベントリスナー登録。起動時の背景再スキャン（`indexer::load_or_scan_with_stats` が返す `BackgroundRescanTask`）を `setup` フェーズで低優先度スレッドに spawn し、`RescanOutcome::Changed` なら `icon::invalidate_icon_cache` を呼ぶ
 - `state.rs`: `AppState` 定義（`Mutex<Engine>` + `AtomicBool` × 3: `indexing` / `index_build_started` / `main_visible`）。`Engine` は `snotra-core` の facade で、検索・履歴・設定を単一ロックに統合。`main_visible` は Win32 `is_visible()` の 35ms レイテンシを回避するためのキャッシュ。インデックスビルドの開始/終了は `try_begin_index_build()` / `finish_index_build()` メソッド経由で行い、`indexing`・`index_build_started` を coherent に更新する
-- `icon.rs`: アイコンのオンデマンド抽出（`SHGetFileInfoW` → PNG バイト列）、検索時に遅延ロードしキャッシュ永続化
+- `icon.rs`: アイコンのオンデマンド抽出（`SHGetFileInfoW` → PNG バイト列）、検索時に遅延ロードしキャッシュ永続化。`invalidate_icon_cache` はメモリ内 `IconCacheState` と `icons.bin` を**両方**無効化する（片方だけだと終了時の `save_if_dirty` で古いアイコンが復活する）
 - `indexing.rs`: バックグラウンドインデックス構築
 - `config_watcher.rs`: `notify` クレートで `config.toml` 変更を監視（100ms debounce）し、差分検出後にホットキー・トレイ・インデックス・テーマ・ウィンドウ幅・言語を反映する `apply_config_change()` を実行。**不変条件: 言語変更とホットキー変更が同時に発生した場合、`language-changed` イベントをホットキー失敗通知より先に発火する**（フロントエンドが正しい言語でエラー文字列を組み立てるため）。発火するイベント: `language-changed` / `hotkey-registration-failed` / `visual-config-changed` / `show-icons-changed` / `max-results-changed` / `instant-prefix-changed` / `top-n-history-changed` / `indexing-started`（indexing.rs から）/ `indexing-complete`（indexing.rs から）
 - `ime.rs`: IME オフ操作（`ImmSetOpenStatus(false)`）。Win32 IMM API の薄いラッパー

--- a/src-tauri/CLAUDE.md
+++ b/src-tauri/CLAUDE.md
@@ -5,7 +5,7 @@ Tauri v2 バイナリ crate。Win32 API 統合とフロントエンドとの IPC
 ## モジュール構成
 
 - `main.rs`: エントリポイント、Tauri セットアップ、イベントリスナー登録
-- `state.rs`: `AppState` 定義（`Mutex<Engine>` + `AtomicBool` × 3: `indexing` / `index_build_started` / `main_visible`）。`Engine` は `snotra-core` の facade で、検索・履歴・設定を単一ロックに統合。`main_visible` は Win32 `is_visible()` の 35ms レイテンシを回避するためのキャッシュ
+- `state.rs`: `AppState` 定義（`Mutex<Engine>` + `AtomicBool` × 3: `indexing` / `index_build_started` / `main_visible`）。`Engine` は `snotra-core` の facade で、検索・履歴・設定を単一ロックに統合。`main_visible` は Win32 `is_visible()` の 35ms レイテンシを回避するためのキャッシュ。インデックスビルドの開始/終了は `try_begin_index_build()` / `finish_index_build()` メソッド経由で行い、`indexing`・`index_build_started` を coherent に更新する
 - `icon.rs`: アイコンのオンデマンド抽出（`SHGetFileInfoW` → PNG バイト列）、検索時に遅延ロードしキャッシュ永続化
 - `indexing.rs`: バックグラウンドインデックス構築
 - `config_watcher.rs`: `notify` クレートで `config.toml` 変更を監視（100ms debounce）し、差分検出後にホットキー・トレイ・インデックス・テーマ・ウィンドウ幅・言語を反映する `apply_config_change()` を実行。**不変条件: 言語変更とホットキー変更が同時に発生した場合、`language-changed` イベントをホットキー失敗通知より先に発火する**（フロントエンドが正しい言語でエラー文字列を組み立てるため）。発火するイベント: `language-changed` / `hotkey-registration-failed` / `visual-config-changed` / `show-icons-changed` / `max-results-changed` / `instant-prefix-changed` / `top-n-history-changed` / `indexing-started`（indexing.rs から）/ `indexing-complete`（indexing.rs から）
@@ -21,6 +21,7 @@ Tauri v2 バイナリ crate。Win32 API 統合とフロントエンドとの IPC
 - 設定画面は `snotra-settings.exe`（egui 別バイナリ）を子プロセスとして起動。`SettingsProcessState` で重複起動を防止し、子プロセス存命中はメインウィンドウの `alwaysOnTop` を一時解除する
 - `commands/` は薄いラッパーに保ち、実処理は `snotra-core` に寄せる（KISS）
 - `AppState` は `Mutex<Engine>` で検索エンジン・履歴・設定を一括管理。Phase 2.3 以前の 3重ロック（`Mutex<SearchEngine>` / `Mutex<HistoryStore>` / `Mutex<Config>`）は Engine facade に統合済み
+- **インデックスビルドのフラグは `AppState` のメソッド経由で更新する**: `try_begin_index_build()`（`index_build_started` を CAS 取得 → `indexing` を立てる）と `finish_index_build()`（両方を戻す）が唯一の正しい経路。`indexing` / `index_build_started` を直接 `store()` しない——外部からの force-reset は走行中ビルドのガードを踏み倒す競合の原因になる。2フラグは別物（`index_build_started` は CAS 専用ガード、`indexing` は first-run 時にビルドスレッド不在でも true になる UI 表示用）
 - Managed state として `IconCacheState`（`Mutex<Option<IconCache>>`、初回アイコン要求で遅延初期化）と `SettingsProcessState`（`Mutex<Option<Child>>`、設定プロセスのハンドル管理）を保持
 - **`show_main_and_emit` の操作順序制約**: 高さリセット（52px）→ `position_on_target_monitor` → `show()` の順。位置計算はウィンドウサイズ（`outer_size()`）でクランプするため、高さリセット前に位置を決めると展開時の高さでクランプされ、折りたたみ時に位置がずれる
 

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -10,8 +10,6 @@ pub fn rebuild_index(state: State<AppState>, app: AppHandle) -> bool {
     if state.indexing.load(Ordering::SeqCst) {
         return false;
     }
-    // Reset the guard so start_index_build can proceed
-    state.index_build_started.store(false, Ordering::SeqCst);
     indexing::start_index_build(&app)
 }
 

--- a/src-tauri/src/config_watcher.rs
+++ b/src-tauri/src/config_watcher.rs
@@ -157,7 +157,6 @@ fn apply_config_change(app: &AppHandle) {
     // Trigger reindex if needed
     let indexing_in_progress = state.indexing.load(Ordering::SeqCst);
     if index_changed && !indexing_in_progress {
-        state.index_build_started.store(false, Ordering::SeqCst);
         indexing::start_index_build(app);
     }
 

--- a/src-tauri/src/icon.rs
+++ b/src-tauri/src/icon.rs
@@ -119,6 +119,24 @@ fn icon_bin_file() -> Option<BinFile> {
     BinFile::new(ICON_MAGIC, ICON_VERSION, "icons.bin")
 }
 
+/// アイコンキャッシュをメモリ内・ディスク両方で無効化する。
+/// 背景再スキャンでエントリ集合が変わったときに呼ぶ。メモリ内 `IconCacheState` を
+/// `None` にし、`icons.bin` を削除する。両方やらないと、ファイルだけ消しても
+/// メモリ内の古いアイコンが終了時の `save_if_dirty` で再永続化される。
+pub fn invalidate_icon_cache(icons: &IconCacheState) {
+    invalidate_icon_cache_with(icons, icon_bin_file());
+}
+
+/// テスト可能な内部実装。`bin_file` を `None` で渡すとファイル削除をスキップする。
+fn invalidate_icon_cache_with(icons: &IconCacheState, bin_file: Option<BinFile>) {
+    // メモリ内キャッシュをクリア（次の get_icons_batch で icons.bin から再ロードされる）。
+    *icons.lock().unwrap() = None;
+    // ディスク上の icons.bin も削除（再ロード時に古いデータを読まないため）。
+    if let Some(bf) = bin_file {
+        bf.remove();
+    }
+}
+
 struct IconData {
     width: u32,
     height: u32,
@@ -320,5 +338,21 @@ mod tests {
         offset += len;
 
         assert_eq!(offset, buf.len());
+    }
+
+    #[test]
+    fn invalidate_icon_cache_clears_in_memory_state() {
+        // メモリ内にキャッシュがある状態で invalidate すると None になる
+        // （次の get_icons_batch で icons.bin から再ロードされる）。
+        // bin_file=None でファイル削除はスキップ（テストは実 icons.bin に触れない）。
+        let state: IconCacheState = Mutex::new(Some(IconCache {
+            data: IconCacheData::default(),
+            dirty: false,
+        }));
+        invalidate_icon_cache_with(&state, None);
+        assert!(
+            state.lock().unwrap().is_none(),
+            "invalidate_icon_cache must clear the in-memory IconCacheState to None"
+        );
     }
 }

--- a/src-tauri/src/indexing.rs
+++ b/src-tauri/src/indexing.rs
@@ -1,5 +1,4 @@
 use std::sync::Mutex;
-use std::sync::atomic::Ordering;
 
 use snotra_core::indexer;
 use tauri::{AppHandle, Emitter, Manager};
@@ -12,15 +11,9 @@ use crate::state::AppState;
 /// Returns `true` if the build was started, `false` if already running.
 pub fn start_index_build(app: &AppHandle) -> bool {
     let state = app.state::<AppState>();
-    if state
-        .index_build_started
-        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-        .is_err()
-    {
+    if !state.try_begin_index_build() {
         return false;
     }
-
-    state.indexing.store(true, Ordering::SeqCst);
 
     // Notify platform thread
     if let Some(bridge) = app.try_state::<Mutex<PlatformBridge>>()
@@ -33,7 +26,7 @@ pub fn start_index_build(app: &AppHandle) -> bool {
     let _ = app.emit("indexing-started", ());
 
     let app_handle = app.clone();
-    std::thread::Builder::new()
+    let spawn_result = std::thread::Builder::new()
         .name("snotra-index-build".to_string())
         .spawn(move || {
             let (scan, show_hidden_system, show_icons, include_path_env) = {
@@ -94,11 +87,7 @@ pub fn start_index_build(app: &AppHandle) -> bool {
             };
 
             // Mark indexing complete
-            {
-                let state = app_handle.state::<AppState>();
-                state.indexing.store(false, Ordering::SeqCst);
-                state.index_build_started.store(false, Ordering::SeqCst);
-            }
+            app_handle.state::<AppState>().finish_index_build();
 
             // Notify platform thread
             if let Some(bridge) = app_handle.try_state::<Mutex<PlatformBridge>>()
@@ -114,8 +103,20 @@ pub fn start_index_build(app: &AppHandle) -> bool {
             if needs_rebuild {
                 start_index_build(&app_handle);
             }
-        })
-        .ok();
+        });
+
+    if spawn_result.is_err() {
+        // スレッド生成失敗。フラグをリセットし platform/frontend にも完了を通知して、
+        // index_build_started=true のまま wedge するのを防ぐ（嘘の true を返さない）。
+        state.finish_index_build();
+        if let Some(bridge) = app.try_state::<Mutex<PlatformBridge>>()
+            && let Ok(b) = bridge.lock()
+        {
+            b.send_command(PlatformCommand::SetIndexing(false));
+        }
+        let _ = app.emit("indexing-complete", ());
+        return false;
+    }
 
     true
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -364,27 +364,26 @@ fn main() {
     let is_first_run = Config::is_first_run();
     let config = Config::load();
 
-    let (entries, initial_indexing, cached_masks) = if is_first_run {
-        (Vec::new(), true, None)
+    let (entries, initial_indexing, cached_masks, rescan_task) = if is_first_run {
+        (Vec::new(), true, None, None)
     } else {
-        #[cfg(debug_assertions)]
-        let (entries, _, stats, cached_masks) =
-            indexer::load_or_scan_with_stats(&config.paths.scan, config.search.show_hidden_system);
-        #[cfg(not(debug_assertions))]
-        let (entries, _, _, cached_masks) =
+        let result =
             indexer::load_or_scan_with_stats(&config.paths.scan, config.search.show_hidden_system);
         #[cfg(debug_assertions)]
-        eprintln!(
-            "[index-load] cache_hit={} total={}ms hash={}ms cache_load={}ms scan={}ms sort={}ms cache_save={}ms",
-            stats.cache_hit,
-            stats.total_ms,
-            stats.hash_ms,
-            stats.cache_load_ms,
-            stats.scan_ms,
-            stats.sort_ms,
-            stats.cache_save_ms,
-        );
-        (entries, false, cached_masks)
+        {
+            let s = &result.stats;
+            eprintln!(
+                "[index-load] cache_hit={} total={}ms hash={}ms cache_load={}ms scan={}ms sort={}ms cache_save={}ms",
+                s.cache_hit,
+                s.total_ms,
+                s.hash_ms,
+                s.cache_load_ms,
+                s.scan_ms,
+                s.sort_ms,
+                s.cache_save_ms,
+            );
+        }
+        (result.entries, false, result.cached_masks, result.rescan_task)
     };
 
     // PATH エントリのスキャン + マージ
@@ -650,6 +649,22 @@ fn main() {
             // Start config.toml file watcher for external changes (snotra-settings)
             if let Some(watcher) = config_watcher::start(&app_handle) {
                 app_handle.manage(Mutex::new(watcher));
+            }
+
+            // 背景再スキャン（SPEC §3.3 ハイブリッド方式）。キャッシュヒット時のみ。
+            // ロジックは snotra-core、spawn と結果の後始末（アイコン無効化）は src-tauri。
+            if let Some(task) = rescan_task {
+                let handle_for_rescan = app_handle.clone();
+                let _ = std::thread::Builder::new()
+                    .name("snotra-index-rescan".to_string())
+                    .spawn(move || {
+                        indexer::lower_current_thread_priority();
+                        if task.run() == indexer::RescanOutcome::Changed
+                            && let Some(icons) = handle_for_rescan.try_state::<IconCacheState>()
+                        {
+                            icon::invalidate_icon_cache(&icons);
+                        }
+                    });
             }
 
             // All windows pre-created and all listeners registered; now safe to show tray.

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,5 +1,5 @@
 use std::sync::Mutex;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use snotra_core::engine::Engine;
 
@@ -9,4 +9,110 @@ pub struct AppState {
     pub index_build_started: AtomicBool,
     /// Tracks main window visibility to avoid costly Win32 `is_visible()` IPC on hotkey toggle.
     pub main_visible: AtomicBool,
+}
+
+impl AppState {
+    /// インデックスビルドの開始権を CAS で取得する。
+    /// 成功時は `index_build_started` と `indexing` を両方 true にして `true` を返す。
+    /// 既にビルドが始まっている場合は何も変更せず `false` を返す。
+    pub fn try_begin_index_build(&self) -> bool {
+        if self
+            .index_build_started
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return false;
+        }
+        self.indexing.store(true, Ordering::SeqCst);
+        true
+    }
+
+    /// インデックスビルドの終了。`indexing` と `index_build_started` を両方 false に戻す。
+    /// 正常完了経路と `thread::spawn` 失敗経路の両方から呼ぶ。
+    pub fn finish_index_build(&self) {
+        self.indexing.store(false, Ordering::SeqCst);
+        self.index_build_started.store(false, Ordering::SeqCst);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snotra_core::config::Config;
+    use snotra_core::history::HistoryStore;
+
+    fn test_state() -> AppState {
+        AppState {
+            engine: Mutex::new(Engine::new(Vec::new(), HistoryStore::load(10), Config::default())),
+            indexing: AtomicBool::new(false),
+            index_build_started: AtomicBool::new(false),
+            main_visible: AtomicBool::new(false),
+        }
+    }
+
+    #[test]
+    fn try_begin_index_build_succeeds_and_sets_flags_when_idle() {
+        let state = test_state();
+        let started = state.try_begin_index_build();
+        assert!(started, "try_begin_index_build must succeed when idle");
+        assert!(
+            state.indexing.load(Ordering::SeqCst),
+            "indexing flag must be set after a successful begin"
+        );
+        assert!(
+            state.index_build_started.load(Ordering::SeqCst),
+            "index_build_started flag must be set after a successful begin"
+        );
+    }
+
+    #[test]
+    fn finish_index_build_clears_both_flags_and_allows_restart() {
+        let state = test_state();
+        assert!(
+            state.try_begin_index_build(),
+            "setup: first begin must succeed"
+        );
+        state.finish_index_build();
+        assert!(
+            !state.indexing.load(Ordering::SeqCst),
+            "indexing flag must be cleared after finish_index_build"
+        );
+        assert!(
+            !state.index_build_started.load(Ordering::SeqCst),
+            "index_build_started flag must be cleared after finish_index_build"
+        );
+        assert!(
+            state.try_begin_index_build(),
+            "try_begin_index_build must succeed again after finish_index_build"
+        );
+    }
+
+    #[test]
+    fn try_begin_index_build_fails_when_already_started() {
+        // カバレッジ: CAS 実装が「二重起動しない」をどう満たすかを固定する。
+        let state = test_state();
+        assert!(
+            state.try_begin_index_build(),
+            "setup: first begin must succeed"
+        );
+        let second = state.try_begin_index_build();
+        assert!(
+            !second,
+            "try_begin_index_build must fail (no double-start) while a build is already in progress"
+        );
+    }
+
+    #[test]
+    fn try_begin_index_build_succeeds_in_first_run_state() {
+        // カバレッジ: 初回起動状態 = indexing=true（UI 表示用）だが index_build_started=false
+        // （ビルド未開始）。try_begin は index_build_started を CAS するので、この状態でも
+        // 成功しなければならない。try_begin を indexing 側にすると first-run が壊れる。
+        let state = test_state();
+        state.indexing.store(true, Ordering::SeqCst);
+        assert!(
+            state.try_begin_index_build(),
+            "try_begin must succeed in first-run state (indexing=true, index_build_started=false)"
+        );
+        assert!(state.index_build_started.load(Ordering::SeqCst));
+    }
 }


### PR DESCRIPTION
## Summary

監査で特定したインデックス／アイコン処理の3つの並行性競合を、3サイクルに分けて TDD で解消する。

- **競合①②（`baac6b9`）** — `index.bin` を scan+save する3経路（cache-miss save / `rebuild_and_save` / 背景再スキャン）が排他されておらず、`BinFile::save` の固定 tmp 名への同時書き込みでキャッシュが破損しうる。`INDEX_WRITE_LOCK`（`indexer.rs` の `static Mutex<()>`）を導入し、全書き手をこのロック経由に配線。
- **競合②（`3777d40`）** — `indexing` / `index_build_started` の AtomicBool ペアが非整合に維持され、`config_watcher` / `system` の force-reset が走行中ビルドの CAS ガードを踏み倒しうる。`try_begin_index_build` / `finish_index_build` で2フラグを coherent に更新し、force-reset を対称除去。
- **競合③（`7b4038a`）** — 背景再スキャンが `icons.bin` だけ消してメモリ内 `IconCache` を残し、終了時 `save_if_dirty` で古いアイコンが復活する。`RescanOutcome` でエントリ変化を伝え、無効化（ファイル＋メモリ内）を `src-tauri` が coherent に行う形へ。`index.bin` は snotra-core、`icons.bin` は src-tauri と、資源の所有者に責務を寄せた。

いずれも race 依存で静かに起きる競合で、ユニットテストでは現れにくい。各サイクルで決定論的なテストを追加。

## Test Plan

- [x] `cargo test -p snotra-core`（350 passed）
- [x] `cargo test -p snotra`（32 passed）
- [x] `cargo clippy -p snotra-core -p snotra -p snotra-settings -- -D warnings`（3クレート clean）
- [ ] 手動: 起動 → 即 `/s`／設定保存で背景再スキャンと再構築を競合させても `index.bin` が破損しない
- [ ] 手動: 設定変更を連打しても `indexing` フラグが UI に正しく反映される
- [ ] 手動: スキャン対象変更後、古いアイコンが再起動を跨いで残らない

🤖 Generated with [Claude Code](https://claude.com/claude-code)