### PR TITLE
refactor: frontend hide の trim を hide 完了後に実行し回収を改善 (#361)

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -67,7 +67,20 @@ hide 経路で Win32 `EmptyWorkingSet` をプロセスツリー全体へ能動�
 | hotkey hide 後（自動 trim） | ~9.4 MB |
 | frontend(Escape) hide 後（自動 trim） | ~22.8 MB |
 
-再表示レイテンシは劣化しない（trim 無/有とも ~41ms、メモリ圧迫下でも 44ms、ウィンドウ出現はブロックされない）。ページは standby/pagefile に退避され show 時に OS が透過 re-fault する（圧迫下のみハード読込 ~934/s ≈ 3.6MB/s で SSD では体感不能）。削減対象は物理 working set であって commit（~195MB 不変）ではない。frontend 経路が hotkey より浅い（22.8 vs 9.4MB）のは `notify_main_hidden` が tokio で `win.hide()` と並行するタイミング差（#361 で polish）。
+再表示レイテンシは劣化しない（trim 無/有とも ~41ms、メモリ圧迫下でも 44ms、ウィンドウ出現はブロックされない）。ページは standby/pagefile に退避され show 時に OS が透過 re-fault する（圧迫下のみハード読込 ~934/s ≈ 3.6MB/s で SSD では体感不能）。削減対象は物理 working set であって commit（~195MB 不変）ではない。frontend 経路が hotkey より浅い（22.8 vs 9.4MB）のは `notify_main_hidden` が tokio で `win.hide()` と並行するタイミング差（#361 で修正済み、下記）。
+
+### follow-up: frontend hide の trim タイミング修正（issue #361 / 2026-06-02 計測）
+
+frontend hide（`hideMainWindow()`）で `notifyMainHidden()`（trim）を `await win.hide()` の**後**に呼ぶよう順序を入れ替え、可視中の trim でレンダラがページを再 touch する取りこぼしを解消（hotkey 経路と同じ hide→trim 順）。MainApp.tsx のフォーカス喪失・クリック起動経路も `hideMainWindow()` に集約（DRY）。
+
+クリーン再計測（検索なし、`%TEMP%/snotra-mem-measure.ps1`、**プロセスツリー総 WorkingSet64**= 共有ページ込みで上表の Private WS とは別指標）:
+
+| 経路 | #361 前 | #361 後 |
+|---|---|---|
+| frontend(Escape) hide 後 | ~50 MB（3 回 50-61） | **~27 MB**（3 回 27-30） |
+| hotkey hide 後（参照・無変更） | ~10 MB | ~10 MB |
+
+frontend hide の総ツリー WS が**約半減**（frontend↔hotkey 差の ~57% を解消）。残差（~17MB）は frontend 経路が `suspend_webview`（TrySuspend）を行わない設計差に起因（tokio IPC スレッドの `with_webview` 非同期制約のため hotkey 限定。`src-tauri/CLAUDE.md`「TrySuspend / Resume パターン」節）。gap は「trim タイミング」成分（#361 で解消）+「suspend 有無」成分（設計上の意図的な差）の和。
 
 ### 効かなかった/見送った手法
 

--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -29,7 +29,7 @@ SolidJS + TypeScript フロントエンド。Tauri IPC 経由で Rust バック�
 - `invoke.ts`: 型付き Tauri IPC ラッパー
 - `theme.ts`: CSS 変数によるテーマ適用
 - `types.ts`: TypeScript 型定義の集約先（DRY）
-- `commands.ts`: スラッシュコマンド定義（`/r` `/o` `/s` `/q`）と `SLASH_COMMANDS` 配列・`findCommand()` 関数。`hideMainWindow()` でメインウィンドウを非表示にする
+- `commands.ts`: スラッシュコマンド定義（`/r` `/o` `/s` `/q`）と `SLASH_COMMANDS` 配列・`findCommand()` 関数。`hideMainWindow()` は全 frontend hide（Escape / Enter / Shift+Enter / クリック起動 / フォーカス喪失 / `/s`）の単一チョークポイント。**`await win.hide()` → `notifyMainHidden()` の順を守る**——`notifyMainHidden` 内の `EmptyWorkingSet` trim を hide 完了後に走らせることで、可視中の再 touch による working set 回収の取りこぼしを避ける（hotkey 経路と同順。#361）。MainApp.tsx のフォーカス喪失・クリック起動経路もこの関数に集約する
 - `i18n.ts`: 多言語対応（日本語・英語）。`TranslationKey` 型と `t(key, params?)` 関数。`{param}` 形式プレースホルダー対応。SolidJS シグナルで言語を管理し、`setLanguage()` で切替。初期言語は `navigator.language` から同期的に決定（bootstrap 到着前のフラッシュ防止）
 - `folderNav.ts`: フォルダナビゲーション純粋ロジック（`computeParentDir`・`clampSelectedIndex`）。ドライブルート・UNC パス対応。テスト可能なため `stores/` から分離
 - `hotkeyValidation.ts`: ホットキーの有効性チェック（`isHotkeyInvalid`・`formatHotkeyLabel`）。Win キー・禁止キー・修飾キーなしをガード

--- a/ui/src/MainApp.tsx
+++ b/ui/src/MainApp.tsx
@@ -16,6 +16,7 @@ import {
   instantCommandMode,
   setInstantCommandPrefix,
 } from "./stores/search";
+import { hideMainWindow } from "./lib/commands";
 import { applyTheme } from "./lib/theme";
 import { t, setLanguage, type Lang } from "./lib/i18n";
 import type { BootstrapPayload, UpdateAvailablePayload, VisualConfig } from "./lib/types";
@@ -49,9 +50,10 @@ const MainApp: Component = () => {
   onMount(async () => {
     const hideMain = async () => {
       if (!mainVisible()) return;
+      // eager に results を畳み Blob URL を hide 前に解放する（signal 駆動）。
+      // hide→notify(trim) の順序は hideMainWindow に集約（#361）。
       setMainVisible(false);
-      api.notifyMainHidden().catch(() => {});
-      await win.hide();
+      await hideMainWindow();
     };
 
     const registerAutoHideOnFocusLost = async () => {
@@ -290,8 +292,7 @@ const MainApp: Component = () => {
       trace("app:event:result_clicked:done", { index, launched });
       if (launched) {
         setMainVisible(false);
-        api.notifyMainHidden().catch(() => {});
-        void win.hide();
+        void hideMainWindow();
       } else {
         console.warn("Failed to launch clicked result", { index });
       }

--- a/ui/src/lib/commands.test.ts
+++ b/ui/src/lib/commands.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as api from "./invoke";
-import { findCommand, SLASH_COMMANDS } from "./commands";
+import { findCommand, hideMainWindow, SLASH_COMMANDS } from "./commands";
 
 const mockMainHide = vi.hoisted(() => vi.fn(async () => {}));
 const mockSetLaunchNoticeWithAutoClear = vi.hoisted(() => vi.fn());
@@ -125,5 +125,27 @@ describe("slash command actions", () => {
 
     expect(mockMainHide).not.toHaveBeenCalled();
     expect(api.quitApp).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("hideMainWindow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // #361: trim（notifyMainHidden 内の EmptyWorkingSet）は win.hide() 完了後に走らせる。
+  // 可視中に trim するとレンダラがページを再 touch し working set 回収が削がれるため。
+  it("hide 完了後に notifyMainHidden(trim) を呼ぶ", async () => {
+    const order: string[] = [];
+    mockMainHide.mockImplementation(async () => {
+      order.push("hide");
+    });
+    vi.mocked(api.notifyMainHidden).mockImplementation(async () => {
+      order.push("notify");
+    });
+
+    await hideMainWindow();
+
+    expect(order).toEqual(["hide", "notify"]);
   });
 });

--- a/ui/src/lib/commands.ts
+++ b/ui/src/lib/commands.ts
@@ -14,10 +14,14 @@ export interface SlashCommand {
   action: () => void | Promise<void>;
 }
 
-/** main webview コンテキストから呼び出すこと（getCurrentWindow() が main を返す前提） */
+/** main webview コンテキストから呼び出すこと（getCurrentWindow() が main を返す前提）。
+ *  全 frontend hide（Escape / Enter / Shift+Enter / クリック起動 / フォーカス喪失 / /s）の
+ *  単一チョークポイント。notifyMainHidden() の trim（EmptyWorkingSet）は win.hide() 完了後に
+ *  走らせる——可視中に trim するとレンダラがページを再 touch し working set 回収が削がれるため
+ *  （hotkey 経路と同じ hide→trim 順に揃える。#361）。 */
 export async function hideMainWindow() {
-  api.notifyMainHidden().catch(() => {});
   await getCurrentWindow().hide();
+  api.notifyMainHidden().catch(() => {});
 }
 
 export const SLASH_COMMANDS: SlashCommand[] = [

--- a/workspace/plan.md
+++ b/workspace/plan.md
@@ -1,0 +1,162 @@
+# plan.md — issue #361
+
+frontend hide 経路の `EmptyWorkingSet` trim を `win.hide()` 完了後に走らせ、回収を hotkey 経路
+（~9MB）に近づける。**案A**（JS 側順序入れ替え + `hideMainWindow()` への統合）を採用。
+
+## 変更ファイル一覧
+
+### 1. `ui/src/lib/commands.ts` — 順序入れ替え（中核修正）
+
+`hideMainWindow()` を `hide` → `notify` の順に直す。
+
+```ts
+/** main webview コンテキストから呼び出すこと（getCurrentWindow() が main を返す前提）。
+ *  全 frontend hide（Escape / Enter / Shift+Enter / クリック起動 / フォーカス喪失 / /s）の
+ *  単一チョークポイント。notifyMainHidden() の trim（EmptyWorkingSet）は win.hide() 完了後に
+ *  走らせる——可視中に trim するとレンダラがページを再 touch し回収が削がれるため
+ *  （hotkey 経路と同じ hide→trim 順に揃える。issue #361）。 */
+export async function hideMainWindow() {
+  await getCurrentWindow().hide();
+  api.notifyMainHidden().catch(() => {});
+}
+```
+
+### 2. `ui/src/MainApp.tsx` — インライン 2 経路を hideMainWindow へ統合（DRY）
+
+import 追加:
+```ts
+import { hideMainWindow } from "./lib/commands";
+```
+
+`hideMain()`（フォーカス喪失, ~L50）:
+```ts
+const hideMain = async () => {
+  if (!mainVisible()) return;
+  setMainVisible(false);   // eager: ResultsSection を即座に畳み Blob URL を hide 前に解放
+  await hideMainWindow();  // hide → trim の順は hideMainWindow に集約
+};
+```
+
+`handleClickResult()`（クリック起動, ~L287）の launched ブロック:
+```ts
+if (launched) {
+  setMainVisible(false);
+  void hideMainWindow();
+} else {
+  console.warn("Failed to launch clicked result", { index });
+}
+```
+
+- `setMainVisible(false)` は**残す**: MainApp ローカルシグナルで、eager に呼ぶことで
+  `ResultsSection visible` が即 false → `cache.revokeAll()` が hide 前に走る（trim 前に Blob 解放）。
+  commands.ts からはこのシグナルに触れないため MainApp 側に残すのが正しい責務分離。
+- `api.notifyMainHidden()` / `win.hide()` のインライン呼び出しは削除（hideMainWindow に集約）。
+
+### 3. `ui/src/lib/commands.test.ts` — 順序不変条件のユニットテスト追加（Red→Green）
+
+```ts
+import { findCommand, hideMainWindow, SLASH_COMMANDS } from "./commands";
+
+describe("hideMainWindow", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("hide 完了後に notifyMainHidden(trim) を呼ぶ（#361: 可視中 trim 回避）", async () => {
+    const order: string[] = [];
+    mockMainHide.mockImplementation(async () => { order.push("hide"); });
+    vi.mocked(api.notifyMainHidden).mockImplementation(async () => { order.push("notify"); });
+
+    await hideMainWindow();
+
+    expect(order).toEqual(["hide", "notify"]);
+  });
+});
+```
+- 既存コード（notify→hide）では `["notify","hide"]` となり **落ちる**（Red 確認）。
+- 修正後 `["hide","notify"]` で **通る**（Green）。
+- 全 frontend hide が `hideMainWindow()` に集約されるため、この 1 テストで 3 経路すべての
+  順序不変条件を守れる。
+
+### 4. ドキュメント同期
+
+- `ui/CLAUDE.md` 「実装パターン」に `hideMainWindow()` = 全 frontend hide の単一チョークポイント・
+  `hide → notify(trim)` 順である旨を 1 行追記。
+- `src-tauri/CLAUDE.md` は無変更（`notify_main_hidden` 不変・「全 hide 経路に適用」も真）。
+- SPEC.md 無変更（状態遷移不変）。
+
+## 実装順序（フェーズ）
+
+1. **Phase 1**: commands.test.ts に順序テスト追加 → 実行して Red 確認。
+2. **Phase 2**: commands.ts の `hideMainWindow()` 順序入れ替え → テスト Green 確認。
+3. **Phase 3**: MainApp.tsx の 2 経路を hideMainWindow へ統合（import 追加・インライン削除）。
+4. **Phase 4**: ドキュメント同期（ui/CLAUDE.md）。
+5. **Phase 5**: 検証（下記）。
+
+## 不変条件
+
+- **順序不変条件**: `hideMainWindow()` は `win.hide()` の解決後にのみ `notifyMainHidden()` を呼ぶ。
+  → commands.test.ts で機械的に保証。
+- **Blob URL ライフサイクル**: `cache.revokeAll()` は **signal 駆動**（event 駆動ではない）。
+  `ResultsSection visible = shouldShowResults() && mainVisible()` が false → `iconsEnabled` メモ
+  が false → `cache.revokeAll()`（ResultsSection.tsx ~L105）。
+  - MainApp 経路: eager `setMainVisible(false)` で hide 前に駆動（変更なし）。
+  - commands.ts 経路: window-hidden イベント受信が `setMainVisible(false)` を駆動（hide 後）。
+    window 非可視後の解放のため視覚影響なし。revoke は必ず実行されリークなし。
+- **`main_visible` フラグ**: hide 後に false 化（数 ms〜~35ms 遅延）。hotkey hide は冪等のため
+  この窓で hotkey が押されても機能破壊なし（show 意図が 1 回空振りしうる極小窓のみ。既存の
+  fire-and-forget IPC 往復遅延でも同等の窓は存在）。
+- **best-effort 維持**: trim 失敗・notify 失敗（`.catch(() => {})`）は機能に影響しない。
+- **異常系**: `win.hide()` が reject した場合 → `notifyMainHidden()` は呼ばれない
+  （`await` で例外伝播）。現状は notify が先に走るため、reject 時に notify だけ走る不整合があった。
+  reorder により「hide 成功時のみ trim」となり整合性は**向上**。hide reject は通常発生しないが、
+  発生時は窓が可視のまま残り次の hide 試行で再度処理される（回復可能）。
+
+## テスト方針
+
+- **追加テスト**: `ui/src/lib/commands.test.ts` の `hideMainWindow` describe（順序不変条件）。
+- **検証コマンド**（docs/build-commands.md カテゴリ準拠。.ts/.tsx 変更 = フロントエンド）:
+  - `npm run typecheck`（TypeScript）
+  - `npm test`（vitest: commands.test.ts / SearchWindow.test.tsx が緑のまま）
+  - `npm run lint`
+  - `npm run smoke:startup`（起動スモーク）
+  - release build（`npm run tauri build` 相当）で目視ライフサイクル確認。
+- **手動計測（issue 必須項目「クリーンな再計測」）**: release build を起動し、検索を実行せず
+  フォーカス喪失で hide → working set を計測。frontend 経路が hotkey 経路（~9MB）に近づくことを確認。
+  → ユニット/smoke では代替不能。実装後にユーザーへ手動計測を依頼 or 環境が許せば実施。
+
+## SPEC.md 更新要否
+
+不要（状態遷移・IPC 契約・状態フラグの文書化挙動は不変。trim タイミングは実装詳細）。
+
+## セルフレビュー
+
+### Step 5a — plan-review（並列 Explore × 2: TS フロント / Rust 境界）
+
+- **要対処: 0 件。** 両レイヤーとも計画は堅実、見落としなしと判定。
+- **対称ペア（show/hide）**: Rust 境界エージェントが専項検証 →「問題なし」。
+  show（`show_main_and_emit`: ... → `show()` → `main_visible.store(true)` → `emit(window-shown)`）と
+  hotkey hide（`w.hide()` → `main_visible.store(false)` → `emit(window-hidden)` → suspend → trim）は
+  どちらも「visibility 変更 → flag 更新 → emit」順で対称。frontend hide も `notify_main_hidden` に
+  集約され全 hide が Rust 一元管理に揃う。hotkey 経路無変更は正当（同期 main thread・suspend 要件）。
+- **`main_visible` レース**: hide 完了後に notify するため Win32 `IsVisible` は既に false。stale
+  `main_visible=true` 窓で hotkey が押されても hide は冪等（無害）。**現状の fire-and-forget IPC でも
+  同等窓は既存**で、reorder は機能破壊しない。異常系（hide reject）整合性はむしろ向上。
+- **軽微（実装時対応）**:
+  1. commands.test.ts に `hideMainWindow` を import 追加（Phase 1 で対応）。
+  2. ui/CLAUDE.md の追記位置は `lib/` セクションの commands.ts 行に明示（Phase 4 で対応）。
+
+### Step 5b — セルフレビューチェックリスト
+
+1. **対称コードパス**: ✓ show/hide を 5a で検証済み（問題なし）。
+2. **影響範囲の網羅性**: ✓ `hideMainWindow`/`notifyMainHidden`/`win.hide()` を grep。frontend hide は
+   commands.ts(1) + MainApp.tsx(2) の 3 経路のみ。SearchWindow の Escape/Enter/Shift+Enter は既に
+   hideMainWindow 経由。
+3. **境界条件**: ✓ hide reject 時・フォーカス喪失 debounce 中の hotkey・二重 hide を検証済み。
+4. **リソース管理**: ✓ Blob URL revoke（signal 駆動）が reorder 後も確実に実行。新規 listen/timer/
+   プロセス導入なし（破棄ペア不要）。
+5. **既存パターン整合**: ✓ `hideMainWindow()` 既存関数への集約。新パターン導入なし。
+6. **YAGNI**: ✓ 順序入れ替え + DRY 統合のみ。案B（タイマー defer）の複雑性を回避。
+7. **シンプル化**: ✓ 新状態（AtomicBool/Mutex/子プロセス）導入なし。タイマー不要。「hide が reject
+   したら notify されない＝trim されない」を異常系として明記済み。
+8. **破壊不変条件**: hotkey toggle が `main_visible` に依存（Win32 フック系の「戻ってこない」リスクは
+   本変更にはない＝Rust 側無変更）。検知手段: commands.test.ts 順序テスト + smoke:startup +
+   手動ライフサイクル（フォーカス喪失/Escape/クリック/hotkey の全経路で hide→再表示）。

--- a/workspace/research.md
+++ b/workspace/research.md
@@ -102,8 +102,44 @@ hide 完了後に trim するため深く回収できる。**これが frontend 
   「hide → notify(trim)」順である旨を実装パターンに追記。
 - `src-tauri/CLAUDE.md`: `notify_main_hidden` は無変更のため記述は維持（「全 hide 経路に適用」も真）。
 
-## 未解決の疑問
+## 計測 — baseline（#361 適用前 / 現行 main コード、2026-06-02）
 
-- **クリーンな再計測**（直前検索なしのフォーカス喪失 hide で frontend が hotkey ~9MB に近づくか）は
-  release build + 手動フォーカス喪失トリガー + working set 計測が必要。ユニット/smoke では代替不能。
-  実装フェーズで build + `smoke:startup` で回帰なしを確認し、メモリ差分は手動計測を要する旨を明記する。
+`target/release/snotra.exe`（`EmptyWorkingSet` 含有を確認済み = #355/#360 適用済み）を起動し、
+合成キー入力（`keybd_event`）で駆動。**検索を一切打たないクリーン状態**で計測。
+計測スクリプト: `%TEMP%/snotra-mem-measure.ps1`。
+
+- **指標**: snotra + WebView2 子孫の**プロセスツリー全体の総 WorkingSet64**（BFS 合算、共有 Edge DLL
+  ページ込み）。PERFORMANCE.md の Private WS（共有 ~280MB 除外）とは**絶対値が異なる**。比較は相対差。
+- **健全性確認**: 「show 時に WS 上昇 → hide+trim 後に下降」パターンで自動化を検証。
+- 起動直後（hidden idle, trim 前）: 7 プロセス・総 405 MB（共有 DLL 込み）。
+
+| 経路 | hide+trim 後（3 反復） | min | 備考 |
+|---|---|---|---|
+| frontend (Escape) | 61.4 / 50.5 / 53 MB | **50.5** | 3/3 安定（~50-61MB） |
+| hotkey (Ctrl+K) | 18 / 10.6 / 68.5 MB | **10.6** | 2/3 clean。68.5 は toggle 同期ずれ（auto_hide 先行発火）で無効 |
+
+**結論**: クリーン状態でも frontend hide は hotkey hide より総 WS を ~40MB 多く残す（~50 vs ~10MB）。
+issue の前提（frontend 経路の trim 取りこぼし）はクリーン計測で**確証**。hot な 22.8 vs 9.4（Private）
+より相対差は大きく、本修正（案A）は正当化される。
+
+### 検証結果（#361 適用後 / 2026-06-02）
+
+`npx tauri build --no-bundle` で release 再ビルド → 同スクリプトで after 計測。
+
+| 経路 | baseline（前） | after（後） | 改善 |
+|---|---|---|---|
+| frontend(Escape) hide | 50.5/55 MB（min/avg・生 61.4/50.5/53） | **27.3/28.3 MB**（生 30.3/27.3/27.4） | ~23MB 減（~46%） |
+| hotkey hide（参照・無変更） | 10.6 MB | 10.6 MB | — |
+
+- frontend hide の総ツリー WS が**約半減**。frontend↔hotkey 差(~40MB)の **~57% を解消**。
+- **残差 ~17MB** は frontend 経路が `suspend_webview`（TrySuspend）を行わない設計差に起因
+  （hotkey 限定。#361 のスコープ外）。gap = trim タイミング成分（#361 で解消）+ suspend 成分（設計差）。
+- 回帰なし: `npm run typecheck` 緑 / `npm test` 216/216 緑 / `smoke:startup` 5×0err 緑。
+- 計測ノイズ: hotkey #3（baseline 68.5 / after 58.4）は toggle 同期ずれ（auto_hide 先行発火）で無効。
+  Escape（非トグル）の frontend は前後とも 3/3 密集で信頼可。
+- 記録先: `PERFORMANCE.md`「follow-up: frontend hide の trim タイミング修正（#361）」節。
+
+### 残検証（PR）
+
+- `e2e:tauri` はローカル未実行。PR に `e2e` ラベルを付与し CI（E2E & Smoke workflow）で smoke+e2e を回す
+  （カテゴリ C: hide 順序変更）。

--- a/workspace/research.md
+++ b/workspace/research.md
@@ -1,0 +1,109 @@
+# research.md — issue #361
+
+## issue の要約
+
+#355 / PR #360 で hide 時に Win32 `EmptyWorkingSet` をプロセスツリーへ適用しアイドル
+working set を回収する仕組みを実装した。実測で **hotkey hide は 112→9.4MB**、
+**frontend hide（Escape 等）は 98.5→22.8MB** と frontend 経路の回収が ~13MB 控えめ。
+
+原因: frontend hide では trim（`notify_main_hidden` 内）が **`win.hide()` 完了前に**走る。
+`notifyMainHidden()` が fire-and-forget（await しない）で tokio IPC スレッドに投げられ、
+`await win.hide()` と並行するため、**まだ可視な状態で trim** が走りレンダラが直後にページを
+再 touch → trim 効果が削がれる。hotkey 経路（main.rs、メインスレッドで同期実行）は
+`w.hide()` → emit → suspend → trim の順で hide 完了後に trim するためこの問題がない。
+
+本 issue は frontend 経路の trim タイミングを hide 完了後にずらし、回収差 ~13MB を詰める
+follow-up（polish, type:refactor）。
+
+## 関連コード
+
+### frontend hide 経路（全 3 箇所）
+
+| 箇所 | 現状の順序 | 経由する操作 |
+|---|---|---|
+| `ui/src/lib/commands.ts:18` `hideMainWindow()` | `notifyMainHidden()` → `await win.hide()` | Escape・Enter・Shift+Enter（SearchWindow.tsx）・スラッシュ `/s` |
+| `ui/src/MainApp.tsx:50` `hideMain()`（フォーカス喪失） | `setMainVisible(false)` → `notifyMainHidden()` → `await win.hide()` | onFocusChanged の 100ms debounce 後 |
+| `ui/src/MainApp.tsx:287` `handleClickResult()`（クリック起動） | `setMainVisible(false)` → `notifyMainHidden()` → `void win.hide()` | 結果行クリック |
+
+- SearchWindow.tsx の Escape(`:172`) / Enter(`:227`) / Shift+Enter(`:221`) はすべて
+  `hideMainWindow()` 経由 → commands.ts を直せば自動的に揃う。
+- MainApp.tsx の 2 箇所だけが順序をインラインで重複保持している（DRY 違反）。
+
+### Rust チョークポイント
+
+`src-tauri/src/commands/system.rs:41` `notify_main_hidden`:
+```rust
+pub fn notify_main_hidden(state: State<AppState>, app: AppHandle) {
+    state.main_visible.store(false, Ordering::SeqCst);   // ① UI 表示用フラグ
+    let _ = app.emit("window-hidden", ());               // ② JS の Blob URL 一括解放を駆動
+    crate::working_set::trim_idle_working_set(...);       // ③ EmptyWorkingSet
+}
+```
+全 frontend hide が必ずここを通る。Rust 側は無変更で、JS 側の呼び出しタイミングのみ直す。
+
+### hotkey 経路（参考・無変更）
+
+`src-tauri/src/main.rs:565-585`（`app_handle.listen("hotkey-pressed")` コールバック = 同期）:
+`w.hide()` → `main_visible.store(false)` → `emit("window-hidden")` → `suspend_webview` → `trim`。
+hide 完了後に trim するため深く回収できる。**これが frontend 経路の目標形。**
+
+## 既存パターン
+
+- `hideMainWindow()` は既に frontend hide の共通関数として存在するが、MainApp.tsx の
+  2 経路はこれを使わずインライン重複している。**案A の DRY 統合は既存関数への集約**であり、
+  新パターン導入ではない（KISS / 既存パターン踏襲）。
+- `EmptyWorkingSet` は trim が hide 前後どちらで走っても無害（src-tauri/CLAUDE.md
+  「show 側に逆操作は不要・再 fault するだけ」）。**正しさではなく回収効率の問題。**
+
+## 技術的制約・留保観点（issue 記載）
+
+1. **`window-hidden` emit 順序依存**: `notify_main_hidden` が emit する `window-hidden` は
+   フロントの Blob URL 一括解放（`ResultsSection` visible→false → `cache.revokeAll()`）を駆動
+   （ui/CLAUDE.md「Blob URL 管理の不変条件」）。
+   - 検証: MainApp の 2 経路は `setMainVisible(false)` を**先に同期で**呼んでおり、
+     Blob 解放はその時点で既に駆動される（`ResultsSection visible = shouldShowResults() && mainVisible()`）。
+     window-hidden イベントの `setMainVisible(false)` は冪等な二重 set。よって emit を hide 後に
+     ずらしても MainApp 経路の Blob 解放タイミングは変わらない。
+   - commands.ts 経路（Escape/Enter）は eager set がなく window-hidden イベント頼り。
+     emit が hide 後になると Blob 解放も hide 後になるが、**window 非可視後の解放のため視覚影響なし**
+     （むしろ可視中に結果が消える微小フラッシュを避けられる）。リークなし（revoke は実行される）。
+
+2. **`main_visible` タイミングのレース**: hide 後に `main_visible.store(false)` を遅らせると、
+   `await win.hide()` の間（数 ms〜~35ms）`main_visible=true` のまま。この窓で hotkey が押されると
+   listener が `visible=true && toggle` と判定し hide 経路を再実行する。
+   - hide は冪等（既に隠れた窓を hide しても無害）。show 意図の hotkey が 1 回空振りしうるが、
+     窓は < ~35ms で人為的に狙えない。**現状も notifyMainHidden は fire-and-forget で IPC 往復
+     遅延があり同様の窓が既存**。reorder は既存の極小窓を僅かに広げるのみで機能破壊なし。
+
+3. **best-effort・機能不変**: trim 失敗は機能に影響しない（全 Win32 失敗を握りつぶす）。
+   hide の体感レイテンシは増やさない（`notifyMainHidden` は hide 後 fire-and-forget のまま）。
+
+## 採用案: 案A（JS 側・順序入れ替え + hideMainWindow 統合）
+
+- 案A: `await win.hide()` の**後**に `notifyMainHidden()`。frontend hide が散在するため
+  **先に `hideMainWindow()` へ統合**してから 1 箇所で直す。タイマー不要・チョークポイント統合で
+  DRY 改善。→ **KISS。採用。**
+- 案B（Rust 側 trim を ~50-100ms defer）は async タスク/タイマーの複雑性が増し、固定ディレイは
+  hide 完了の実時間と無関係。→ 不採用。
+- 統合の副次効果: 全 frontend hide が `hideMainWindow()` 1 関数を通るため、**順序不変条件を
+  commands.test.ts の 1 ユニットテストで守れる**。
+
+## SPEC.md 更新要否
+
+**不要。** SPEC.md は状態遷移（`SearchVisible → Standby` on Escape/focus_lost/hotkey）のみ規定し、
+`EmptyWorkingSet` の trim タイミング・`notifyMainHidden` の順序は記載していない。状態機械の挙動は
+完全に不変（hide → Standby）。trim タイミングは実装詳細（メモリ最適化）。
+
+## ドキュメント同期
+
+- `ui/src/lib/commands.ts`: `hideMainWindow()` のコメントを「hide 完了後に trim を走らせるため
+  notify は hide の後」に更新。
+- `ui/CLAUDE.md`: `hideMainWindow()` が全 frontend hide の単一チョークポイントで
+  「hide → notify(trim)」順である旨を実装パターンに追記。
+- `src-tauri/CLAUDE.md`: `notify_main_hidden` は無変更のため記述は維持（「全 hide 経路に適用」も真）。
+
+## 未解決の疑問
+
+- **クリーンな再計測**（直前検索なしのフォーカス喪失 hide で frontend が hotkey ~9MB に近づくか）は
+  release build + 手動フォーカス喪失トリガー + working set 計測が必要。ユニット/smoke では代替不能。
+  実装フェーズで build + `smoke:startup` で回帰なしを確認し、メモリ差分は手動計測を要する旨を明記する。


### PR DESCRIPTION
## 概要

issue #361（follow-up / polish）。frontend hide 経路で Win32 `EmptyWorkingSet` の trim が `win.hide()` 完了**前**に走り、レンダラがページを再 touch して working set 回収が削がれていた問題を修正。trim を hide 完了後に実行する（hotkey 経路と同順）。

## 変更

- `ui/src/lib/commands.ts`: `hideMainWindow()` を `await win.hide()` → `notifyMainHidden()`(trim) の順に入れ替え。全 frontend hide（Escape / Enter / Shift+Enter / クリック起動 / フォーカス喪失 / `/s`）の単一チョークポイント。
- `ui/src/MainApp.tsx`: フォーカス喪失（`hideMain`）・クリック起動（`handleClickResult`）の 2 経路を `hideMainWindow()` に統合（DRY）。`setMainVisible(false)` の eager 呼び出しは保持（Blob URL を hide 前に signal 駆動で解放）。
- `ui/src/lib/commands.test.ts`: 順序不変条件テスト（hide → notify）を追加。
- `ui/CLAUDE.md` / `PERFORMANCE.md`: チョークポイント注記・クリーン再計測結果を記録。

Rust 側（`notify_main_hidden`）・SPEC.md は**無変更**（状態遷移・IPC 契約は不変。trim タイミングは実装詳細）。

## 計測（実機クリーン計測・プロセスツリー総 WorkingSet64、共有ページ込み）

| 経路 | #361 前 | #361 後 |
|---|---|---|
| frontend(Escape) hide | ~50 MB（3 回 50-61） | **~27 MB**（3 回 27-30） |
| hotkey hide（参照・無変更） | ~10 MB | ~10 MB |

frontend hide のアイドル working set が**約半減**（frontend↔hotkey 差の ~57% を解消）。残差 ~17MB は frontend 経路が `suspend_webview`（TrySuspend）を行わない設計差に起因（tokio IPC スレッドの `with_webview` 非同期制約のため hotkey 限定）＝意図的・本 polish のスコープ外。

## 検証

- ✅ `npm run typecheck` クリーン
- ✅ `npm test` 216/216 緑（順序不変条件テスト含む）
- ✅ `npm run smoke:startup`（release バイナリ）5 回 0 エラー
- ⏳ `e2e:tauri`: カテゴリ C（hide 順序変更）のため `e2e` ラベルを付与し CI（E2E & Smoke workflow）で smoke+e2e を実行

## 留保観点の検証

- **`main_visible` レース**: hide 完了後に notify するため Win32 `IsVisible` は既に false。stale フラグ窓で hotkey が押されても hide は冪等で無害（現状の fire-and-forget IPC でも同等窓は既存）。異常系（hide reject）整合性はむしろ向上。
- **Blob URL ライフサイクル**: signal 駆動（`mainVisible` → `ResultsSection visible` → `cache.revokeAll()`）。reorder 後も確実に revoke されリークなし。

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)
