### PR TITLE
chore: plan-review スキルをモデル起動可にする

### DIFF
--- a/.claude/skills/plan-review/SKILL.md
+++ b/.claude/skills/plan-review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: plan-review
 description: "workspace/plan.md をサブエージェントで並列検証する。影響範囲の漏れ・対称パスの見落とし・不変条件の欠落・リソース管理の問題を洗い出す。/start-issue の Step 5 または実装前に使う。"
-disable-model-invocation: true
 allowed-tools:
   - Read
   - Agent


### PR DESCRIPTION
## 概要

`.claude/skills/plan-review/SKILL.md` から `disable-model-invocation: true` を除去し、`plan-review` をモデルから起動できるようにする。

## 背景

`/start-issue` Step 5a・`/implement` のワークフローは `/plan-review` の起動をモデルに指示するが、当該スキルが `disable-model-invocation: true` のためモデルからは起動できず、ワークフローが機能しない不整合があった。

チェック系スキル（`symmetric-check` / `cache-check` / `dry-check` / `race-check`）は元々モデル起動可で、矛盾していたのは `plan-review` のみ。最上位のワークフロー入口（`start-issue` / `implement` / `health-check` / `retrospective` / `deps-update` / `research-review`）は「モデルが勝手に重量級ワークフローを起動しない」意図的設計のため変更しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)