### PR TITLE
chore: snotra-core のメモリ削減（派生 Vec の Box<str> 化 + index.bin 保存の二重バッファ除去）

### DIFF
--- a/snotra-core/CLAUDE.md
+++ b/snotra-core/CLAUDE.md
@@ -94,6 +94,7 @@ raw なデータ構造（`FxHashMap<String, u32>` など）を返す pub API は
 5. **`save_cache_sorted()`**: 新フィールドの計算ロジックを追加
 6. **`CachedMasks` 構造体**: 新フィールドを `Option<T>` で追加（旧キャッシュでは None）
 7. **`SearchEngine::new_with_cached_masks()`**: 新パラメータを受け取り、None 時は自前で計算
+8. **`IndexCacheRef<'a>` 構造体**: `save_cache_sorted` が使う Serialize 専用の借用版。新フィールドを **`IndexCache` と完全に同じ順序・型**（`Vec<T>` → `&[T]`）で追加する。postcard は構造順依存のため、ずれると無言でフォーマットが変わり旧 `index.bin` を破損する。バイト一致は `index_cache_ref_serializes_identically_to_owned` テストでガード
 
 1つでも欠けるとキャッシュヒット時/ミス時で異なる結果を返す。
 

--- a/snotra-core/src/binfmt.rs
+++ b/snotra-core/src/binfmt.rs
@@ -106,12 +106,7 @@ pub fn serialize_with_header<T: Serialize>(
     version: u32,
     payload: &T,
 ) -> Option<Vec<u8>> {
-    let body = postcard::to_allocvec(payload).ok()?;
-    let mut out = Vec::with_capacity(HEADER_LEN + body.len());
-    out.extend_from_slice(&magic);
-    out.extend_from_slice(&version.to_le_bytes());
-    out.extend_from_slice(&body);
-    Some(out)
+    try_serialize_with_header(magic, version, payload).ok()
 }
 
 /// Result-based serialization (preferred over Option-based `serialize_with_header`).
@@ -120,12 +115,13 @@ pub fn try_serialize_with_header<T: Serialize>(
     version: u32,
     payload: &T,
 ) -> Result<Vec<u8>, BinError> {
-    let payload_bytes = postcard::to_allocvec(payload).map_err(|_| BinError::SerializeFailed)?;
-    let mut buf = Vec::with_capacity(HEADER_LEN + payload_bytes.len());
+    // ヘッダを先頭に書き込み、postcard 本体を同じ Vec へ直接追記する（postcard::to_extend）。
+    // to_allocvec で本体を別 Vec に確保してから extend_from_slice でコピーし直す二重バッファを
+    // 避け、save 区間のピークメモリと総コピー量を削減する。出力バイト列は従来と同一。
+    let mut buf = Vec::with_capacity(HEADER_LEN);
     buf.extend_from_slice(&magic);
     buf.extend_from_slice(&version.to_le_bytes());
-    buf.extend_from_slice(&payload_bytes);
-    Ok(buf)
+    postcard::to_extend(payload, buf).map_err(|_| BinError::SerializeFailed)
 }
 
 #[deprecated(note = "use try_deserialize_with_header for Result-based error handling")]

--- a/snotra-core/src/indexer.rs
+++ b/snotra-core/src/indexer.rs
@@ -224,6 +224,26 @@ struct IndexCache {
     normalized_keys: Vec<String>,
 }
 
