### PR TITLE
fix: E2E テストの config TOML エスケープと driver バージョン解決を修正

### DIFF
--- a/e2e/tauri.slash.e2e.ts
+++ b/e2e/tauri.slash.e2e.ts
@@ -1,6 +1,6 @@
 import { test as base, expect } from "@playwright/test";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
 import net from "node:net";
 import os from "node:os";
@@ -104,7 +104,7 @@ exe = "notepad.exe"
 [[openers.tools]]
 name = "Type"
 exe = "cmd.exe"
-args = "/c type \"{path}\""
+args = '/c type "{path}"'
 `.trim();
 }
 
@@ -183,12 +183,56 @@ async function waitForPort(port: number, timeoutMs: number): Promise<void> {
   throw new Error(`Timed out waiting for port ${port}`);
 }
 
+/**
+ * msedgedriver must match the **WebView2 Runtime** the app embeds, not the Edge
+ * browser. The `edgedriver` package resolves the driver from the installed Edge
+ * browser version, which can differ from the WebView2 Runtime by a patch level —
+ * the mismatch makes every session fail with
+ * "session not created: Chrome instance exited". Detect the runtime version from
+ * its install directory so the downloaded driver matches what the app actually uses.
+ * Returns undefined if not found (caller falls back to the package's auto-detect).
+ */
+async function resolveWebView2DriverVersion(): Promise<string | undefined> {
+  if (process.platform !== "win32") return undefined;
+  const bases = [
+    "C:\\Program Files (x86)\\Microsoft\\EdgeWebView\\Application",
+    "C:\\Program Files\\Microsoft\\EdgeWebView\\Application",
+  ];
+  const cmpVersion = (a: string, b: string): number => {
+    const pa = a.split(".").map(Number);
+    const pb = b.split(".").map(Number);
+    for (let i = 0; i < 4; i++) {
+      if ((pa[i] ?? 0) !== (pb[i] ?? 0)) return (pa[i] ?? 0) - (pb[i] ?? 0);
+    }
+    return 0;
+  };
+  for (const base of bases) {
+    try {
+      const names = await readdir(base);
+      const versions = names.filter((n) => /^\d+\.\d+\.\d+\.\d+$/.test(n)).sort(cmpVersion);
+      if (versions.length > 0) return versions[versions.length - 1];
+    } catch {
+      // directory absent — try next base
+    }
+  }
+  return undefined;
+}
+
 async function spawnTauriDriver(): Promise<ChildProcessWithoutNullStreams> {
   const tauriDriverPath = getTauriDriverPath();
   if (!(await fileExists(tauriDriverPath))) {
     throw new Error(
       `tauri-driver not found at ${tauriDriverPath}. Run: npm run e2e:tauri:setup`,
     );
+  }
+  // Pin msedgedriver to the WebView2 Runtime version (unless explicitly overridden
+  // via EDGEDRIVER_VERSION). edgedriver otherwise matches the Edge browser, which
+  // can differ from the WebView2 Runtime and break session creation.
+  if (!process.env.EDGEDRIVER_VERSION) {
+    const wv2Version = await resolveWebView2DriverVersion();
+    if (wv2Version) {
+      process.env.EDGEDRIVER_VERSION = wv2Version;
+    }
   }
   const nativeDriverPath = await downloadEdgeDriver();
   const proc = spawn(tauriDriverPath, ["--native-driver", nativeDriverPath], {


### PR DESCRIPTION
## 概要

`npm run e2e:tauri` が全件失敗していた 2 つのハーネス起因の原因を修正する。アプリのロジック回帰ではなく E2E テストハーネス側の不具合（`main` でも再現）。

## 真因と修正

### ① config TOML のクォート未エスケープ（検索系 11 件全滅の主因）

`buildE2EConfigToml` の `args = "/c type \"{path}\""` は JS テンプレートリテラル内で `\"` が `"` に潰れ、出力 TOML が `args = "/c type "{path}""` という不正な文字列になっていた。これにより config 全体が parse 失敗 → `Config::load()` の `unwrap_or_default()` が `Config::default()`（Start Menu / Desktop スキャン）にフォールバック → fixture が索引されず `search("snotra-e2e")` が 0 件 → 検索系テスト 11 件が全滅していた。

→ TOML リテラル文字列（シングルクォート）`args = '/c type "{path}"'` に変更し、エスケープ不要にする。

### ② msedgedriver と WebView2 Runtime のバージョン不一致（全セッション失敗の原因）

`edgedriver` は Edge ブラウザ版に合わせて driver を取得するが、アプリが automation するのは WebView2 Runtime。両者はパッチレベルでドリフトし、不一致は全セッションが `session not created: Chrome instance exited` で失敗する。

→ `spawnTauriDriver` が WebView2 Runtime のインストールディレクトリからバージョンを検出し `EDGEDRIVER_VERSION` に設定する（`resolveWebView2DriverVersion`、明示指定があれば尊重）。

## 検証

- `npm run e2e:tauri` → **14/14 passed**（`EDGEDRIVER_VERSION` 未指定で）
- `npm run typecheck` → pass
- 同一テストが `main`（変更前）でも同様に失敗することを確認済み（メモリ PR #331 等の回帰ではない）

変更は `e2e/tauri.slash.e2e.ts` のみ（+46 / −2）。

Fixes #332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
