### PR TITLE
chore: PR 作成前に未 push コミットをブロックする hook を追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "input=$(cat); if echo \"$input\" | grep -qE 'git\\s+(commit|merge|rebase)' && [ \"$(git branch --show-current)\" = 'main' ]; then echo 'BLOCKED: main ブランチへの直接コミットは禁止です。feature ブランチを作成してください。' >&2; exit 2; fi"
+          },
+          {
+            "type": "command",
+            "command": "input=$(cat); if echo \"$input\" | grep -qE 'gh\\s+pr\\s+create'; then up=$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null); if [ -z \"$up\" ] || [ -n \"$(git log @{u}..HEAD --oneline 2>/dev/null)\" ]; then echo 'BLOCKED: 未 push のコミット、または upstream 未設定です。git push -u origin HEAD してから gh pr create してください（空 PR / Closes 誤 close 防止）。' >&2; exit 2; fi; fi"
           }
         ]
       }


### PR DESCRIPTION
## 背景

実装コミットを `git push` せずに `gh pr create` した結果、リモートには直前のコミットしか無く**実質空の PR がマージ**され、PR 本文の `Closes #N` で **issue まで誤 close** する事故が起きた（#356 / #363）。同じ失敗を構造的に防ぐ。

## 変更

`.claude/settings.json` の `PreToolUse`(Bash) に hook を 1 つ追加。`gh pr create` を含む Bash 入力に対し:

- 現在ブランチに **upstream が無い**、または
- **未 push コミットがある**（`git log @{u}..HEAD` が非空）

場合に `exit 2` でブロックする。`block-main-commit` と同じ方式。

## 検証（ローカル実証済み）

| ケース | 結果 |
|---|---|
| 同期済みブランチ + `gh pr create` | PASS（許可） |
| upstream 未設定の新規ブランチ + `gh pr create` | BLOCK (exit 2) |
| 無関係コマンド（`git status` 等） | grep 不一致で素通り |

この PR 自体が「先に `push -u` → それから `gh pr create`」の正しい順序で guard を通過したドッグフーディングになっている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