+/// `IndexCache` の借用版（Serialize 専用）。`save_cache_sorted` が `entries` の全件 clone
+/// （`entries.to_vec()`）を避け、スライス参照を直接シリアライズするために使う。
+///
+/// **重要**: フィールドの順序・型を `IndexCache` と完全に一致させること。postcard は構造体を
+/// フィールド順でシリアライズし名前を見ないため、`&[T]` は `Vec<T>` とバイト列が一致する。
+/// 順序がずれると無言でフォーマットが変わり旧 `index.bin` を破損する。この不変条件は
+/// `index_cache_ref_serializes_identically_to_owned` テストでガードする。read 経路は所有版
+/// `IndexCache` のまま（バイト列不変のため `INDEX_CACHE_VERSION` バンプ不要）。
+#[derive(Serialize)]
+struct IndexCacheRef<'a> {
+    built_at: u64,
+    entries: &'a [AppEntry],
+    config_hash: u64,
+    char_masks: &'a [u64],
+    file_name_char_masks: &'a [u64],
+    lower_names: &'a [String],
+    lower_file_names: &'a [Option<String>],
+    normalized_keys: &'a [String],
+}
+
 /// v3 フォールバック用スキーマ（ビットマスクのみ、lower names なし）。
 #[derive(Serialize, Deserialize)]
 struct IndexCacheV3 {
@@ -402,18 +422,20 @@ fn save_cache_sorted(entries: &[AppEntry], config_hash: u64) {
     let normalized_keys: Vec<String> =
         entries.iter().map(|e| normalize_entry_key(&e.target_path)).collect();
 
-    let cache = IndexCache {
+    // 借用版 IndexCacheRef を使い entries の全件 clone を避ける。派生 Vec も参照で渡す
+    // （所有版 IndexCache へ move する必要がない）。出力バイト列は所有版と同一。
+    let cache = IndexCacheRef {
         built_at: SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs(),
-        entries: entries.to_vec(),
+        entries,
         config_hash,
-        char_masks,
-        file_name_char_masks,
-        lower_names,
-        lower_file_names,
-        normalized_keys,
+        char_masks: &char_masks,
+        file_name_char_masks: &file_name_char_masks,
+        lower_names: &lower_names,
+        lower_file_names: &lower_file_names,
+        normalized_keys: &normalized_keys,
     };
     bf.save(&cache);
 }
@@ -987,6 +1009,69 @@ mod tests {
             restored.normalized_keys,
             vec!["c:\\apps\\firefox.lnk", "c:\\projects"]
         );
+    }
+
+    #[test]
+    fn index_cache_ref_serializes_identically_to_owned() {
+        // IndexCacheRef（save で使う借用版）が所有版 IndexCache とバイト列一致することを保証する。
+        // これが崩れると save の出力フォーマットが無言で変わり、既存 index.bin の読込が壊れる。
+        let entries = vec![
+            AppEntry {
+                name: "Firefox".to_string(),
+                target_path: "C:\\apps\\firefox.lnk".to_string(),
+                is_folder: false,
+            },
+            AppEntry {
+                name: "Projects".to_string(),
+                target_path: "C:\\Projects".to_string(),
+                is_folder: true,
+            },
+        ];
+        let char_masks = vec![0xABu64, 0xCD];
+        let file_name_char_masks = vec![0x12u64, 0x34];
+        let lower_names = vec!["firefox".to_string(), "projects".to_string()];
+        let lower_file_names = vec![Some("firefox.lnk".to_string()), None];
+        let normalized_keys =
+            vec!["c:\\apps\\firefox.lnk".to_string(), "c:\\projects".to_string()];
+        let built_at = 1_700_000_000u64;
+        let config_hash = 12345u64;
+
+        let owned = IndexCache {
+            built_at,
+            entries: entries.clone(),
+            config_hash,
+            char_masks: char_masks.clone(),
+            file_name_char_masks: file_name_char_masks.clone(),
+            lower_names: lower_names.clone(),
+            lower_file_names: lower_file_names.clone(),
+            normalized_keys: normalized_keys.clone(),
+        };
+        let borrowed = IndexCacheRef {
+            built_at,
+            entries: &entries,
+            config_hash,
+            char_masks: &char_masks,
+            file_name_char_masks: &file_name_char_masks,
+            lower_names: &lower_names,
+            lower_file_names: &lower_file_names,
+            normalized_keys: &normalized_keys,
+        };
+
+        let owned_bytes =
+            serialize_with_header(INDEX_MAGIC, INDEX_CACHE_VERSION, &owned).expect("owned");
+        let ref_bytes =
+            serialize_with_header(INDEX_MAGIC, INDEX_CACHE_VERSION, &borrowed).expect("borrowed");
+        assert_eq!(
+            owned_bytes, ref_bytes,
+            "IndexCacheRef must serialize byte-identically to owned IndexCache"
+        );
+
+        // 借用版で書いたバイト列を所有版として読み戻せること（read 経路の不変性）も確認する。
+        let restored: IndexCache =
+            deserialize_with_header(&ref_bytes, INDEX_MAGIC, INDEX_CACHE_VERSION)
+                .expect("roundtrip");
+        assert_eq!(restored.entries.len(), 2);
+        assert_eq!(restored.normalized_keys, normalized_keys);
     }
 
     #[test]

--- a/snotra-core/src/search.rs
+++ b/snotra-core/src/search.rs
@@ -97,10 +97,12 @@ impl From<&SearchConfig> for SearchOptions {
 /// enforce this by running the full test suite after any structural change.
 pub struct SearchEngine {
     entries: Vec<AppEntry>,
-    lower_names: Vec<String>,
-    lower_file_names: Vec<Option<String>>,
+    /// 派生文字列の並列 Vec は `Box<str>` で保持する。これらは構築後に伸長しないため、
+    /// `String` の容量ワード（8B/要素）が無駄になる。`str` へ Deref するので読み取り側は無変更。
+    lower_names: Vec<Box<str>>,
+    lower_file_names: Vec<Option<Box<str>>>,
     /// Pre-computed normalized keys for history lookups (one per entry).
-    normalized_keys: Vec<String>,
+    normalized_keys: Vec<Box<str>>,
     /// Character-presence bitmask for lower_name (a-z: bits 0-25, 0-9: bits 26-35).
     /// Kept as a compact Vec<u64> — 8 entries per cache line — so the pre-filter sweep
     /// that discards non-matching candidates before scoring is L1-cache-friendly.
@@ -111,7 +113,7 @@ pub struct SearchEngine {
     file_name_char_masks: Vec<u64>,
     /// エントリ名をひらがな正規化した Vec（katakana→hiragana、ASCII はそのまま）。
     /// migemo 検索（ローマ字→かな変換マッチ）で使用。インデックスキャッシュには保存しない。
-    kana_lower_names: Vec<String>,
+    kana_lower_names: Vec<Box<str>>,
     /// Incremental search cache: normalized query string from the previous call.
     prev_query: String,
     /// Incremental search cache: entry indices that matched on the previous call,
@@ -138,19 +140,21 @@ struct EntryView<'a> {
     normalized_key: &'a str,
 }
 
+/// Wave 1 の出力: `(lower_names, lower_file_names, normalized_keys, kana_lower_names)`。
+/// いずれも構築後に伸長しないため `Box<str>` で保持する（容量ワード 8B/要素を節約）。
+type Wave1Strings = (Vec<Box<str>>, Vec<Option<Box<str>>>, Vec<Box<str>>, Vec<Box<str>>);
+
 /// Wave 1: entries から文字列正規化データを並列構築する。
 /// lower_names / lower_file_names / normalized_keys / kana_lower_names は
 /// entries への純粋な map であり相互依存がないため rayon::join で並列構築する。
-fn compute_wave1(
-    entries: &[AppEntry],
-) -> (Vec<String>, Vec<Option<String>>, Vec<String>, Vec<String>) {
+fn compute_wave1(entries: &[AppEntry]) -> Wave1Strings {
     let ((lower_names, lower_file_names), (normalized_keys, kana_lower_names)) = rayon::join(
         || {
             rayon::join(
                 || {
                     entries
                         .iter()
-                        .map(|e| to_lower_folded(&e.name))
+                        .map(|e| to_lower_folded(&e.name).into_boxed_str())
                         .collect::<Vec<_>>()
                 },
                 || {
@@ -160,7 +164,7 @@ fn compute_wave1(
                             std::path::Path::new(&e.target_path)
                                 .file_name()
                                 .and_then(|f| f.to_str())
-                                .map(to_lower_folded)
+                                .map(|s| to_lower_folded(s).into_boxed_str())
                         })
                         .collect::<Vec<_>>()
                 },
@@ -171,13 +175,13 @@ fn compute_wave1(
                 || {
                     entries
                         .iter()
-                        .map(|e| normalize_entry_key(&e.target_path))
+                        .map(|e| normalize_entry_key(&e.target_path).into_boxed_str())
                         .collect::<Vec<_>>()
                 },
                 || {
                     entries
                         .iter()
-                        .map(|e| to_kana(&to_lower_folded(&e.name)))
+                        .map(|e| to_kana(&to_lower_folded(&e.name)).into_boxed_str())
                         .collect::<Vec<_>>()
                 },
             )
@@ -192,8 +196,8 @@ fn compute_wave1(
 /// u64::MAX ensures (query_mask & u64::MAX) == query_mask for any query_mask,
 /// so these entries always pass the bitmask pre-filter regardless of the query.
 fn compute_wave2(
-    lower_names: &[String],
-    lower_file_names: &[Option<String>],
+    lower_names: &[Box<str>],
+    lower_file_names: &[Option<Box<str>>],
 ) -> (Vec<u64>, Vec<u64>) {
     rayon::join(
         || {
@@ -220,12 +224,12 @@ impl SearchEngine {
     /// 全並列 Vec の長さが entries と一致することを検証し、Self を組み立てる。
     fn assemble(
         entries: Vec<AppEntry>,
-        lower_names: Vec<String>,
-        lower_file_names: Vec<Option<String>>,
-        normalized_keys: Vec<String>,
+        lower_names: Vec<Box<str>>,
+        lower_file_names: Vec<Option<Box<str>>>,
+        normalized_keys: Vec<Box<str>>,
         char_masks: Vec<u64>,
         file_name_char_masks: Vec<u64>,
-        kana_lower_names: Vec<String>,
+        kana_lower_names: Vec<Box<str>>,
     ) -> Self {
         debug_assert!(
             lower_names.len() == entries.len()
@@ -285,11 +289,19 @@ impl SearchEngine {
             if let (Some(ln), Some(lfn), Some(nk)) =
                 (cached_lower_names, cached_lower_file_names, cached_normalized_keys)
             {
-                // A-3: v4 キャッシュヒット → Wave 1 完全スキップ（kana_lower_names は毎起動再計算）
+                // A-3: v4 キャッシュヒット → Wave 1 完全スキップ（kana_lower_names は毎起動再計算）。
+                // キャッシュ由来の Vec<String> を Box<str> へ移す。postcard デシリアライズ後の
+                // String は capacity == len のため into_boxed_str は再アロケーションを伴わない。
                 let kana = entries
                     .par_iter()
-                    .map(|e| to_kana(&to_lower_folded(&e.name)))
+                    .map(|e| to_kana(&to_lower_folded(&e.name)).into_boxed_str())
                     .collect::<Vec<_>>();
+                let ln = ln.into_iter().map(String::into_boxed_str).collect::<Vec<_>>();
+                let lfn = lfn
+                    .into_iter()
+                    .map(|o| o.map(String::into_boxed_str))
+                    .collect::<Vec<_>>();
+                let nk = nk.into_iter().map(String::into_boxed_str).collect::<Vec<_>>();
                 (ln, lfn, nk, kana)
             } else {
                 // v3 フォールバック: Wave 1 を並列実行


### PR DESCRIPTION
## 概要

Snotra のメモリ消費削減サイクルの第一弾。多エージェント監査（27 候補を検証）で「無条件 safe で恒常 RSS を大きく削れる候補はゼロ、効果のあるものは付帯条件付きの risky」と判明した中から、**最低リスク・snotra-core 完結**の 2 件を実装した。

パフォーマンスと機能は維持（同一マシン A/B ベンチで検索・構築とも退行なし、全テスト緑）。

## 変更

### ① 検索インデックスの派生 Vec を `Box<str>` 化 (cbe7247)

`SearchEngine` の派生文字列 Vec（`lower_names` / `lower_file_names` / `normalized_keys` / `kana_lower_names`）を `Vec<String>` → `Vec<Box<str>>` に。`String` の容量ワード 8B/要素を除去（4 Vec で **約 32B/entry**、50k 件で ~1.6MB の恒常 RSS 削減）。

- `compute_wave1` / `compute_wave2` / `assemble` / `new_with_cached_masks` を同期更新（並列 Vec「5 箇所同時更新」不変条件を遵守）
- 消費側はすべて `&str` 読み取り（`EntryView` / `kana_substring_score`）→ `Deref` で素通り、呼び出し側無変更
- `IndexCache` / `CachedMasks` は `Vec<String>` のまま据え置き → バイト形式不変・`INDEX_CACHE_VERSION` バンプ不要・`indexer.rs` 無変更
- 並列 Vec の **struct 化（SoA→AoS）は行っていない**（既知の Fuzzy 35〜120% 退行を回避）。要素型を狭めるだけの変更

### ② index.bin 保存の二重バッファ除去（`IndexCacheRef` + `to_extend`） (581b2d4)

save 区間の一過性ピークメモリを削減。

- 借用版 `IndexCacheRef<'a>`（Serialize 専用）を追加し、`save_cache_sorted` の `entries.to_vec()`（全件 clone）を `&[AppEntry]` 参照に置換。派生 Vec も参照渡し。read 経路は所有版 `IndexCache` のまま
- `binfmt` の `try_serialize_with_header` を `postcard::to_extend` に変更し、本体を別 Vec に確保 → `extend_from_slice` でコピーし直す二重バッファを除去（`serialize_with_header` は try 版へ委譲し DRY 化）
- 30k 件規模で save ピークを概算 **8〜9MB** 削減
- 出力バイト列・read 経路・`INDEX_CACHE_VERSION` はすべて不変

## 検証

- `cargo check`（3 crate）/ `cargo clippy -D warnings` ✅
- `cargo test -p snotra-core`: **351 passed**（新規 `index_cache_ref_serializes_identically_to_owned` 含む）✅
- 同一マシン・単一スレッド A/B ベンチ（退行なし）:

| bench | `String`(基準) | 本 PR | 判定 |
|-------|------:|------:|------|
| fuzzy 50k | 348µs | 325µs | 微減 |
| fuzzy 100k | 731µs | 687µs | 微減 |
| new 50k | 40ms | 43ms | 誤差内 |
| new 100k | 91ms | 89ms | 誤差内 |

- バイト互換: 新規バイト一致テスト + 既存ラウンドトリップ（binfmt / history / indexer / window）全通過

## スコープ外（後続 PR）

監査で risky 採用圏に残った ③`IconCache` LRU 上限（src-tauri・SPEC §3.4 同期・config 後方互換）、④グローバルアロケータ mimalloc（依存追加・要 release 実測）は別 PR で扱う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
