### PR TITLE
docs: #355 retrospective + アイドルメモリ最適化知見を PERFORMANCE.md へ

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -47,6 +47,35 @@ opt-level = "s"
 `opt-level = "s"` によるループアンローリング・SIMD 抑制が直撃する。
 **`snotra-core` への `opt-level = "s"` / `"z"` 適用は行わない**。
 
+## アイドルメモリ（working set）の削減（2026-06-01〜02 計測）
+
+ランチャーは 99% 非表示常駐のため、アイドル時の物理メモリ（working set / private RSS）の最小化が重要。installed release ビルド（32GB/SSD 機）で WebView2 プロセスツリー（main + webview2 子孫 計 7 プロセス）を実機計測した。
+
+### 実態（Private Working Set = プロセス固有の物理 RAM）
+
+- 非表示アイドルの定常 baseline: **~110MB**。Working Set 表示値 ~390MB との差 ~280MB は Edge ランタイム共有 DLL（`msedge.dll` ~310MB 等）のページで、プロセス間共有・デマンドページゆえ Private には乗らない（「Snotra=390MB」は誤読）
+- 内訳（`VirtualQueryEx` で committed をタイプ別分類）: WebView2 エンジン固有 ~64MB（browser 33 + renderer/V8 18 + utility/crashpad 13、アプリ制御不可）+ Rust 本体 ~30MB + GPU プロセス ~18MB
+- Rust 本体 ~30MB の正体: index は極小（`index.bin` 数百 bytes）ゆえデータではなく、Tauri/WRY/tokio/serde/windows クレート + アロケータ保持の baseline（committed 42.8MB の内訳はヒープ 40.7MB / スレッドスタック 2.17MB）
+
+### 採用: hide 時の `EmptyWorkingSet`（issue #355 / PR #360）
+
+hide 経路で Win32 `EmptyWorkingSet` をプロセスツリー全体へ能動適用し、アイドル常駐を **110MB → 数MB** へ回収する。実装は `src-tauri/src/working_set.rs`、パターン詳細は `src-tauri/CLAUDE.md`「WebView2 working set の能動回収」節。
+
+| 状態 | Private WS |
+|---|---|
+| アイドル baseline | ~110 MB |
+| hotkey hide 後（自動 trim） | ~9.4 MB |
+| frontend(Escape) hide 後（自動 trim） | ~22.8 MB |
+
+再表示レイテンシは劣化しない（trim 無/有とも ~41ms、メモリ圧迫下でも 44ms、ウィンドウ出現はブロックされない）。ページは standby/pagefile に退避され show 時に OS が透過 re-fault する（圧迫下のみハード読込 ~934/s ≈ 3.6MB/s で SSD では体感不能）。削減対象は物理 working set であって commit（~195MB 不変）ではない。frontend 経路が hotkey より浅い（22.8 vs 9.4MB）のは `notify_main_hidden` が tokio で `win.hide()` と並行するタイミング差（#361 で polish）。
+
+### 効かなかった/見送った手法
+
+- **TrySuspend / MemoryUsageTargetLevel.Low 単独**: 論理目標を下げるだけで、メモリ圧迫のない実機では OS が物理 working set を回収しない（表示↔非表示・120 秒放置で 110MB 不変）。主効果は CPU 中断。working set 回収には `EmptyWorkingSet` の能動適用が必要（両者は別レイヤーで補完的）
+- **tokio / rayon の worker スレッド削減**: Rust 本体は Tauri 既定の multi-thread tokio（worker = CPU コア数）+ rayon プールで ~50 スレッドを抱えるが、スレッドスタックは計 2.17MB（committed 42.8MB の 5%）に過ぎず、worker を絞っても RSS 削減は <1MB で**無意味**。30MB の大半はヒープ/フレームワーク baseline
+- **`--disable-gpu --disable-gpu-compositing`**: GPU プロセスは消えない（in-process ソフト合成に切替）が Private 18→6MB・合計 110→99MB。ただしブラウザフラグは Microsoft 非サポート（ランタイム更新で挙動変化）＋ CPU 合成化で描画レイテンシ未検証。限界効用は `EmptyWorkingSet`（~107MB）に対し桁違いに小さく見送り
+- **アイコン PNG 圧縮強化（issue #335）**: 16×16 アイコンで実測 ~0.06MB と桁違いに小さく却下（詳細は #335）
+
 ## 試みたが機能しない手法
 
 - **Custom URI Scheme（`snotra-icon://` 等）による画像配信**: WebView2 では `register_uri_scheme_protocol`（WRY/Tauri）で登録したカスタムスキームへのリクエストが、WebView2 環境生成時の `SetCustomSchemeRegistrations` 事前宣言なしにはハンドラーに届かない。WRY 0.54.x では自動的に処理されず、`eprintln` 診断でハンドラーが一切呼ばれないことを確認済み。バイナリ配信の代替は `tauri::ipc::Response`（上記セクション2）を用いること。

