### PR TITLE
feat: 非表示時に WebView2 プロセスツリーへ EmptyWorkingSet を適用 (#355)

### DIFF
--- a/src-tauri/CLAUDE.md
+++ b/src-tauri/CLAUDE.md
@@ -11,6 +11,7 @@ Tauri v2 バイナリ crate。Win32 API 統合とフロントエンドとの IPC
 - `config_watcher.rs`: `notify` クレートで `config.toml` 変更を監視（100ms debounce）し、差分検出後にホットキー・トレイ・インデックス・テーマ・ウィンドウ幅・言語を反映する `apply_config_change()` を実行。**不変条件: 言語変更とホットキー変更が同時に発生した場合、`language-changed` イベントをホットキー失敗通知より先に発火する**（フロントエンドが正しい言語でエラー文字列を組み立てるため）。**不変条件: `LoadOutcome::ReadFailed`（一時的・環境的な read 失敗）では `apply_config_change` は何も適用せず早期 return する**（`should_apply_config_change()` で判定。fallback-default を実行中エンジンへ適用すると、live-read 化した履歴剪定が `history.bin` をデータ損失させ、index 再構築判定（`IndexInputs` 差分）が default scan で誤再構築を起こすため。`Config::load` の「一時的失敗は退避も上書きもしない」保全を適用側にも揃える、#348）。ただし早期 return の前に短いバウンドリトライ（`load_with_read_failed_retry`、既定 3 回 × 150ms）で一時的ロック解除を待ち、解ければ正規の変更を取りこぼさず適用する（予算超過時のみ skip。リトライ中は適用しないのでデータ損失安全は不変）。**不変条件: index 再構築の要否は `IndexInputs::from_config(old) != IndexInputs::from_config(new)` で判定し、ビルド進行中（`indexing`）でも `!indexing` ゲートなしで常に `start_index_build` を kick する**（`start_index_build` が `mark_index_stale` で stale を立て、in-flight ビルドの drain / finish 後再チェックが取りこぼしを拾う。CAS が二重起動を防ぐ。#347/#348-A）。発火するイベント: `language-changed` / `hotkey-registration-failed` / `visual-config-changed` / `show-icons-changed` / `max-results-changed` / `instant-prefix-changed` / `top-n-history-changed` / `indexing-started`（indexing.rs から）/ `indexing-complete`（indexing.rs から）
 - `ime.rs`: IME オフ操作（`ImmSetOpenStatus(false)`）。Win32 IMM API の薄いラッパー
 - `monitor.rs`: マルチモニター対応の Win32 ヘルパー（`GetCursorPos` / `MonitorFromPoint` / `MonitorFromWindow` / `GetMonitorInfoW`）。物理座標ベースで作業領域を取得し、ウィンドウ位置のクランプ・中央配置を提供
+- `working_set.rs`: 非表示アイドル時に Win32 `EmptyWorkingSet` でプロセスツリー全体（自プロセス + WebView2 子孫）の物理 working set を回収（Windows のみ、非 Windows は no-op）。`collect_descendant_pids()` は Toolhelp の (pid,ppid) 上を BFS する純関数（Win32 非依存・ユニットテスト対象）。`trim_idle_working_set()` は hide 経路（hotkey + `notify_main_hidden`）から呼ばれる best-effort 操作で、HANDLE は RAII ガードで解放し、全 Win32 失敗を握りつぶす
 - `commands/`: ディレクトリモジュール（`mod.rs` + `search.rs` / `launch.rs` / `config.rs` / `icon.rs` / `window.rs` / `system.rs` / `instant.rs`）。`#[tauri::command]` を責務別に分割。`launch.rs` は `launch_item_core`（`pub(crate)`、`instant.rs` から再利用）に加え、トレイメニューからの起動用に `launch_item_with_state` / `launch_with_tool_with_state` / `launch_default_with_state` / `resolve_all_openers` を `pub` で公開
 - `platform/`: ディレクトリモジュール（`mod.rs` + `hotkey.rs` / `tray.rs` / `wndproc.rs`）。Win32 メッセージループスレッド + トレイアイコン + ホットキー + ウィンドウプロシージャ
   - `wndproc.rs`: `SendMessage` 経由で届く `WM_TRAY_ICON` および `WM_CONTEXTMENU` を `PostThreadMessageW` でスレッドキューに再投入し、メッセージループでの統一処理を保証
@@ -54,6 +55,15 @@ NOTIFYICON_VERSION_4 では、キーボード操作（Shift+F10 / Application �
 - **フロントエンド起因の hide（Escape / クリック起動 / フォーカス喪失）では suspend しない**: `notifyMainHidden` IPC は tokio スレッドで実行されるため `with_webview(TrySuspend)` は非同期ディスパッチになり、`win.hide()` より先にメインスレッドに到達すると IsVisible=true で失敗する。ホットキートグル（メインスレッドで同期実行）に限定することで順序を保証
 - **`with_webview()` の同期性はコンテキスト依存**: setup フェーズ / `app.listen` コールバック → 同期。IPC ハンドラ / `std::thread::spawn` → 非同期（fire-and-forget）
 - **TrySuspend と MemoryUsageTargetLevel は混用禁止**: TrySuspend が自動で MemoryUsageTargetLevel を Low に設定し、Resume が Normal に戻す
+
+## WebView2 working set の能動回収（EmptyWorkingSet）
+
+TrySuspend / MemoryUsageTargetLevel.Low は**論理目標**を下げるだけで、メモリ圧迫のない環境では OS が**物理 working set を回収しない**（実測: 非表示アイドル ~110MB が表示↔非表示・120 秒放置でも不変）。`working_set::trim_idle_working_set()` が hide 経路で Win32 `EmptyWorkingSet` をプロセスツリー全体（自プロセス + WebView2 子孫）へ能動適用し、アイドル物理 RSS を数MB まで落とす（再表示は OS の透過 re-fault で ~44ms 維持、UI 正常）。
+
+- **TrySuspend とは別レイヤーで補完的**: TrySuspend=論理目標（圧迫待ち・CPU 中断）、EmptyWorkingSet=物理 working set の即時トリミング。競合しない
+- **全 hide 経路に適用**: hotkey トグル（`main.rs`、`suspend_webview` の後）と `notify_main_hidden`（`commands/system.rs`、全フロントエンド hide の IPC チョークポイント）の両方から呼ぶ。**`EmptyWorkingSet` はスレッド非依存**（`with_webview` のような非同期制約がない）ため、tokio IPC スレッドの `notify_main_hidden` からも安全
+- **show 側に逆操作は不要**: trim されたページは show 時に OS が透過的に re-fault する。明示 untrim API は存在しない。trim が hide 前後どちらで走っても無害（再 fault するだけ）
+- **best-effort・物理 RAM のみ**: Toolhelp / `OpenProcess` / `EmptyWorkingSet` の全失敗は黙ってスキップ（機能影響ゼロ）。HANDLE は RAII ガードで解放。削減対象は working set であって commit ではない
 
 ## Win32 / Tauri 注意事項
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,8 @@ windows = { version = "0.62.2", features = [
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_Input_Ime",
     "Win32_System_Threading",
+    "Win32_System_ProcessStatus",
+    "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_Com",
     "Win32_Security",
     "Win32_Foundation",

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -41,4 +41,8 @@ pub fn notify_main_shown(state: State<AppState>) {
 pub fn notify_main_hidden(state: State<AppState>, app: AppHandle) {
     state.main_visible.store(false, Ordering::SeqCst);
     let _ = app.emit("window-hidden", ());
+    // フロントエンド起因の hide（フォーカス喪失/Escape/クリック起動/スラッシュ）も
+    // working set を回収する。EmptyWorkingSet はスレッド非依存ゆえ tokio IPC スレッドから
+    // 安全に呼べる（suspend_webview の with_webview 非同期制約がない）。best-effort。
+    crate::working_set::trim_idle_working_set(std::process::id());
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,6 +8,7 @@ mod indexing;
 mod monitor;
 mod platform;
 mod state;
+mod working_set;
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -579,6 +580,9 @@ fn main() {
                     if let Some(w) = handle_for_hotkey.get_webview_window("main") {
                         suspend_webview(&w);
                     }
+                    // 非表示アイドルの物理 working set を回収（TrySuspend は圧迫なし環境では
+                    // 回収しないため能動適用）。best-effort・機能挙動には影響しない。
+                    working_set::trim_idle_working_set(std::process::id());
                 } else if is_alt_pressed() {
                     trace_main("hotkey:alt_wait_start", json!({}));
                     let handle_for_show = handle_for_hotkey.clone();

--- a/src-tauri/src/working_set.rs
+++ b/src-tauri/src/working_set.rs
@@ -1,0 +1,164 @@
+//! 非表示アイドル時に WebView2 プロセスツリー全体の working set を回収する。
+//!
+//! `TrySuspend` / `MemoryUsageTargetLevel.Low`（`main.rs`）は論理目標を下げるだけで、
+//! メモリ圧迫のない環境では OS が物理 working set を回収しない（実測: 非表示 120 秒でも
+//! 不変）。ここでは hide 経路で Win32 `EmptyWorkingSet` をプロセスツリー（自プロセス +
+//! WebView2 子孫）へ能動適用し、アイドル常駐の物理 RSS を削減する。
+//!
+//! - show 時は OS がページを透過的に re-fault するため、逆操作（untrim）は不要かつ存在しない。
+//! - best-effort: Toolhelp / `OpenProcess` / `EmptyWorkingSet` の全失敗は黙ってスキップする
+//!   （失敗しても「メモリが減らない」だけで機能影響はない）。release は `panic = "abort"`
+//!   のため、ここでは panic させない（`unwrap`/`expect`/添字を使わない）。
+
+/// `(pid, parent_pid)` のリストから `root` を含む子孫 PID を BFS で収集する純関数。
+///
+/// `visited` 集合で循環参照・自己参照・PID 再利用（実在しない `ppid`）に対する停止性を
+/// 保証する。Win32 非依存ゆえユニットテスト可能（プロセスツリー走査の唯一のロジック）。
+pub(crate) fn collect_descendant_pids(pairs: &[(u32, u32)], root: u32) -> Vec<u32> {
+    use std::collections::{HashSet, VecDeque};
+
+    let mut result = Vec::new();
+    let mut visited = HashSet::new();
+    let mut queue = VecDeque::new();
+
+    visited.insert(root);
+    queue.push_back(root);
+
+    while let Some(cur) = queue.pop_front() {
+        result.push(cur);
+        for &(pid, ppid) in pairs {
+            // cur の子であり、かつ未訪問のものだけを辿る（`insert` が true = 新規）。
+            if ppid == cur && visited.insert(pid) {
+                queue.push_back(pid);
+            }
+        }
+    }
+
+    result
+}
+
+/// `root_pid` を根とするプロセスツリー全体の working set をトリミングする（Windows）。
+///
+/// 全 Win32 呼び出しは best-effort。失敗時は途中で諦めてメモリ削減を見送るだけで、
+/// ウィンドウの hide/show・状態遷移・IPC 契約には一切影響しない。
+#[cfg(windows)]
+pub(crate) fn trim_idle_working_set(root_pid: u32) {
+    use windows::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, PROCESSENTRY32W, Process32FirstW, Process32NextW,
+        TH32CS_SNAPPROCESS,
+    };
+    use windows::Win32::System::ProcessStatus::EmptyWorkingSet;
+    use windows::Win32::System::Threading::{
+        OpenProcess, PROCESS_QUERY_INFORMATION, PROCESS_SET_QUOTA,
+    };
+
+    /// HANDLE を確実に閉じる RAII ガード（`icon.rs` の `BitmapCleanup` と同じ作法）。
+    /// `?` / `continue` / early-return を含む全分岐での close 漏れを防ぐ。
+    struct HandleGuard(HANDLE);
+    impl Drop for HandleGuard {
+        fn drop(&mut self) {
+            if !self.0.is_invalid() {
+                unsafe {
+                    let _ = CloseHandle(self.0);
+                }
+            }
+        }
+    }
+
+    unsafe {
+        // 1. プロセススナップショットから (pid, ppid) を収集。
+        let Ok(snapshot) = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) else {
+            return;
+        };
+        // 名前付き束縛でスコープ末尾まで生かす（`let _ =` だと即 drop してしまう）。
+        let _snapshot_guard = HandleGuard(snapshot);
+
+        let mut entry = PROCESSENTRY32W {
+            dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+            ..Default::default()
+        };
+
+        let mut pairs: Vec<(u32, u32)> = Vec::new();
+        if Process32FirstW(snapshot, &mut entry).is_ok() {
+            loop {
+                pairs.push((entry.th32ProcessID, entry.th32ParentProcessID));
+                if Process32NextW(snapshot, &mut entry).is_err() {
+                    break;
+                }
+            }
+        }
+
+        // 2. 自プロセス + WebView2 子孫の PID を収集。
+        let pids = collect_descendant_pids(&pairs, root_pid);
+
+        // 3. 各プロセスの working set をトリミング（best-effort）。
+        for pid in pids {
+            let Ok(handle) = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_SET_QUOTA, false, pid)
+            else {
+                continue;
+            };
+            // 名前付き束縛でループ反復末尾まで生かす（EmptyWorkingSet 完了まで close しない）。
+            let _handle_guard = HandleGuard(handle);
+            let _ = EmptyWorkingSet(handle);
+        }
+    }
+}
+
+/// 非 Windows: no-op（working set 制御 API が存在しない）。
+#[cfg(not(windows))]
+pub(crate) fn trim_idle_working_set(_root_pid: u32) {}
+
+#[cfg(test)]
+mod tests {
+    use super::collect_descendant_pids;
+
+    fn sorted(mut v: Vec<u32>) -> Vec<u32> {
+        v.sort_unstable();
+        v
+    }
+
+    #[test]
+    fn linear_chain_collects_all_and_ignores_unrelated() {
+        // 1 -> 2 -> 3、(99,100) は無関係
+        let pairs = [(2, 1), (3, 2), (99, 100)];
+        assert_eq!(sorted(collect_descendant_pids(&pairs, 1)), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn webview_tree_shape() {
+        // snotra(1) -> browser(2) -> {renderer(3), gpu(4), utility(5)}, crashpad(6) も browser の子
+        let pairs = [(2, 1), (3, 2), (4, 2), (5, 2), (6, 2)];
+        assert_eq!(
+            sorted(collect_descendant_pids(&pairs, 1)),
+            vec![1, 2, 3, 4, 5, 6]
+        );
+    }
+
+    #[test]
+    fn stops_on_cycle_and_self_reference() {
+        // 1 -> 2 -> 1（循環）と 3 -> 3（自己参照）
+        let pairs = [(2, 1), (1, 2), (3, 3)];
+        assert_eq!(sorted(collect_descendant_pids(&pairs, 1)), vec![1, 2]);
+    }
+
+    #[test]
+    fn root_only_when_no_children() {
+        let pairs = [(10, 20), (11, 20)];
+        assert_eq!(collect_descendant_pids(&pairs, 1), vec![1]);
+    }
+
+    #[test]
+    fn ignores_separate_tree() {
+        // root 1 -> 2、別系統 100 -> 101 -> 102 は巻き込まない
+        let pairs = [(2, 1), (101, 100), (102, 101)];
+        assert_eq!(sorted(collect_descendant_pids(&pairs, 1)), vec![1, 2]);
+    }
+
+    #[test]
+    fn nonexistent_parent_pid_not_traversed() {
+        // ppid 7 は pid として存在しない（PID 再利用相当）。root からのみ辿る
+        let pairs = [(2, 1), (3, 7)];
+        assert_eq!(sorted(collect_descendant_pids(&pairs, 1)), vec![1, 2]);
+    }
+}

--- a/workspace/plan.md
+++ b/workspace/plan.md
@@ -1,57 +1,112 @@
-# plan.md — issue #347 Phase 2: index_stale ledger 化（+ #348 欠陥 A）
+# plan — issue #355: 非表示時に WebView2 プロセスツリーへ EmptyWorkingSet を適用
 
-> 設計 SSOT は `docs/design/2026-05-31-coherence-staleset.md`（status: Agreed）。本ファイルは Phase 2 サイクルの計画と記録。
-> Phase 1（history live-read 化, #348-B）は #350 でマージ済み。本サイクルは **Phase 2 = #347 構造的中核 + #348 欠陥 A（lost-update 窓）**。
+## ゴール / 受け入れ条件
 
-## ゴール
+- 全 hide 経路（hotkey トグル + フロントエンド起因：フォーカス喪失/Escape/クリック起動/スラッシュ）で、Snotra プロセスツリー全体（自プロセス + WebView2 子孫）の working set をトリミングする
+- 非表示アイドルの Private WS が baseline（~110MB）から数MB へ落ちる（手動計測で確認）
+- 再表示が体感即時を維持（~44ms、UI・検索結果・アイコンが正常描画）
+- 失敗時（Toolhelp/OpenProcess 失敗）は黙ってスキップ＝機能影響ゼロ（best-effort）
 
-config 変更→index 再構築の整合を「engine の単一 `index_stale` ledger + 単一 `IndexInputs` 定義」に統合し、
-config_watcher の `!indexing` ゲートを撤去して lost-update 窓を閉じる。コヒーレンシ判断を engine Mutex（軸1）に閉じ、
-AtomicBool（軸2）を CAS+UI 専用に純化する。
+## 設計判断
 
-## 変更ファイル
+1. **適用範囲 = 全 hide 経路**（hotkey + frontend）。理由: ランチャーが最も多く隠れるのはフォーカス喪失（frontend 経路）であり、hotkey 限定では大半の hide で回収できない。`EmptyWorkingSet` はスレッド非依存ゆえ IPC スレッドの `notify_main_hidden` からも安全に呼べる（suspend_webview のような with_webview 非同期制約がない）
+2. **新規モジュール `src-tauri/src/working_set.rs`** に集約。理由: 呼び出しが 2 モジュール（main.rs / commands/system.rs）にまたがるため共有が必要（DRY）。BFS の純ロジックを純関数に切り出してユニットテスト可能にする。main.rs 肥大化も回避
+3. **show 経路に対応操作は追加しない**。trim の「逆」は OS の透過 re-fault で自動。明示 untrim API は存在しない（対称性の非対称はこれが正しい）
+4. **best-effort・panic しない**（release は `panic="abort"`）。全 Win32 失敗を握りつぶす
 
-| ファイル | 変更 |
-|---|---|
-| `snotra-core/src/engine.rs` | `IndexInputs`（5 キー単一定義, `From<&Config>`, `PartialEq`）/ `index_stale: bool` フィールド / `mark_index_stale` / `begin_index_drain` / `complete_index_drain` / `is_index_stale` を追加。コンストラクタで `index_stale: false` 初期化。`update_config` は据え置き |
-| `src-tauri/src/config_watcher.rs` | `needs_reindex` 削除（テストも）。index 判定を `IndexInputs` 差分に。`!indexing_in_progress` ゲート撤去（常に kick）。`Ordering` import 削除 |
-| `src-tauri/src/indexing.rs` | `start_index_build` を drain ループに書き換え（mark→CAS→spawn→begin/build/complete ループ→finish→post-finish 再チェック）。`catch_unwind` で panic でも finish。in-flight `needs_rebuild` 削除 |
-| `snotra-core/CLAUDE.md` / `src-tauri/CLAUDE.md` | engine の index_stale ledger / drain ループ / panic-safety / gate 撤去を記録 |
-| `docs/design/...staleset.md` §8 | Phase 2 実装済み + スケッチからの確定点を追記 |
+## 変更ファイル一覧
 
-## スケッチ §4 からの確定点（マルチパースペクティブレビュー反映）
+### 1. `src-tauri/src/working_set.rs`（新規）
+- `pub(crate) fn collect_descendant_pids(pairs: &[(u32 /*pid*/, u32 /*ppid*/)], root: u32) -> Vec<u32>`
+  - 純関数。root を含む子孫 PID を BFS で収集。循環参照（ppid が自己/既訪問）に対してガード（visited セット）。**ユニットテスト対象**
+- `#[cfg(windows)] pub(crate) fn trim_idle_working_set(root_pid: u32)`
+  - `CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)` → `Process32FirstW`/`Process32NextW` で `(th32ProcessID, th32ParentProcessID)` を収集 → `collect_descendant_pids` → 各 PID に対し `OpenProcess(PROCESS_QUERY_INFORMATION|PROCESS_SET_QUOTA, false, pid)` → `EmptyWorkingSet` → close。全失敗はスキップ
+  - 自プロセスは root_pid として収集に含め、他の PID と統一的に OpenProcess する（`GetCurrentProcess()` 疑似ハンドル分岐は YAGNI、統一処理で DRY）
+- **ハンドルは RAII ガードで閉じる（要対処・plan-review 指摘）**: 明示 `CloseHandle` は `?`/`continue`/early-return で漏れやすい。`icon.rs:255` の `BitmapCleanup` に倣い、`struct HandleGuard(HANDLE)` + `impl Drop`（`if !is_invalid() { CloseHandle }`）を `working_set.rs` 内に定義し、`CreateToolhelp32Snapshot` の HANDLE と各 `OpenProcess` の HANDLE を生成直後に wrap する。全分岐で確実に解放
+- `#[cfg(not(windows))] pub(crate) fn trim_idle_working_set(_root_pid: u32) {}`（no-op）
+- `#[cfg(test)] mod tests`: `collect_descendant_pids` の純テスト（OS 非依存で全 CI 実行可）
 
-1. **bit を立てるのは `start_index_build`**（`update_config` でなく）。first-run / 手動 rebuild は config 変更を伴わないため。`update_config` の呼び出し元は config_watcher 唯一と確認済み → 取りこぼしなし
-2. **finish 後に `is_index_stale` 再チェック → 再 kick**（complete clear〜finish の窓を閉じる）
-3. **build を `catch_unwind` で包み panic でも `finish_index_build`**（panic wedge 対策＝レビュー Agent 1 検出。panic 経路は再 kick せず無限リトライ回避）
+#### windows 0.62.2 API 実装注意（plan-review でソース確認済み）
+- API は全て 0.62.2 で利用可能（`EmptyWorkingSet`→`Win32_System_ProcessStatus` / Toolhelp 群→`Win32_System_Diagnostics_ToolHelp` / OpenProcess 等→`Win32_System_Threading` 既存 / `CloseHandle`→`Win32_Foundation` 既存）
+- `PROCESSENTRY32W` は `Default`（zeroed）。**`Process32FirstW` 前に必ず `entry.dwSize = size_of::<PROCESSENTRY32W>() as u32` を設定**（未設定だと失敗）
+- 戻り値型: `CreateToolhelp32Snapshot`→`Result<HANDLE>`、`Process32FirstW/NextW`/`OpenProcess`(`Result<HANDLE>`)/`EmptyWorkingSet`/`CloseHandle`→`Result<_>`。`GetCurrentProcess`→`HANDLE`（Result でない）。全て `if let Ok(..)` / `let Ok(..) else` で扱い、**`unwrap`/`expect`/添字アクセスを使わない**（best-effort・panic させない）
+- `PROCESS_QUERY_INFORMATION | PROCESS_SET_QUOTA` は `PROCESS_ACCESS_RIGHTS` の `BitOr` 実装で型的に通る
 
-## TDD（実施済み）
+### 2. `src-tauri/src/main.rs`
+- `mod working_set;` を追加
+- hotkey-hide 経路（L579-581 付近、`suspend_webview(&w)` の直後）に `working_set::trim_idle_working_set(std::process::id());` を追加
 
-- engine 層（スレッド不要・AppHandle 非依存）:
-  - `fresh_engine_is_not_index_stale` / `mark_index_stale_makes_begin_return_current_inputs`
-  - `complete_index_drain_clears_stale_when_config_stable`
-  - **`complete_index_drain_keeps_stale_when_config_changed_during_build`**（lost-update #348-A の核。RED→GREEN: 仮実装の無条件 clear で失敗→条件付き clear で通過）
-  - `index_inputs_differ_on_each_index_key` / `index_inputs_equal_when_unrelated_key_changes`（needs_reindex テストの移設先）
-- 検証: snotra-core **373** / snotra **32** / clippy 正規ゲート **green**
+### 3. `src-tauri/src/commands/system.rs`
+- `notify_main_hidden`（L41-44）の `emit("window-hidden")` の後に `crate::working_set::trim_idle_working_set(std::process::id());` を追加
 
-## 不変条件（維持を確認）
+### 4. `src-tauri/Cargo.toml`
+- `windows` features に `Win32_System_ProcessStatus`（EmptyWorkingSet）と `Win32_System_Diagnostics_ToolHelp`（CreateToolhelp32Snapshot / PROCESSENTRY32W / Process32FirstW/NextW）を追加
 
-ロック最小化（重い build はロック外・begin/complete/mark は O(1)〜O(scan)）/ INDEX_WRITE_LOCK 単一書き手 /
-CAS 二重ビルド防止 / first-run・手動 rebuild が壊れない / 新しい同期軸を増やさない（index_stale は engine Mutex 上）/
-panic で flag 固着しない（catch_unwind + 必ず finish）。
+### 5. `src-tauri/CLAUDE.md`（ドキュメント同期）
+- **モジュール構成セクション**に `working_set.rs` を追加（新規 .rs ファイル、AGENTS.md 規定）。文言例: 「`working_set.rs`: 非表示アイドル時に Win32 `EmptyWorkingSet` でプロセスツリー全体の working set を回収（Windows のみ、非 Windows は no-op）。`collect_descendant_pids()` は Toolhelp の (pid,ppid) 上を BFS する純関数（ユニットテスト対象）。best-effort・失敗は握りつぶす」
+- 「WebView2 TrySuspend / Resume パターン」節に EmptyWorkingSet 併用を追記:
+  - hide 時、`suspend_webview` の後（hotkey 経路）/ `notify_main_hidden`（全 frontend 経路）で trim を呼ぶ
+  - **TrySuspend と EmptyWorkingSet は別レイヤー**: TrySuspend=論理目標（MemoryUsageTargetLevel.Low、圧迫待ち）、EmptyWorkingSet=物理 working set の即時トリミング。補完的で競合しない
+  - `EmptyWorkingSet` はスレッド非依存（with_webview 非同期制約がない）ため frontend hide（tokio スレッド）からも適用可
+  - show 側に逆操作は不要（OS が透過 re-fault）。trim は hide 前後どちらで走っても無害（再 fault するだけ・OS page 標準動作）
+  - 削減対象は物理 RAM（working set）のみ、commit は不変
 
-## マルチパースペクティブレビュー結果（実装前）
+## 実装順序
 
-- **並行性**（Agent 1）: 全インターリーブで lost-update / 二重ビルド / 無限ループなしを確認。**panic wedge を検出→ catch_unwind で同梱修正**
-- **呼び出しグラフ / first-run**（Agent 2）: first-run・手動 rebuild・キー集合・icon prune 冪等性すべて問題なし
-- **不変条件 / 乖離**（Agent 3）: 乖離（start_index_build が bit を立てる）は first-run 由来の正当な確定。`update_config` 呼び出し元は config_watcher 唯一で取りこぼし穴なし。TDD 強化を要対処→実施
+1. `working_set.rs` 作成（純関数 + Win32 + no-op + テスト）→ `cargo test -p snotra`（純関数テストが落ちることを確認 = Red → Green）
+2. `Cargo.toml` に features 追加
+3. `main.rs` に `mod` 宣言 + hotkey-hide 呼び出し
+4. `system.rs` に notify_main_hidden 呼び出し
+5. `cargo check` / `cargo clippy`
+6. ドキュメント同期（CLAUDE.md）
+7. リリースビルドで手動計測（hide → Private WS 数MB、show → ~44ms・UI 正常）
 
-## 未テスト範囲（許容・記録）
+## 不変条件
 
-finish 窓 / CAS / panic 経路はスレッド + AppHandle を要し単体テスト不可。engine 層の状態機械テスト + state.rs の CAS テスト
-+ コードレビューで担保。決定論テスト不能な並行部分は既存方針（state.rs を分離テスト）に倣う。
+- **trim は機能挙動を変えない**: ウィンドウの hide/show・状態機械・IPC 契約は不変。物理メモリ working set のみ縮小。失敗しても「メモリが減らない」だけ
+- **best-effort で panic しない**: Toolhelp/OpenProcess/EmptyWorkingSet の全失敗を握りつぶす（release `panic="abort"` のため panic させない）
+- **ハンドルリーク防止（生成/破棄ペア）**: `CreateToolhelp32Snapshot` の HANDLE と各 `OpenProcess` の HANDLE は必ず `CloseHandle` する。早期 return パスでも漏らさない（RAII ガード or 明示 close を全分岐に）
+- **BFS の停止性**: `collect_descendant_pids` は visited セットで循環（ppid 参照の輪・自己参照）を防ぎ必ず停止する。PID 再利用で実在しない ppid を指していても、存在する pid 集合内でのみ辿るので無限ループしない
+- **異常順序/失敗時**: trim が visible なウィンドウに対して race で走っても無害（再 fault するだけ）。hide 前に走っても最終的に hide されれば trim 効果は次のアイドルで効く
 
-## 残り（別サイクル）
+## テスト方針
 
-- **Phase 3**: `docs/architecture.md` に StaleSet 契約 + 設計メモ参照、`.claude/rules/*` 同期（相談のうえ）
-- #348 欠陥 A（lost-update 窓）は本 Phase で解消 → #348 はクローズ可。#347 は Phase 3 完了で完結
+- **ユニットテスト**（`working_set.rs` `#[cfg(test)]`、OS 非依存）:
+  - `collect_descendant_pids`: (a) 単純な親→子→孫の連鎖、(b) 複数子・孫（browser→{renderer,gpu,utility} の実形状を模す）、(c) 循環参照でも停止、(d) root のみ（子なし）、(e) 無関係プロセス混在で巻き込まない
+- **Win32 部分はユニットテストしない**（AGENTS.md）。手動計測で代替
+- **検証コマンド**（`docs/build-commands.md` 準拠）:
+  - A: `cargo check -p snotra-core -p snotra -p snotra-settings` / `cargo clippy -p snotra-core -p snotra -p snotra-settings -- -D warnings` / `cargo test -p snotra`（working_set テスト）
+  - C（ウィンドウ表示順に触れる）: `npm run smoke:startup` / `npm run e2e:tauri`
+- **手動計測**（リリースビルド、調査時の PowerShell スクリプト再利用）:
+  - hide（hotkey）→ 非表示 Private WS が数MB に落ちる
+  - hide（フォーカス喪失：別ウィンドウをクリック）→ 同様に落ちる ← frontend 経路の確認
+  - show → ~44ms 維持・検索結果/アイコン正常描画
+  - メモリ圧迫下の再表示レイテンシ最悪値
+
+## SPEC.md 更新要否
+
+**不要**（research.md 参照）。SPEC は suspend_webview/メモリ機構を記載しておらず、本変更はユーザー可視挙動・状態機械・IPC 契約を変えない内部最適化。文書化は src-tauri/CLAUDE.md に閉じる。issue 本文の「SPEC 同期（必須）」は撤回（実装後に issue へコメントで訂正）。
+
+## セルフレビュー
+
+### 5a. check スキル結果
+- **/plan-review**（Explore × 3 並列）実施済み。総評: completeness 高、着手可。
+  - 経路網羅性: (A)hotkey + (B)notify_main_hidden で全 hide 経路（focus-lost / Escape / click / Enter / Shift+Enter / slash）を網羅。frontend は `hideMainWindow → notifyMainHidden` に統一済みで漏れなし
+  - windows 0.62.2 API: 使用予定 API 全て正当とソース確認。実装注意（dwSize 初期化・Result 型・no unwrap）を計画に反映済み
+  - **要対処 1 件（反映済み）**: ハンドルリーク → RAII `HandleGuard`（icon.rs `BitmapCleanup` 踏襲）に修正
+- **/symmetric-check**: 対称ペア show/hide の検証は plan-review Agent 1 が実施。結論: hide→trim の show 側カウンターパートは**不要**（EmptyWorkingSet に逆操作 API はなく、show 時に OS が透過 re-fault する）。suspend_webview↔resume_webview の既存対称は不変。→ 対称適用漏れなし
+- **/cache-check**: 非該当（キャッシュ・incremental ロジックに触れない）
+
+### 5b. チェックリスト
+1. **対称コードパス**: ✓ show/hide 検証済み（上記）。trim は hide 側のみ、show 側は OS 自動 re-fault で対称
+2. **影響範囲の網羅性**: ✓ hide 経路を grep 列挙（main.rs hotkey / system.rs notify_main_hidden / ui の hideMainWindow 集約）。2 チョークポイントで全網羅
+3. **境界条件**: ✓ BFS の循環/自己参照/PID 再利用/root のみ/無関係混在をテストケース化。Win32 失敗（snapshot/OpenProcess）は best-effort スキップ
+4. **リソース管理**: ✓ HANDLE 生成/破棄ペアを RAII `HandleGuard`(Drop→CloseHandle) で保証（要対処を反映）
+5. **既存パターンとの整合**: ✓ best-effort・`#[cfg(windows)]`/no-op ペア（suspend_webview 踏襲）、RAII ガード（BitmapCleanup 踏襲）。新規パターンなし
+6. **YAGNI 違反**: なし。2 call-site は frontend hide（最多経路）を覆うため必要。GetCurrentProcess 疑似ハンドル分岐は YAGNI として排除し統一 OpenProcess に
+7. **シンプル化の挑戦**: 新規状態（AtomicBool/Mutex/子プロセス）を**導入しない**——trim はステートレスな関数呼び出し。失敗時は「メモリが減らないだけ」で副作用ゼロ。これ以上単純化すると hide 経路網羅を落とす
+8. **破壊不変条件の明示**: 本変更に「壊れたら即アウト」の不変条件は**ない**（best-effort・機能挙動不変）。検知手段: collect_descendant_pids ユニットテスト + 手動メモリ計測（hide 後 Private WS 数MB / show ~44ms / UI 正常）+ smoke:startup / e2e:tauri で起動・表示の回帰検知
+
+### 判定
+- completeness: **高**
+- 着手可否: **可**（要対処はすべて plan.md に反映済み）

--- a/workspace/research.md
+++ b/workspace/research.md
@@ -1,110 +1,46 @@
-# research.md — issue #347 config↔派生状態コヒーレンシ所有の一元化（StaleSet 契約）
-
-> このサイクルは **設計先行**（ユーザー合意済み）。成果物は本 research.md と
-> `docs/design/2026-05-31-coherence-staleset.md` の設計メモまで。実装は合意後の別サイクル。
-> #348 の 2 症状は #347 の StaleSet 機構に**統合**する前提で設計する（ユーザー合意済み）。
+# research — issue #355: 非表示時に WebView2 プロセスツリーへ EmptyWorkingSet を適用
 
 ## issue の要約
 
-config は単一の source of truth だが、その派生消費者が **2 つの異なる整合契約**に分かれ、
-それを束ねる「コヒーレンシ所有者」がいない。
+ランチャーは 99% 非表示常駐。実機計測（installed release / 32GB・SSD）で、非表示アイドルの Private WS ≈ 110MB が、既存の `TrySuspend`/`MemoryUsageTargetLevel.Low` では**全く回収されない**（圧迫なし実機では OS が working set をトリミングしないため。120 秒放置でも不変）ことが判明。hide 経路で Win32 `EmptyWorkingSet` をプロセスツリー全体に能動適用し、アイドル常駐を **110MB → 数MB（約 107MB 回収）** する。再表示レイテンシは実測で劣化しない（無圧迫 41ms / 圧迫下 44ms、UI 正常性も目視確認済み）。
 
-- **カテゴリ A（live-read 型）**: 毎操作で config を読み直す → 設定変更が自動で即時整合
-- **カテゴリ B（構築時焼き込み型）**: config 値が長命オブジェクトに凍結される → 整合には再構築が必要
+## 関連コード
 
-`Engine` は `config` + `search_engine` + `history` を単一 Mutex で共同所有する自然な所有者だが、
-`update_config` は **config を差し替えるだけで派生状態に触れない**。結果、カテゴリ B の整合責任が
-Engine の外（config_watcher → needs_reindex → start_index_build の非同期ループ）へ追放され、
-しかも **index 由来（entries+kana）だけ**がカバーされ、`HistoryStore.top_n` は漏れている。
+- `src-tauri/src/main.rs`
+  - `suspend_webview()` / `resume_webview()`（L162-207）: 既存の WebView2 メモリ機構。trim ヘルパーはこれと対をなす位置づけ
+  - hotkey-hide 経路（hotkey-pressed リスナー内 L564-581）: `w.hide()` → `emit("window-hidden")` → `suspend_webview(&w)`。**ここが hotkey トグル hide のチョークポイント**
+  - `std::process::id()` で自 PID を取得
+- `src-tauri/src/commands/system.rs`
+  - `notify_main_hidden()`（L41-44）: `main_visible=false` + `emit("window-hidden")`。**フロントエンド起因 hide 全経路（フォーカス喪失・Escape・クリック起動・スラッシュ）の IPC チョークポイント**。現状ここでは suspend していない（with_webview 非同期制約のため）
+- `ui/src/MainApp.tsx` / `ui/src/lib/commands.ts`: フロントエンド hide は `api.notifyMainHidden()` + `win.hide()` を呼ぶ（L53-54 フォーカス喪失、L293-294 クリック起動、commands.ts L19-20 スラッシュ等）。hotkey-hide の `window-hidden` リスナー（MainApp L90）は `setMainVisible(false)` のみで notifyMainHidden は呼ばない → hotkey と frontend は別経路
+- `src-tauri/Cargo.toml`: `windows = "0.62.2"` features。現状 `Win32_System_Threading`（OpenProcess/GetCurrentProcess/PROCESS_*）・`Win32_Foundation`（CloseHandle）は有効だが、**`Win32_System_ProcessStatus`（EmptyWorkingSet）と `Win32_System_Diagnostics_ToolHelp`（CreateToolhelp32Snapshot/PROCESSENTRY32W）は未宣言**
+- `src-tauri/CLAUDE.md`: 「WebView2 TrySuspend / Resume パターン」節がメモリ機構の文書ホーム
 
-→ `update_config` を「config を差し替え、**どの派生物が stale になったか**を記録/反映する」
-**単一のコヒーレンシ・チョークポイント**にする。重い再構築はロック外（PrebuiltIndex パターン）を維持。
+## 既存パターン
 
-## 関連コード（コヒーレンシ・アーキテクチャの精査）
-
-### カテゴリ A（live-read 型）— 即時整合。**変更しない**
-
-すべて `Engine` が毎操作で `self.config` から読み直す（`engine.rs`）:
-
-| 派生値 | 読み取り箇所 | config ソース |
-|---|---|---|
-| `mode` | `engine.rs:80` `SearchMode::from(config.search.normal_mode)` | `normal_mode` |
-| `normalization` | `search.rs:68` `SearchOptions::from` | `history_normalization` |
-| `fuzzy_history_cap_ratio` | `search.rs:69` | `fuzzy_history_cap_ratio` |
-| **`migemo_enabled`（フラグ）** | `search.rs:70` → `kana_query` を計算するか否か | `migemo_enabled` |
-| `migemo_min_chars` | `search.rs:71` | `migemo_min_chars` |
-| **検索の取得上限 `fetch_limit`** | `engine.rs:83` `effective_top_n_history()` | `top_n_history` |
-| `recent_history` の `max` | `engine.rs:89` `effective_max_history_display()` | `max_history_display` |
-| folder ctx（mode/hidden/max） | `engine.rs:95-97` | `folder_mode`/`show_hidden_system`/`top_n_history` |
-
-> **重要な分裂**: `migemo_enabled` は **フラグとしては A**（`kana_query` を作るかの即時判定）だが、
-> **`kana_lower_names` の構築入力としては B**。同様に `top_n_history` は **検索取得上限としては A**
-> （`fetch_limit` live-read）だが **`HistoryStore.top_n` としては B**。
-> 一つの config キーが両カテゴリにまたがるため、「キー単位」での整合判断は誤りを生む。
-> stale は **派生オブジェクト単位**で追う必要がある。
-
-### カテゴリ B（構築時焼き込み型）— 再構築が必要
-
-| 派生オブジェクト | 焼き込み箇所 | config 入力 | 整合の現状 |
-|---|---|---|---|
-| `SearchEngine`（entries + lower_names + char_masks + normalized_keys + **kana_lower_names**） | `engine.rs:46/63` `new_with_migemo` / `new_with_cached_masks`、構築は `compute_wave1`/`compute_wave2`（`search.rs`） | `scan` / `show_hidden_system` / `include_path_env` / **`migemo_enabled`** | ✅ config_watcher の非同期ループでカバー |
-| **`HistoryStore.top_n`** | `history.rs:37-47` `load(top_n)`、`main.rs:404` で起動時焼き込み。`prune()`（`history.rs:192-214`）が使用 | `top_n_history` | ❌ **reconcile ループに含まれていない**。setter も無い |
-
-### index 由来 B の整合ループ（現状）と 3 つの同期軸
-
-`config_watcher.rs::apply_config_change`:
-1. `Config::load_reporting()` で新 config 読込
-2. `update_config(new_config)`（`engine.rs:148-150`）— **config 差し替えのみ**
-3. `needs_reindex(old, new)`（`config_watcher.rs:211-217`）が true かつ `!indexing` なら `start_index_build`
-
-`indexing.rs::start_index_build`（背景スレッド）:
-1. engine ロック内で index 入力 5 つをキャプチャ（`scan`/`show_hidden_system`/`show_icons`/`include_path_env`/`migemo_enabled`、`indexing.rs:32-42`）
-2. ロック外で `rebuild_and_save` + `PrebuiltIndex::new`（`indexing.rs:44-74`）
-3. engine ロック内で `apply_prebuilt_index`（O(1) スワップ、`indexing.rs:75-78`）
-4. engine ロック内で **完了後 needs_rebuild 再判定**（`indexing.rs:81-90`、キャプチャ値 vs 現在 config）
-5. `finish_index_build()`（`state.rs:32-35`）
-6. `if needs_rebuild { start_index_build(再帰) }`（`indexing.rs:106-108`）
-
-**この整合は 3 つの分離した同期軸にまたがる**:
-- **軸1: engine Mutex**（`state.rs:7`）— `update_config` / `apply_prebuilt_index` / 完了後 needs_rebuild 読み取り
-- **軸2: `indexing` / `index_build_started` AtomicBool**（`state.rs:8-9`）— UI 表示 + 二重ビルド防止 CAS（`try_begin_index_build` / `finish_index_build`）
-- **軸3: `INDEX_WRITE_LOCK`**（`indexer.rs:520`）— `index.bin` の単一書き手
-
-**コヒーレンシの正しさが軸1と軸2の両方に依存しているのが構造的弱点**（→ lost-update 窓 = #348 欠陥 A）。
-
-### キー集合の二重メンテ（migemo 特別扱いの正体）
-
-index 入力キーの集合が **2 箇所**に重複定義されている:
-- `config_watcher.rs:211-217` `needs_reindex`（変更検出側）
-- `indexing.rs:85-90` 完了後 `needs_rebuild`（in-flight 再判定側）
-
-#337 で migemo を追加したとき、**両方**に同時に入れる必要があった（`snotra-core/CLAUDE.md` /
-`.claude/rules/snotra-core-search.md` に「両方に含める」と明記）。この「同一キー集合の対称二重メンテ」が
-新しい index 入力を足すたびに対称漏れリスクを生む。StaleSet ではこの集合を **1 箇所**に集約できる。
-
-## 既存パターン（再利用できるもの）
-
-- **PrebuiltIndex（ロック外構築 → atomic swap）**: 重い再構築をロック外に追い出す確立パターン（`engine.rs:28-36`/`160-162`）。StaleSet の「重い drain」はこれをそのまま使う
-- **「開始時キャプチャ vs 完了後の現在値」比較**（`indexing.rs:32/81`、AGENTS.md パターン）: 設計の「完了後 re-diff で stale を条件付きクリア」はこの一般化
-- **CAS 二重起動防止**（`state.rs:18-28` `try_begin_index_build`）: drain の単一実行保証に流用。StaleSet を入れても CAS はそのまま
-- **FolderListContext（スナップショット）**（`engine.rs:93-111`）: ロック外処理に config スナップショットを渡すパターン。index snapshot も同型
-- **Engine facade（単一 Mutex）**（`state.rs:7`、`src-tauri/CLAUDE.md`）: config + 派生状態が同一ロック下にあるため、stale ledger を engine ロック軸に載せれば「変更検出軸 = 整合判断軸」に統合できる
-- **`#[must_use]` によるフラグ戻し漏れ検出**（AGENTS.md「状態フラグも真偽ペア」）: stale bit の set/clear ペア設計に適用
+- **WebView2 TrySuspend/Resume**（main.rs）: hide 時 suspend、show 時 resume。best-effort・silently-ignore の作法。trim ヘルパーも同じ best-effort 作法に揃える
+- **`#[cfg(windows)]` / `#[cfg(not(windows))]` ペア**: suspend_webview 等が踏襲。trim ヘルパーも Windows 実装 + 非 Windows no-op で揃える
+- **プロセスツリー走査**: 調査時の PowerShell スクリプトが Toolhelp 相当の (pid,ppid) BFS を実証済み（renderer/gpu/utility は browser プロセスの孫なので全ツリー走査が必須）
 
 ## 技術的制約
 
-- **ロック最小化原則（絶対）**: 重い再構築（秒単位）を engine ロック内でやってはならない（`src-tauri/CLAUDE.md` ロック最小化節）。変えるのは「整合の所有と網羅」であって「同期 vs 非同期」ではない
-- **レイヤー境界**: `snotra-core` は Tauri に依存できない。スレッド spawn・`AppHandle`・イベント emit は `src-tauri` の責務。→ **コヒーレンシ判断（何が stale か・ループ要否）は Engine（snotra-core）、重い drain の駆動（スレッド）は src-tauri** に分離せざるを得ない
-- **`icons.bin` は src-tauri の資源**（`snotra-core` ルール「icons.bin に触れない」）。現状 `show_icons` が `needs_reindex` に含まれるのは index ビルドのついでにアイコンキャッシュを prune するため。厳密には `show_icons` は **icon-stale（src-tauri 所有）であって index-stale ではない** → スコープ境界として要明示
-- **`INDEX_WRITE_LOCK` 単一書き手契約を維持**（`indexer.rs`）。drain も `rebuild_and_save` 経由でこのロックを通る
-- **CAS 二重ビルド防止を維持**（`state.rs`）。`index_build_started` は CAS 専用、`indexing` は first-run でビルドスレッド不在でも true になる UI 表示用——2 フラグの役割分担を壊さない
-- **後方互換**: `HistoryStore.top_n` 追従を足しても history.bin フォーマットは不変（top_n は永続化されない実行時パラメータ）。マイグレーション不要
-- **Win32 非依存でテスト可能**: stale 判定ロジック・history top_n 追従は `snotra-core` 内ユニットテスト可能。lost-update 窓の状態遷移は `state.rs` のフラグ機構でテスト可能（AppHandle 非依存）
+- **Win32 API はユニットテスト前提にしない**（AGENTS.md）。`EmptyWorkingSet`/Toolhelp 呼び出し自体はテスト不可。BFS の純ロジック（(pid,ppid) リスト → 子孫 PID 収集）を純関数に切り出してユニットテストする
+- **`EmptyWorkingSet` はスレッド非依存**（純粋な Win32 プロセス API）。`suspend_webview` の「with_webview が IPC ハンドラスレッドだと非同期ディスパッチ」制約（src-tauri/CLAUDE.md）を持たないため、tokio スレッドで動く `notify_main_hidden` からも安全に呼べる → **全 hide 経路に適用可能**
+- **削減対象は物理 RAM（working set）であって commit ではない**（commit ~195MB 不変）
+- **EmptyWorkingSet に「逆操作」は不要**: trim されたページは show 時に OS が透過的に re-fault する。明示的な untrim API は存在せず、show 経路に対応操作を追加する必要はない（対称性の非対称はこれが理由）
+- **release は `panic = "abort"`**: ヘルパーは panic しない設計（全 Win32 呼び出しの失敗を握りつぶす best-effort）。catch_unwind 不要
+- **best-effort**: Toolhelp スナップショット失敗・OpenProcess 失敗（子プロセスが race で終了）は黙ってスキップ。失敗してもメモリが減らないだけで機能影響なし
 
-## 未解決の疑問（→ 設計メモで意思決定）
+## SPEC.md 更新要否（重要・issue の記述を訂正）
 
-1. **StaleSet の粒度**: bitflags（index-stale / history-stale / …）か、最小実装（index-dirty フラグ + config snapshot ＋ history はインライン reconcile）か。2 カテゴリしかない現状で bitflags は YAGNI か？
-2. **`show_icons` の扱い**: index-stale に含めたまま（現状維持・スコープ最小）か、icon-stale として分離（概念的に正しいが src-tauri 側の別機構）か
-3. **history-stale の drain モード**: 軽量（O(top_n)）なのでインライン reconcile（update_config 内で `set_top_n` + 必要なら prune）か、StaleSet の「軽量 drain クラス」として統一モデルに載せるか
-4. **失敗時の回復**: drain（ビルド）が失敗したとき stale bit は set のまま残す設計だが、再試行契機は「次の config 変更」のみで十分か、明示的リトライが要るか
-5. **収束性**: 完了後 re-diff で「config がビルド中に変わったらループ」する設計の停止性（config が落ち着けば収束する、の厳密化）
+issue 本文では「SPEC.md 同期（必須）」としたが、**調査の結果これは誤り**:
+
+- SPEC §8（ウィンドウ動作）は表示/非表示の**ユーザー可視挙動と状態機械**を記述するが、`suspend_webview`/TrySuspend/MemoryUsageTargetLevel/メモリ機構は**一切記載していない**（grep 確認済み）
+- EmptyWorkingSet は同層の内部メモリ最適化で、**ウィンドウの表示/非表示挙動・状態機械・IPC 契約を一切変えない**（窓は従来どおり hide/show する）
+- 既存姉妹機構（suspend_webview）が SPEC 非記載である以上、整合上も EmptyWorkingSet を SPEC に書く必要はない
+
+→ **SPEC.md 更新は不要**。文書化は `src-tauri/CLAUDE.md` の「WebView2 TrySuspend / Resume パターン」節に EmptyWorkingSet の併用を追記する形で行う（コンパニオン機構として）。
+
+## 未解決の疑問
+
+- なし（要求・実装方針とも確定）。設計判断「適用範囲＝全 hide 経路」は計画で確定（下記）


### PR DESCRIPTION
## 概要

非表示（hide）時に Win32 `EmptyWorkingSet` を Snotra プロセスツリー全体（自プロセス + WebView2 子孫）へ適用し、アイドル常駐の物理メモリ（working set）を回収する。

## 背景

既存の `TrySuspend` / `MemoryUsageTargetLevel.Low` は**論理目標**を下げるだけで、メモリ圧迫のない実機では OS が物理 working set を回収しない（実測: 非表示アイドル ~110MB が表示↔非表示・120 秒放置でも不変）。能動的に `EmptyWorkingSet` を適用することでアイドル RSS を大幅削減する。

## 変更

- **`src-tauri/src/working_set.rs`（新規）**
  - `collect_descendant_pids`: `(pid, ppid)` 上を BFS する純関数。`visited` で循環/自己参照/PID 再利用に停止性を保証。ユニットテスト 6 件（OS 非依存）
  - `trim_idle_working_set`: `CreateToolhelp32Snapshot` で `(pid, ppid)` 列挙 → BFS → 各 PID に `EmptyWorkingSet`。HANDLE は RAII `HandleGuard`（`Drop`→`CloseHandle`、`icon.rs` の `BitmapCleanup` 踏襲）で全分岐解放。best-effort で panic させない。非 Windows は no-op
- **`main.rs`**: hotkey-hide 経路で `suspend_webview` の後に trim
- **`commands/system.rs`**: `notify_main_hidden`（全 frontend hide の IPC チョークポイント）で trim。`EmptyWorkingSet` はスレッド非依存ゆえ tokio IPC スレッドから安全（`suspend_webview` の `with_webview` 非同期制約がない）
- **`Cargo.toml`**: windows features に `Win32_System_ProcessStatus` / `Win32_System_Diagnostics_ToolHelp` 追加
- **`src-tauri/CLAUDE.md`**: モジュール構成 + EmptyWorkingSet パターンを文書化

## 実測（release ビルド・32GB/SSD、Private WS）

| 状態 | Private WS |
|---|---|
| アイドル baseline | ~110 MB |
| **hotkey hide（自動 trim）** | **9.4 MB** |
| **Escape hide＝frontend 経路（自動 trim）** | **22.8 MB** |
| 再表示+検索（active） | ~98 MB |

再表示は体感即時を維持（先行調査で無圧迫 41ms / 圧迫下 44ms、ハード読込は圧迫下のみ）。trim+resume+検索後の UI/検索結果/アイコンは正常描画を目視確認。

## 検証

- `cargo check -p snotra-core -p snotra -p snotra-settings` ✅
- `cargo clippy -p snotra -- -D warnings` ✅（クリーン）
- `cargo test -p snotra working_set` ✅ 6/6
- `npm run smoke:startup`（release バイナリ）✅ 5/5・エラー 0
- 実機で hotkey / Escape 両 hide 経路の自動 trim と再表示正常を確認

## 補足

- **SPEC.md は更新不要**: メモリ機構（既存 `suspend_webview` 含む）は SPEC 非記載で、本変更はウィンドウ挙動・状態機械・IPC 契約を変えない内部最適化。文書化は `src-tauri/CLAUDE.md` に閉じた
- frontend 経路の trim は hotkey 経路よりやや控えめ（22.8 vs 9.4MB）。`notify_main_hidden` が tokio スレッドで `win.hide()` と並行するタイミング差によるもので、許容範囲。将来 hide 完了後への微小ディレイで改善余地あり
- `e2e:tauri` は tauri-driver/edgedriver の重いセットアップかつ検証対象（起動入力・`/o`）が本変更のスコープ外のため未実行（手動でライフサイクル検証済み）

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)
