### PR TITLE
docs: CLAUDE.md シェル環境節に Windows 操作の落とし穴 3 件を追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,9 @@
 - **bash の HEREDOC（`<<EOF` / `<<'EOF'`）を使わない** — PowerShell では here-string の引用境界が壊れ、終端マーカーがコミットメッセージ本文に漏れる事故が起きている。複数行のコミットメッセージは一時ファイルに書き出して `git commit -F <tmpfile>` を使うか、PowerShell の here-string `@'...'@`（閉じ `'@` は必ず行頭）を使う
 - **`git` コマンドをチェーンしない** — `git checkout <branch> && git rebase main` のような連鎖は `block-main-commit` フックを誤発火させた実績がある。`checkout` と `rebase`、`add` と `commit` のように影響範囲の異なる操作はそれぞれ独立した呼び出しに分ける
 - **パス区切りは `/` を優先** — PowerShell でも Git/Node/Cargo は `/` を受け付ける。`\` を含めるとエスケープが必要になるため、文字列中のパスは `/` で統一する
+- **main の fast-forward 同期は `git pull --ff-only` を使う** — `git merge --ff-only origin/main` でも `block-main-commit` フックが `git\s+(commit|merge|rebase)` を文字列一致で弾く（コミットを作らない FF でも発火する）
+- **Bash ツールに `/tmp` は無い（Windows）** — 一時ファイルは `$env:TEMP` 配下に置くか Write ツールで作る。`cat > /tmp/...` は `FileNotFoundError` で失敗する
+- **Python で非 ASCII を標準出力するときは `PYTHONIOENCODING=utf-8` を付ける** — cp932 コンソールで `—`・日本語などを print すると `UnicodeEncodeError` で落ちる（JSON/ログ整形で多用）
 
 ## チーム憲章
 


### PR DESCRIPTION
## 概要

ルート `CLAUDE.md` の「シェル環境（Windows / PowerShell）」節に、当セッションで実際に手戻りを生んだ Windows 操作の落とし穴 3 件を追記する。`/claude-md-management:revise-claude-md` の振り返り由来。

## 変更

- main の fast-forward 同期は `git pull --ff-only` を使う（`git merge --ff-only` でも `block-main-commit` フックが `git\s+(commit|merge|rebase)` を文字列一致で弾く／コミットを作らない FF でも発火）
- Bash ツールに `/tmp` は無い（Windows）。一時ファイルは `$env:TEMP` 配下か Write ツール
- Python で非 ASCII を標準出力するときは `PYTHONIOENCODING=utf-8`（cp932 コンソールで `UnicodeEncodeError`）

`docs/development-principles.md`（A/B 比較・最下層観測）/ `docs/build-commands.md`（E2E driver・config TOML）の既出内容とは重複させず、操作上の落とし穴のみに絞る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)