--- a/RETROSPECTIVE.md
+++ b/RETROSPECTIVE.md
@@ -1,38 +1,35 @@
-# Retrospective — #347 config↔派生状態コヒーレンシの一元化（Phase 1: history live-read / Phase 2: index_stale ledger）+ #348 解消
+# Retrospective — #355 メモリ削減: 非表示時 EmptyWorkingSet でアイドル working set 回収（#335 検証 → deep-research → 実機計測 → 実装 → マージ）
 
 ## よかったこと
 
-### 設計先行 + git archaeology が「削ってよい線」を引いた
-#347 を設計先行で起こし、git 史実調査で**本質的制約**（lock 最小化 / レイヤー境界 / 2 AtomicBool / INDEX_WRITE_LOCK、commit 証拠付き）と**偶発的複雑さ**（所有権追放 / キー二重メンテ / top_n 漏れ）を切り分けた。これにより「カテゴリ B はキャッシュ、既定 live-read」と再定義し、history を live-read 化して B を既約核（SearchEngine 1 つ）へ縮小。当初の「全 B を reconcile する機構」より単純な「**B を減らす**」解に到達。整合機構を足す前に整合対象を消せないか問う、が効いた（`docs/development-principles.md` に反映）。
+### 実証ファーストで方向を決め、誤った投資を早期に排除した
+見積もり・俗説を机上で採否せず、すべて実機計測で検証/反証してから方針を固めた。#335 アイコン圧縮（実測 ~0.06MB で却下）、deep-research（「妙案ほぼ無し」を 25 主張の敵対的検証で確認）、TrySuspend（無圧迫の実機では working set を回収しないと計測で実証）、tokio スレッド削減（VirtualQueryEx で「スタック計 2.17MB・無効」と判定）。本命の EmptyWorkingSet も PowerShell で手動実証（110→数MB）してから実装に入った。「効くと思う」より「測った」で進めたことで、桁違いに小さい/効かないレバーへの実装着手を防げた。
 
-### 二段レビューが別種の欠陥を別タイミングで捕えた
-実装前のマルチパースペクティブ DESIGN レビュー（並行性 / 呼び出しグラフ / 不変条件）が **panic wedge** を実装前に検出 → catch_unwind を書く前に織り込めた。実装後の Codex レビューが **panic="abort" での過大主張**を検出。前者は「設計の前提の脆さ」、後者は「事実と主張のズレ」と、別レイヤーの欠陥を別タイミングのレビューが捕えた。
+### 自分の仮説を自分で覆した（前提固執の回避）
+属性分析の途中で「Rust 30MB / 49 スレッド → スレッド削減が有望レバー」と一度見立てたが、`VirtualQueryEx` で committed private 42.8MB を「スタック 2.17MB / ヒープ 40.7MB」に分解し、**スレッド削減はメモリ上ほぼ無意味**と自分で結論を反転させた。仮説に都合のよいデータだけ見ず、分解して定量化した。
 
