### PR TITLE
ci: ラベル付き PR で E2E & Smoke を自動実行し検証要件と整合 (#356)

### DIFF
--- a/workspace/plan.md
+++ b/workspace/plan.md
@@ -1,112 +1,114 @@
-# plan — issue #355: 非表示時に WebView2 プロセスツリーへ EmptyWorkingSet を適用
+# plan — issue #356: PR CI と smoke/E2E 検証要件の整合
 
 ## ゴール / 受け入れ条件
 
-- 全 hide 経路（hotkey トグル + フロントエンド起因：フォーカス喪失/Escape/クリック起動/スラッシュ）で、Snotra プロセスツリー全体（自プロセス + WebView2 子孫）の working set をトリミングする
-- 非表示アイドルの Private WS が baseline（~110MB）から数MB へ落ちる（手動計測で確認）
-- 再表示が体感即時を維持（~44ms、UI・検索結果・アイコンが正常描画）
-- 失敗時（Toolhelp/OpenProcess 失敗）は黙ってスキップ＝機能影響ゼロ（best-effort）
+- smoke/E2E を必須とする変更種別で、**PR 上の実行責任が明確**になっている。
+- `.claude/skills/deps-update/SKILL.md` の記述が実際の CI トリガーと**矛盾しない**。
+- エージェントが「**通常 CI 緑だけで smoke/E2E 済み**」と誤認しない。
 
-## 設計判断
-
-1. **適用範囲 = 全 hide 経路**（hotkey + frontend）。理由: ランチャーが最も多く隠れるのはフォーカス喪失（frontend 経路）であり、hotkey 限定では大半の hide で回収できない。`EmptyWorkingSet` はスレッド非依存ゆえ IPC スレッドの `notify_main_hidden` からも安全に呼べる（suspend_webview のような with_webview 非同期制約がない）
-2. **新規モジュール `src-tauri/src/working_set.rs`** に集約。理由: 呼び出しが 2 モジュール（main.rs / commands/system.rs）にまたがるため共有が必要（DRY）。BFS の純ロジックを純関数に切り出してユニットテスト可能にする。main.rs 肥大化も回避
-3. **show 経路に対応操作は追加しない**。trim の「逆」は OS の透過 re-fault で自動。明示 untrim API は存在しない（対称性の非対称はこれが正しい）
-4. **best-effort・panic しない**（release は `panic="abort"`）。全 Win32 失敗を握りつぶす
+**採用方針（ユーザー決定）**: 「CI を自動化する」。`e2e` ラベル付き PR で E2E workflow を自動実行。さらに同 workflow で **smoke:startup も実行**し、「`e2e` ラベル付き PR の CI 緑 = カテゴリ C（smoke + E2E）済み」を実態として真にする。health-check に対応チェックを追加。
 
 ## 変更ファイル一覧
 
-### 1. `src-tauri/src/working_set.rs`（新規）
-- `pub(crate) fn collect_descendant_pids(pairs: &[(u32 /*pid*/, u32 /*ppid*/)], root: u32) -> Vec<u32>`
-  - 純関数。root を含む子孫 PID を BFS で収集。循環参照（ppid が自己/既訪問）に対してガード（visited セット）。**ユニットテスト対象**
-- `#[cfg(windows)] pub(crate) fn trim_idle_working_set(root_pid: u32)`
-  - `CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)` → `Process32FirstW`/`Process32NextW` で `(th32ProcessID, th32ParentProcessID)` を収集 → `collect_descendant_pids` → 各 PID に対し `OpenProcess(PROCESS_QUERY_INFORMATION|PROCESS_SET_QUOTA, false, pid)` → `EmptyWorkingSet` → close。全失敗はスキップ
-  - 自プロセスは root_pid として収集に含め、他の PID と統一的に OpenProcess する（`GetCurrentProcess()` 疑似ハンドル分岐は YAGNI、統一処理で DRY）
-- **ハンドルは RAII ガードで閉じる（要対処・plan-review 指摘）**: 明示 `CloseHandle` は `?`/`continue`/early-return で漏れやすい。`icon.rs:255` の `BitmapCleanup` に倣い、`struct HandleGuard(HANDLE)` + `impl Drop`（`if !is_invalid() { CloseHandle }`）を `working_set.rs` 内に定義し、`CreateToolhelp32Snapshot` の HANDLE と各 `OpenProcess` の HANDLE を生成直後に wrap する。全分岐で確実に解放
-- `#[cfg(not(windows))] pub(crate) fn trim_idle_working_set(_root_pid: u32) {}`（no-op）
-- `#[cfg(test)] mod tests`: `collect_descendant_pids` の純テスト（OS 非依存で全 CI 実行可）
+### 1. `.github/workflows/e2e.yml`（トリガー + smoke step 追加）
+- `on:` に `pull_request: { branches: [main] }` を追加（`workflow_dispatch` は維持）。
+- job に label ゲートを追加:
+  ```yaml
+  if: >-
+    github.event_name == 'workflow_dispatch' ||
+    contains(github.event.pull_request.labels.*.name, 'e2e')
+  ```
+  （配列 `contains` で要素完全一致。`skip-ci` の join+部分一致より誤マッチに強い）
+- `Build app and setup E2E`（`e2e:tauri:setup`）の後、`Run E2E tests` の**前**に smoke step を追加:
+  ```yaml
+  - name: Run startup smoke
+    run: pwsh -NoProfile -File scripts/smoke-startup.ps1 -ExePath target/release/snotra.exe
+  ```
+  （setup が生成した release バイナリを共有。debug 二重ビルドを避ける）
+- workflow `name:` を `E2E` → `E2E & Smoke` に変更（実態を反映）。
 
-#### windows 0.62.2 API 実装注意（plan-review でソース確認済み）
-- API は全て 0.62.2 で利用可能（`EmptyWorkingSet`→`Win32_System_ProcessStatus` / Toolhelp 群→`Win32_System_Diagnostics_ToolHelp` / OpenProcess 等→`Win32_System_Threading` 既存 / `CloseHandle`→`Win32_Foundation` 既存）
-- `PROCESSENTRY32W` は `Default`（zeroed）。**`Process32FirstW` 前に必ず `entry.dwSize = size_of::<PROCESSENTRY32W>() as u32` を設定**（未設定だと失敗）
-- 戻り値型: `CreateToolhelp32Snapshot`→`Result<HANDLE>`、`Process32FirstW/NextW`/`OpenProcess`(`Result<HANDLE>`)/`EmptyWorkingSet`/`CloseHandle`→`Result<_>`。`GetCurrentProcess`→`HANDLE`（Result でない）。全て `if let Ok(..)` / `let Ok(..) else` で扱い、**`unwrap`/`expect`/添字アクセスを使わない**（best-effort・panic させない）
-- `PROCESS_QUERY_INFORMATION | PROCESS_SET_QUOTA` は `PROCESS_ACCESS_RIGHTS` の `BitOr` 実装で型的に通る
+### 2. `.github/labels.yml`（`e2e` + `skip-ci` ラベル定義追加）
+- discoverability のため `e2e` ラベルを追加（label-sync が自動作成）:
+  ```yaml
+  - name: e2e
+    color: "5319e7"
+    description: この PR で E2E/smoke workflow を自動実行する（カテゴリ C 変更時に付与）
+  ```
+- 併せて、`ci.yml` が使用済みだが未定義の `skip-ci` も定義する（plan-review 指摘の整合修正）:
+  ```yaml
+  - name: skip-ci
+    color: "ededed"
+    description: 通常 PR CI（frontend-check / rust-check）をスキップする
+  ```
 
-### 2. `src-tauri/src/main.rs`
-- `mod working_set;` を追加
-- hotkey-hide 経路（L579-581 付近、`suspend_webview(&w)` の直後）に `working_set::trim_idle_working_set(std::process::id());` を追加
+### 3. `docs/build-commands.md`（カテゴリ C の責任明確化 + 対応表）
+- カテゴリ C に「PR では `e2e` ラベルを付与すると `E2E & Smoke` workflow が smoke:startup + e2e:tauri を自動実行する。ローカル実行でも可」を明記。
+- 「CI/CD メモ」に **build-commands ↔ workflow 対応表**を追加:
+  - `npm test` → `ci.yml`（PR 自動）
+  - `npm run smoke:startup` / `npm run e2e:tauri` → `e2e.yml`（`e2e` ラベル付き PR / workflow_dispatch）
 
-### 3. `src-tauri/src/commands/system.rs`
-- `notify_main_hidden`（L41-44）の `emit("window-hidden")` の後に `crate::working_set::trim_idle_working_set(std::process::id());` を追加
+### 4. `.claude/skills/deps-update/SKILL.md`（CI トリガーとの矛盾解消）
+- Step 3 の「E2E・スモークテストはローカルで実行せず CI に委ねる」を、
+  「E2E・スモークはローカル実行せず、PR に **`e2e` ラベルを付与**して `E2E & Smoke` workflow に委ねる（通常 PR CI では走らない）」に修正。
+- Step 4（PR 作成）に「カテゴリ C 相当の変更を含む場合 `gh pr edit --add-label e2e` でラベル付与」を追記。
+- Step 5（CI ポーリング）に「`e2e` ラベル付与時は `E2E & Smoke` の完了も待つ」を追記。
 
-### 4. `src-tauri/Cargo.toml`
-- `windows` features に `Win32_System_ProcessStatus`（EmptyWorkingSet）と `Win32_System_Diagnostics_ToolHelp`（CreateToolhelp32Snapshot / PROCESSENTRY32W / Process32FirstW/NextW）を追加
+### 5. `.claude/skills/health-check/SKILL.md`（Check 10 追加）
+- **Check 10 — build-commands.md ↔ .github/workflows/\* の対応**:
+  - `docs/build-commands.md` の「必須」コマンド（特にカテゴリ C の `smoke:startup` / `e2e:tauri`）が、いずれかの workflow で実行されるか grep 検証。
+  - 実行 workflow が無い必須コマンドを **Warning** で報告（CI で担保されない検証要件のドリフト検知）。
+- frontmatter `description` の検証項目列挙に「workflow 対応」を追記。
 
-### 5. `src-tauri/CLAUDE.md`（ドキュメント同期）
-- **モジュール構成セクション**に `working_set.rs` を追加（新規 .rs ファイル、AGENTS.md 規定）。文言例: 「`working_set.rs`: 非表示アイドル時に Win32 `EmptyWorkingSet` でプロセスツリー全体の working set を回収（Windows のみ、非 Windows は no-op）。`collect_descendant_pids()` は Toolhelp の (pid,ppid) 上を BFS する純関数（ユニットテスト対象）。best-effort・失敗は握りつぶす」
-- 「WebView2 TrySuspend / Resume パターン」節に EmptyWorkingSet 併用を追記:
-  - hide 時、`suspend_webview` の後（hotkey 経路）/ `notify_main_hidden`（全 frontend 経路）で trim を呼ぶ
-  - **TrySuspend と EmptyWorkingSet は別レイヤー**: TrySuspend=論理目標（MemoryUsageTargetLevel.Low、圧迫待ち）、EmptyWorkingSet=物理 working set の即時トリミング。補完的で競合しない
-  - `EmptyWorkingSet` はスレッド非依存（with_webview 非同期制約がない）ため frontend hide（tokio スレッド）からも適用可
-  - show 側に逆操作は不要（OS が透過 re-fault）。trim は hide 前後どちらで走っても無害（再 fault するだけ・OS page 標準動作）
-  - 削減対象は物理 RAM（working set）のみ、commit は不変
+### 6. スキル表 description の微更新（ルート `CLAUDE.md`）
+- `/health-check` 行: 検証項目に「workflow 対応」を追記。
+- `/deps-update` 行: 「カテゴリ C 相当時はラベル付与・E2E/smoke CI 完了確認」を追記。
+- `.claude/skills/deps-update/SKILL.md` frontmatter `description` も同様に整合。
 
-## 実装順序
+## 実装順序（依存考慮）
 
-1. `working_set.rs` 作成（純関数 + Win32 + no-op + テスト）→ `cargo test -p snotra`（純関数テストが落ちることを確認 = Red → Green）
-2. `Cargo.toml` に features 追加
-3. `main.rs` に `mod` 宣言 + hotkey-hide 呼び出し
-4. `system.rs` に notify_main_hidden 呼び出し
-5. `cargo check` / `cargo clippy`
-6. ドキュメント同期（CLAUDE.md）
-7. リリースビルドで手動計測（hide → Private WS 数MB、show → ~44ms・UI 正常）
+1. `.github/labels.yml`（`e2e` + `skip-ci` ラベル定義）
+2. `.github/workflows/e2e.yml`（トリガー + smoke step + rename）
+3. `docs/build-commands.md`（責任明確化 + 対応表）
+4. `.claude/skills/deps-update/SKILL.md`（文言整合 + frontmatter description）
+5. `.claude/skills/health-check/SKILL.md`（Check 10 + frontmatter description）
+6. ルート `CLAUDE.md` スキル表（health-check / deps-update の description 微更新）
 
 ## 不変条件
 
-- **trim は機能挙動を変えない**: ウィンドウの hide/show・状態機械・IPC 契約は不変。物理メモリ working set のみ縮小。失敗しても「メモリが減らない」だけ
-- **best-effort で panic しない**: Toolhelp/OpenProcess/EmptyWorkingSet の全失敗を握りつぶす（release `panic="abort"` のため panic させない）
-- **ハンドルリーク防止（生成/破棄ペア）**: `CreateToolhelp32Snapshot` の HANDLE と各 `OpenProcess` の HANDLE は必ず `CloseHandle` する。早期 return パスでも漏らさない（RAII ガード or 明示 close を全分岐に）
-- **BFS の停止性**: `collect_descendant_pids` は visited セットで循環（ppid 参照の輪・自己参照）を防ぎ必ず停止する。PID 再利用で実在しない ppid を指していても、存在する pid 集合内でのみ辿るので無限ループしない
-- **異常順序/失敗時**: trim が visible なウィンドウに対して race で走っても無害（再 fault するだけ）。hide 前に走っても最終的に hide されれば trim 効果は次のアイドルで効く
+- **workflow_dispatch は壊さない**: OR 条件の先頭に `github.event_name == 'workflow_dispatch'` を置き、dispatch 時は無条件 true（`pull_request` が null でも `contains(空配列, 'e2e')` = false に短絡されない）。
+- **ラベル無し PR は E2E を起動しない**: コスト制御。`e2e` ラベルが付かない限り job はスキップ。
+- **smoke の ExePath は release を指す**: setup が build する成果物。debug を別途ビルドしない（CI 時間の無駄回避）。smoke step は `e2e:tauri:setup` 成功後にのみ実行（バイナリ存在前提）。
+- **失敗時の挙動**: smoke step が落ちれば後続 E2E は実行されず job が fail（GitHub Actions の既定 step 順序依存）。これは望ましい（起動エラーがあれば E2E まで進む意味がない）。
+- **SSOT 非迂回**: build-commands.md にコマンド本体を集約。SKILL 側はコマンド名・ラベル操作のみ言及（health-check Check 5 の SSOT 迂回検知に抵触しない）。`gh pr edit --add-label e2e` は npm/cargo の検証コマンドではないため SSOT 対象外。
 
 ## テスト方針
 
-- **ユニットテスト**（`working_set.rs` `#[cfg(test)]`、OS 非依存）:
-  - `collect_descendant_pids`: (a) 単純な親→子→孫の連鎖、(b) 複数子・孫（browser→{renderer,gpu,utility} の実形状を模す）、(c) 循環参照でも停止、(d) root のみ（子なし）、(e) 無関係プロセス混在で巻き込まない
-- **Win32 部分はユニットテストしない**（AGENTS.md）。手動計測で代替
-- **検証コマンド**（`docs/build-commands.md` 準拠）:
-  - A: `cargo check -p snotra-core -p snotra -p snotra-settings` / `cargo clippy -p snotra-core -p snotra -p snotra-settings -- -D warnings` / `cargo test -p snotra`（working_set テスト）
-  - C（ウィンドウ表示順に触れる）: `npm run smoke:startup` / `npm run e2e:tauri`
-- **手動計測**（リリースビルド、調査時の PowerShell スクリプト再利用）:
-  - hide（hotkey）→ 非表示 Private WS が数MB に落ちる
-  - hide（フォーカス喪失：別ウィンドウをクリック）→ 同様に落ちる ← frontend 経路の確認
-  - show → ~44ms 維持・検索結果/アイコン正常描画
-  - メモリ圧迫下の再表示レイテンシ最悪値
+- **YAML 妥当性**: `e2e.yml` / `labels.yml` を読み返し、インデント・`if` 式の構文を目視確認。可能なら `python -c "import yaml; yaml.safe_load(open(...))"` でパース確認。
+- **ドキュメント整合**: health-check Check 5（SSOT 迂回）に新規違反を作らないこと、Check 9（スキル表整合）に影響しないことを確認。
+- **CI 実行確認**: 本 PR 自体に `e2e` ラベルを付与し、`E2E & Smoke` workflow が起動 → smoke + e2e が緑になることを確認（受け入れ条件の実証）。ラベル無し時はスキップされることも確認。
+- 変更は `.yml` / `.md` のみ。`.rs` / `.ts` 変更なしのため build-commands カテゴリ A/B のコンパイル検証は対象外。
 
 ## SPEC.md 更新要否
 
-**不要**（research.md 参照）。SPEC は suspend_webview/メモリ機構を記載しておらず、本変更はユーザー可視挙動・状態機械・IPC 契約を変えない内部最適化。文書化は src-tauri/CLAUDE.md に閉じる。issue 本文の「SPEC 同期（必須）」は撤回（実装後に issue へコメントで訂正）。
+**不要**。CI トリガー・検証プロセス・ドキュメントの変更であり、`SPEC.md` が管理するアプリのユーザー可視挙動・状態機械・IPC 契約を一切変えない。
 
 ## セルフレビュー
 
-### 5a. check スキル結果
-- **/plan-review**（Explore × 3 並列）実施済み。総評: completeness 高、着手可。
-  - 経路網羅性: (A)hotkey + (B)notify_main_hidden で全 hide 経路（focus-lost / Escape / click / Enter / Shift+Enter / slash）を網羅。frontend は `hideMainWindow → notifyMainHidden` に統一済みで漏れなし
-  - windows 0.62.2 API: 使用予定 API 全て正当とソース確認。実装注意（dwSize 初期化・Result 型・no unwrap）を計画に反映済み
-  - **要対処 1 件（反映済み）**: ハンドルリーク → RAII `HandleGuard`（icon.rs `BitmapCleanup` 踏襲）に修正
-- **/symmetric-check**: 対称ペア show/hide の検証は plan-review Agent 1 が実施。結論: hide→trim の show 側カウンターパートは**不要**（EmptyWorkingSet に逆操作 API はなく、show 時に OS が透過 re-fault する）。suspend_webview↔resume_webview の既存対称は不変。→ 対称適用漏れなし
-- **/cache-check**: 非該当（キャッシュ・incremental ロジックに触れない）
+**plan-review（Explore 2 並列）結果**: 計画は技術的に妥当・実装可能と判定。反映済みの指摘:
+- `skip-ci` が `ci.yml` で使用済みだが `labels.yml` 未定義 → labels.yml に併せて定義（変更 2 に反映）。
+- ExePath は CI working dir = repo root で `target/release/snotra.exe` が相対解決。`smoke-startup.ps1` が `Test-Path` で存在ガード済みのため追加 step 不要。
+- `npx tauri build --no-bundle` の出力先は workspace root `target/release/`（`.cargo/config.toml` 無し、`release.yml` の出力パスと一致）で確定。
+- `/health-check`・`/deps-update` の description 微更新を推奨 → 変更 6 に反映。
 
-### 5b. チェックリスト
-1. **対称コードパス**: ✓ show/hide 検証済み（上記）。trim は hide 側のみ、show 側は OS 自動 re-fault で対称
-2. **影響範囲の網羅性**: ✓ hide 経路を grep 列挙（main.rs hotkey / system.rs notify_main_hidden / ui の hideMainWindow 集約）。2 チョークポイントで全網羅
-3. **境界条件**: ✓ BFS の循環/自己参照/PID 再利用/root のみ/無関係混在をテストケース化。Win32 失敗（snapshot/OpenProcess）は best-effort スキップ
-4. **リソース管理**: ✓ HANDLE 生成/破棄ペアを RAII `HandleGuard`(Drop→CloseHandle) で保証（要対処を反映）
-5. **既存パターンとの整合**: ✓ best-effort・`#[cfg(windows)]`/no-op ペア（suspend_webview 踏襲）、RAII ガード（BitmapCleanup 踏襲）。新規パターンなし
-6. **YAGNI 違反**: なし。2 call-site は frontend hide（最多経路）を覆うため必要。GetCurrentProcess 疑似ハンドル分岐は YAGNI として排除し統一 OpenProcess に
-7. **シンプル化の挑戦**: 新規状態（AtomicBool/Mutex/子プロセス）を**導入しない**——trim はステートレスな関数呼び出し。失敗時は「メモリが減らないだけ」で副作用ゼロ。これ以上単純化すると hide 経路網羅を落とす
-8. **破壊不変条件の明示**: 本変更に「壊れたら即アウト」の不変条件は**ない**（best-effort・機能挙動不変）。検知手段: collect_descendant_pids ユニットテスト + 手動メモリ計測（hide 後 Private WS 数MB / show ~44ms / UI 正常）+ smoke:startup / e2e:tauri で起動・表示の回帰検知
+**セルフレビューチェックリスト**:
+1. **対称コードパス**: CI トリガーの `workflow_dispatch`/`pull_request`、ラベルゲートの `skip-ci`(無効化)/`e2e`(有効化) は逆向きゲートだがコード対称ペアではない。symmetric-check は非該当（コードパス変更なし）。
+2. **影響範囲の網羅性**: `.github/workflows/` 全 yml を grep。`E2E` workflow 名・job 名への外部参照なし（required status checks はコード非依存）。
+3. **境界条件**: `workflow_dispatch` 時に `pull_request` が null → `contains(空配列,'e2e')`=false だが OR 先頭が true で短絡。ラベル無し PR はスキップ。検証済み。
+4. **リソース管理**: 新規プロセス・フラグ・listener の導入なし。smoke step は既存 ps1 を呼ぶのみ（プロセスは ps1 内で起動/Stop-Process 済み）。
+5. **既存パターンとの整合**: ラベルゲートは `ci.yml` の `skip-ci` 判定を踏襲（配列 contains でより堅牢に）。
+6. **YAGNI 違反**: `skip-ci` ラベル定義は labels.yml を触る同一文脈での整合修正で許容範囲。それ以外に要求超過の追加なし。
+7. **シンプル化**: 単一 workflow 内への step 追加のみで新規ステート・プロセス・抽象を導入しない。smoke は release バイナリ共有で二重ビルド回避。
+8. **破壊不変条件**: 「壊れたら即アウト」= `workflow_dispatch` トリガーの維持（手動 E2E 実行の生命線）。OR 条件先頭で保護。**注意（手動）**: branch protection の required status checks に `E2E` 名が登録されている場合、rename で参照が外れる。e2e は従来 PR で走らず required になり得ないため低リスクだが、PR 後に GitHub UI で required checks を確認する。
 
-### 判定
-- completeness: **高**
-- 着手可否: **可**（要対処はすべて plan.md に反映済み）
+**実装着手可否**: 可。
+

--- a/workspace/research.md
+++ b/workspace/research.md
@@ -1,46 +1,53 @@
-# research — issue #355: 非表示時に WebView2 プロセスツリーへ EmptyWorkingSet を適用
+# research — issue #356: PR CI と smoke/E2E 検証要件の整合
 
 ## issue の要約
 
-ランチャーは 99% 非表示常駐。実機計測（installed release / 32GB・SSD）で、非表示アイドルの Private WS ≈ 110MB が、既存の `TrySuspend`/`MemoryUsageTargetLevel.Low` では**全く回収されない**（圧迫なし実機では OS が working set をトリミングしないため。120 秒放置でも不変）ことが判明。hide 経路で Win32 `EmptyWorkingSet` をプロセスツリー全体に能動適用し、アイドル常駐を **110MB → 数MB（約 107MB 回収）** する。再表示レイテンシは実測で劣化しない（無圧迫 41ms / 圧迫下 44ms、UI 正常性も目視確認済み）。
+手元の検証要件（`docs/build-commands.md` カテゴリ C）と GitHub Actions の自動実行範囲にズレがある。
 
-## 関連コード
+- `docs/build-commands.md` は、ウィンドウ生成・表示順・ホットキー・スラッシュコマンドに触れた場合、`npm test` / `npm run smoke:startup` / `npm run e2e:tauri` を**必須**としている。
+- しかし `.github/workflows/e2e.yml` は `workflow_dispatch` のみで、通常 PR では smoke/E2E が自動実行されない。
+- `.claude/skills/deps-update/SKILL.md` は「E2E・スモークは CI に委ねる」としているが、その CI は通常 PR から起動しない（**文書と実態の矛盾**）。
 
-- `src-tauri/src/main.rs`
-  - `suspend_webview()` / `resume_webview()`（L162-207）: 既存の WebView2 メモリ機構。trim ヘルパーはこれと対をなす位置づけ
-  - hotkey-hide 経路（hotkey-pressed リスナー内 L564-581）: `w.hide()` → `emit("window-hidden")` → `suspend_webview(&w)`。**ここが hotkey トグル hide のチョークポイント**
-  - `std::process::id()` で自 PID を取得
-- `src-tauri/src/commands/system.rs`
-  - `notify_main_hidden()`（L41-44）: `main_visible=false` + `emit("window-hidden")`。**フロントエンド起因 hide 全経路（フォーカス喪失・Escape・クリック起動・スラッシュ）の IPC チョークポイント**。現状ここでは suspend していない（with_webview 非同期制約のため）
-- `ui/src/MainApp.tsx` / `ui/src/lib/commands.ts`: フロントエンド hide は `api.notifyMainHidden()` + `win.hide()` を呼ぶ（L53-54 フォーカス喪失、L293-294 クリック起動、commands.ts L19-20 スラッシュ等）。hotkey-hide の `window-hidden` リスナー（MainApp L90）は `setMainVisible(false)` のみで notifyMainHidden は呼ばない → hotkey と frontend は別経路
-- `src-tauri/Cargo.toml`: `windows = "0.62.2"` features。現状 `Win32_System_Threading`（OpenProcess/GetCurrentProcess/PROCESS_*）・`Win32_Foundation`（CloseHandle）は有効だが、**`Win32_System_ProcessStatus`（EmptyWorkingSet）と `Win32_System_Diagnostics_ToolHelp`（CreateToolhelp32Snapshot/PROCESSENTRY32W）は未宣言**
-- `src-tauri/CLAUDE.md`: 「WebView2 TrySuspend / Resume パターン」節がメモリ機構の文書ホーム
+**リスク**: エージェントは「PR の CI が緑」を完了条件にしがち。Tauri 起動・ホットキー・ウィンドウライフサイクル・スラッシュコマンド系の回帰が PR で素通りする。
 
-## 既存パターン
+**ユーザー決定（要求の曖昧さ解消）**:
+1. 整合の方向 = **CI を自動化する**（対象ラベル付き PR で E2E workflow を自動実行）
+2. health-check に「build-commands.md ↔ .github/workflows/\*」対応チェックを**追加する**
 
-- **WebView2 TrySuspend/Resume**（main.rs）: hide 時 suspend、show 時 resume。best-effort・silently-ignore の作法。trim ヘルパーも同じ best-effort 作法に揃える
-- **`#[cfg(windows)]` / `#[cfg(not(windows))]` ペア**: suspend_webview 等が踏襲。trim ヘルパーも Windows 実装 + 非 Windows no-op で揃える
-- **プロセスツリー走査**: 調査時の PowerShell スクリプトが Toolhelp 相当の (pid,ppid) BFS を実証済み（renderer/gpu/utility は browser プロセスの孫なので全ツリー走査が必須）
+## 関連コード／ファイル
+
+| ファイル | 現状 | 役割 |
+|---|---|---|
+| `.github/workflows/e2e.yml` | `workflow_dispatch` のみ。`e2e:tauri:setup` → `e2e:tauri` を実行 | E2E 実行ワークフロー |
+| `.github/workflows/ci.yml` | `push`/`pull_request`(main)。frontend test+build / cargo check+test+clippy。`skip-ci` ラベルで無効化可 | 通常 PR CI |
+| `.github/labels.yml` | `type:*` / `size:*` のみ定義。`skip-ci` は未定義だが ci.yml で使用 | label-sync 対象 |
+| `.github/workflows/label-sync.yml` | `labels.yml` push 時に同期。`delete-other-labels: false` | ラベル同期 |
+| `docs/build-commands.md` | カテゴリ A〜D。C が smoke/E2E 必須。「CI/CD メモ」あり | 検証コマンド SSOT |
+| `.claude/skills/deps-update/SKILL.md` | Step 3 で「E2E・スモークは CI に委ねる」 | 依存更新スキル |
+| `.claude/skills/health-check/SKILL.md` | Check 1〜9。workflow 対応チェックは無い | 衛生チェック |
+| `scripts/smoke-startup.ps1` | 既定 `-ExePath C:\workspace\Snotra\target\debug\snotra.exe`。`SNOTRA_TRACE=1` で起動し `*:error` トレース不在を検証 | 起動スモーク |
+
+## npm scripts（package.json）
+
+- `test` = `vitest run`（CI で実行済み）
+- `smoke:startup` = `pwsh -NoProfile -File scripts/smoke-startup.ps1`（既定 ExePath = **debug**）
+- `e2e:tauri:setup` = `cargo install tauri-driver --locked && npm run prepare:sidecar && npx tauri build --no-bundle`（**release** バイナリ生成）
+- `e2e:tauri` = `playwright test -c playwright.tauri.config.ts`
+
+## 既存パターン（再利用）
+
+- **ラベルゲート**: `ci.yml` の `if: github.event_name == 'push' || !contains(join(github.event.pull_request.labels.*.name, ','), 'skip-ci')`。同形を E2E に適用（ただし配列 `contains` で誤マッチ回避）。
+- **ターゲットディレクトリ**: ワークスペース target は**リポジトリ root**（smoke 既定 ExePath が `target/debug/snotra.exe` であることから確定）。release は `target/release/snotra.exe`。
+- **CI 環境**: e2e.yml は `windows-latest` + Rust toolchain + Swatinem cache + `npm ci`。同 job 内に smoke step を追加すれば release バイナリを共有できる。
 
 ## 技術的制約
 
-- **Win32 API はユニットテスト前提にしない**（AGENTS.md）。`EmptyWorkingSet`/Toolhelp 呼び出し自体はテスト不可。BFS の純ロジック（(pid,ppid) リスト → 子孫 PID 収集）を純関数に切り出してユニットテストする
-- **`EmptyWorkingSet` はスレッド非依存**（純粋な Win32 プロセス API）。`suspend_webview` の「with_webview が IPC ハンドラスレッドだと非同期ディスパッチ」制約（src-tauri/CLAUDE.md）を持たないため、tokio スレッドで動く `notify_main_hidden` からも安全に呼べる → **全 hide 経路に適用可能**
-- **削減対象は物理 RAM（working set）であって commit ではない**（commit ~195MB 不変）
-- **EmptyWorkingSet に「逆操作」は不要**: trim されたページは show 時に OS が透過的に re-fault する。明示的な untrim API は存在せず、show 経路に対応操作を追加する必要はない（対称性の非対称はこれが理由）
-- **release は `panic = "abort"`**: ヘルパーは panic しない設計（全 Win32 呼び出しの失敗を握りつぶす best-effort）。catch_unwind 不要
-- **best-effort**: Toolhelp スナップショット失敗・OpenProcess 失敗（子プロセスが race で終了）は黙ってスキップ。失敗してもメモリが減らないだけで機能影響なし
-
-## SPEC.md 更新要否（重要・issue の記述を訂正）
-
-issue 本文では「SPEC.md 同期（必須）」としたが、**調査の結果これは誤り**:
-
-- SPEC §8（ウィンドウ動作）は表示/非表示の**ユーザー可視挙動と状態機械**を記述するが、`suspend_webview`/TrySuspend/MemoryUsageTargetLevel/メモリ機構は**一切記載していない**（grep 確認済み）
-- EmptyWorkingSet は同層の内部メモリ最適化で、**ウィンドウの表示/非表示挙動・状態機械・IPC 契約を一切変えない**（窓は従来どおり hide/show する）
-- 既存姉妹機構（suspend_webview）が SPEC 非記載である以上、整合上も EmptyWorkingSet を SPEC に書く必要はない
-
-→ **SPEC.md 更新は不要**。文書化は `src-tauri/CLAUDE.md` の「WebView2 TrySuspend / Resume パターン」節に EmptyWorkingSet の併用を追記する形で行う（コンパニオン機構として）。
+- **smoke と e2e のビルド成果物が別**: smoke 既定は debug、e2e setup は release（tauri build）。CI で両方走らせるなら release バイナリを共有し、smoke は `-ExePath target/release/snotra.exe` を明示する（debug を別途ビルドすると二重ビルドで無駄）。
+- **release バイナリの妥当性**: `cargo build --release` 単体は localhost 向きで `ERR_CONNECTION_REFUSED`（build-commands メモ）。だが `npx tauri build --no-bundle`（e2e setup が使用）はフロントを埋め込むため正常起動する。smoke はこの release バイナリで動作する。
+- **GitHub Actions の `contains`**: 配列に対する `contains(github.event.pull_request.labels.*.name, 'e2e')` は要素完全一致。`workflow_dispatch` 時は `pull_request` が null → 配列空 → false。`github.event_name == 'workflow_dispatch'` を OR の先頭に置けば短絡で true になる。
+- **`GITHUB_TOKEN` でのワークフロー連鎖不可**（build-commands メモ）— 今回は単一 workflow 内に step 追加なので影響なし。
+- **E2E は ~30 分（timeout-minutes: 30）**: ラベル付き PR でのみ走るのでコスト制御済み。
 
 ## 未解決の疑問
 
-- なし（要求・実装方針とも確定）。設計判断「適用範囲＝全 hide 経路」は計画で確定（下記）
+- smoke step を release バイナリで CI 実行したとき、ホットキー登録など CI 環境固有の `*:error` が出ないか。→ E2E が同 release バイナリを起動して通っている実績があるため、起動経路は clean と判断（実行で確認）。


### PR DESCRIPTION
## 背景

`docs/build-commands.md` カテゴリ C は smoke/E2E を必須とするが、`e2e.yml` は `workflow_dispatch` のみで通常 PR では走らず、`deps-update` スキルの「CI に委ねる」記述と矛盾していた。エージェントが「PR CI 緑」を smoke/E2E 済みと誤認する経路を、文書を弱めるのではなく **CI を強めて** 塞ぐ。

Closes #356

## 変更内容

- **`e2e.yml`**: `pull_request` トリガー + `e2e` ラベルゲート（配列 `contains` で完全一致）を追加。`types` に `labeled` を明示購読し、**PR 作成後の後付けラベルでも起動**するようにする。`e2e:tauri:setup` の release バイナリを共有して `smoke:startup` も実行（カテゴリ C フルセット）。name を `E2E` → `E2E & Smoke` に変更
- **`labels.yml`**: `e2e` ラベルを定義。併せて `ci.yml` が使用済みだが未定義だった `skip-ci` も定義（整合修正）
- **`build-commands.md`**: カテゴリ C に PR 実行責任を明記。CI/CD メモに「検証コマンド ↔ workflow」対応表を追加
- **`deps-update` SKILL**: 「CI に委ねる」を「`e2e` ラベルを付与して `E2E & Smoke` に委ねる（通常 PR CI では走らない）」に修正。PR 作成・CI ポーリングにラベル付与・完了待ちを追記
- **`health-check` SKILL**: Check 10（build-commands ↔ workflow 対応のドリフト検知）を追加
- **`CLAUDE.md`**: スキル表の health-check / deps-update description を整合

## 受け入れ条件

- [x] smoke/E2E を必須とする変更種別で PR 上の実行責任が明確（`e2e` ラベル）
- [x] `deps-update/SKILL.md` の記述が実際の CI トリガーと矛盾しない
- [x] エージェントが「通常 CI 緑」だけで smoke/E2E 済みと誤認しない

## レビュー指摘の修正

`code-reviewer` エージェントが検出した Critical/Medium を修正済み:
- **C1**: `on.pull_request` の `types:` 省略デフォルトに `labeled` が含まれず後付けラベルで起動しない → `types: [opened, synchronize, reopened, labeled]` を明示
- **M1**: smoke step が ps1 直叩きのため Check 10 が誤 Warning → ラッパー実体（スクリプトパス）での照合を許容
- **M2**: smoke が E2E 用ビルドの起動検証である旨を build-commands に明記

## 検証

- この PR 自体に `e2e` ラベルを付与し、`E2E & Smoke` workflow が起動 → smoke + e2e が緑になることを確認する（受け入れ条件①の実機確認）
- ラベル無し時はジョブがスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