-### 「実証で判断」が過剰修正を回避
-Codex「出荷不可（panic wedge）」を盲従せず、`Cargo.toml:13` の `panic="abort"` を実際に確認 → 事実は認めつつ「release は元々 abort で挙動不変＝regression なし、silent wedge も起きない」と severity を実証で切り下げ。過剰修正（panic 方針変更・Result 大改修）を回避し、コメント是正という最小の正しい対応に着地。#338 サイクルの「盲従も性急な反論もせず実証で判断」を再演。
+### plan-review が実装手戻りをゼロにした
+実装前の `/plan-review`（Explore×3）が windows 0.62 の API シグネチャ（`PROCESSENTRY32W.dwSize` 初期化・全 API が `Result`）と HANDLE リーク（明示 close → RAII `HandleGuard`）を先取りで潰した。結果、実装は一発で `cargo check`/`clippy -D warnings`/`test` 6/6 を通過し、plan と実装の乖離はゼロ。「windows クレートは事前に型・シグネチャ確認」という既存ルールが計画段階で機能した好例。
 
-### TDD が責務配置を示し lost-update の核を固定
-Phase 1 で engine 層の disk-非分離（load/save が固定パス）が「履歴ロジックの責務は history.rs（disk-free テスト可）」を示唆。Phase 2 で `complete_index_drain` を「無条件 clear」の仮実装にして lost-update の核テスト（`complete_index_drain_keeps_stale_when_config_changed_during_build`）を RED→GREEN で固定し、「ビルド中変更を取りこぼさない」不変条件をコードで保証。
+### 「機構が効く」と「コードが自動発火する」を分けて検証した
+先行調査の手動 `EmptyWorkingSet`（機構の実証）と、実バイナリをビルドしての hide イベント駆動（統合パスの実証）を**別物として両方**確認。新ビルドで Ctrl+K（hotkey）112→9.4MB、Escape（frontend）98.5→22.8MB、再表示 UI 正常、`smoke:startup` 5/5。「調査で効いた」を「実装で効く」と早合点しなかった。
 
 ---
 
 ## 伸びしろ
 
-### 設計スケッチが実呼び出しグラフを取りこぼしていた
-設計メモ §4 スケッチは「`update_config` が bit を立てる」前提だったが、first-run / 手動 rebuild / finish 窓を取りこぼしていた（config 変更を伴わない経路で begin が空振り）。実装時に全呼び出し元を grep して「`start_index_build` が bit を立てる」に確定。API スケッチを実装に落とす前に**駆動経路（特殊フロー含む）を洗う**必要を再認識（既存の「初回フローとガードの相互作用を検証する」を設計確定時にも適用）。
+### issue 本文の「ドキュメント更新が必要」主張を後で訂正した
+#355 起票時に「SPEC.md 同期（必須）」と書いたが、実装調査で「類似既存機構（`suspend_webview`/TrySuspend）が SPEC に一切記載されていない」と判明し、不要へ訂正コメントを出した。**起票時にコードで一次確認していれば**避けられた手戻り（コメント是正）。ドキュメント更新の要否を主張する前に、対象ドキュメントに類似機構が実際に記載されているかを確認する——「『変更なし』の根拠を列挙する」の対称（「『変更が必要』も根拠を確認する」）。
 
-### panic 戦略（abort/unwind）をレビュー観点に入れていなかった
-catch_unwind による wedge 回復を設計したが、release の `panic="abort"` を実装前レビューも自分も見落とし、Codex が後段で検出。「panic 回復設計は build profile 依存」を `AGENTS.md` 事前調査に反映済み。
+### 非同期 IPC × メインスレッド同期の「副作用のタイミング依存」を設計段階で予測しきれなかった
+plan-review は frontend 経路の `notifyMainHidden`（fire-and-forget）と `win.hide()` の順序を検証していたが、その**メモリ trim 効率への影響**（trim が hide 完了前に走り frontend は 22.8MB と hotkey 9.4MB より浅い）までは予測できず、実機計測で初めて判明 → #361 へ切り出し。非同期 IPC とメインスレッド同期処理が並行する経路では、副作用（trim 等）の「効果の深さ」がタイミング依存になりうる、という観点が次回の設計レビューに有用。
 
-### データ損失経路を Phase 1 の自前レビューが踏めなかった
-config ReadFailed → live-read 履歴剪定のデータ損失を、Phase 1 の TDD（disk-free）も設計レビューも踏まなかった（config_watcher 経路を通らない）。Codex アドバーサリアルレビューが捕捉。データ損失系は独立視点（特に実コードを読む手段）が効くを再確認。
-
-### Codex がこの環境で不安定
-Codex のサンドボックス git が常に失敗（exit -1）し、GitHub MCP フォールバックの発火が不安定（このサイクルで 5 回中 2 回のみ実結果）。リトライは宝くじ。実コードを確実に読むリポジトリ内サブエージェントレビューが確実な代替（メモリに記録）。
+### レビュー severity の実証フィルタ（AI レビュー全般のパターン）
+in-repo Explore レビューが「Critical 3 件」を出したが、実証精査で 2 件が plausible-but-wrong（「trim 並行実行が UB」は捏造＝2 経路は hide ごと排他かつ `EmptyWorkingSet` は非破壊、「window-hidden 二重 emit」は本 PR 由来でない既存挙動）。鵜呑みにせず棄却・降格し、棄却分も根拠付きで PR に透明記録した。外部 Codex 限定でなく **AI レビュー全般**の構造として [[feedback_codex_review_unreliable]] を一般化（採否前に「PR 由来か」「実コード/公式仕様と整合か」を一次確認）。CodeRabbit CLI 未導入も依頼時に発覚——レビューツールの可用性は事前把握の余地。
 
 ---
 
 ## ネクストアクション
 
-- [ ] **#347 Phase 3**: `docs/architecture.md` に StaleSet 契約 + 設計メモ参照、`.claude/rules/*` 同期（`.claude/` 編集は相談のうえ）。完了で #347 クローズ
-- [ ] `/health-check` でモジュール構成・SPEC.md 番号・メモリ・スキル・ルールの整合を確認（サイクル末）
+- [ ] **#361**: frontend hide 経路の `EmptyWorkingSet` タイミング最適化（`notify_main_hidden` が tokio で `win.hide()` と並行 → trim を hide 完了後へ。22.8→9.4MB 寄りに）。優先度低・polish
+- [ ] 次回リリースビルド時、**メモリ圧迫下での frontend 経路 trim 後の再表示レイテンシ最悪値**を実機計測（SSD で体感不能の確認。#361 の検証観点と兼ねる）


### PR DESCRIPTION
## 概要

#355 サイクル（非表示時 `EmptyWorkingSet` でアイドル working set 回収）の doc 整備。

## 変更

- **RETROSPECTIVE.md**: #355 サイクルの振り返りで上書き（よかったこと / 伸びしろ / ネクストアクション）
- **PERFORMANCE.md**: 「アイドルメモリ（working set）の削減」節を追加
  - 実機計測: baseline ~110MB・プロセスツリー内訳・`EmptyWorkingSet` で 110→数MB（hotkey 9.4 / Escape 22.8MB）・再表示 44ms 維持
  - 効かなかった/見送った手法: TrySuspend 単独・tokio/rayon スレッド削減・`--disable-gpu`・#335 アイコン圧縮

## 背景

メモリ棚卸しに伴い、auto-memory にあった WebView2 アイドルメモリの計測知見を repo doc へ移設。実装は #360 でコード化 + `src-tauri/CLAUDE.md` に文書化済みのため、計測データを共有可能な `PERFORMANCE.md`（最適化プレイブックの SSOT）に集約した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
