### PR TITLE
fix: E2E 再インデックス系テストの CI 専用タイムアウトを解消 (#369)

### DIFF
--- a/e2e/tauri.slash.e2e.ts
+++ b/e2e/tauri.slash.e2e.ts
@@ -366,6 +366,18 @@ function isDevUrlFallbackSnapshot(body: string): boolean {
   return body.includes("ERR_CONNECTION_REFUSED") || body.includes("接続が拒否されました");
 }
 
+// 検索クエリを「1 回だけ」入力する（#369）。再インデックス系の検証で毎ポール打ち直すと、
+// 打ち直しのたびに query が空→再入力で searchGeneration を bump し続ける。CI の遅い検索 IPC では
+// 検索が完了する前に次の打ち直しが generation を進めるため、refreshResults の staleness ガード
+// （requestId !== searchGeneration）が全 in-flight 検索を破棄し、results() が永遠に空のままになる。
+// 再インデックス完了は indexing-complete → runRefresh() がフロント側で自動再検索するため、
+// 入力は 1 回で足り、以降はポールで行数だけを観測すれば再構築結果が反映される。
+async function typeQueryOnce(driver: WebDriver, query: string): Promise<void> {
+  await switchToLabel(driver, "main");
+  const el = await driver.findElement(By.css(".search-input"));
+  await el.sendKeys(Key.chord(Key.CONTROL, "a"), Key.BACK_SPACE, query);
+}
+
 async function createHarness(): Promise<Harness> {
   const fixtureDir = await setupFixtureDir();
   const backup = await prepareE2EConfig(fixtureDir);
@@ -710,11 +722,11 @@ test("/s 後にインデックス再構築が完了し検索が機能する", as
   `);
   await waitForVisibleLabel(driver, "main", 6_000);
 
-  // 再構築完了まで clear→retype→チェックを繰り返す（最大 30 秒）
+  // クエリは 1 回だけ入力し（#369: 毎ポール打ち直しは CI で全検索を staleness 破棄させる）、
+  // 行が出るまでポールする。再構築完了は indexing-complete → runRefresh() が自動再検索する。
+  await typeQueryOnce(driver, E2E_SEARCH_QUERY);
   await driver.wait(async () => {
     await switchToLabel(driver, "main");
-    const el = await driver.findElement(By.css(".search-input"));
-    await el.sendKeys(Key.chord(Key.CONTROL, "a"), Key.BACK_SPACE, E2E_SEARCH_QUERY);
     return (await driver.findElements(By.css(".result-row"))).length > 0;
   }, 30_000, "インデックス再構築後に検索結果が表示されない");
 
@@ -742,21 +754,21 @@ test("include_path_env の切り替えで PATH 実行ファイルが検索結果
   );
   await writeFile(backup.path, `${configWithPath}\n`, "utf8");
 
-  // 再インデックス完了まで clear→retype→チェック（最大 30 秒）
+  // クエリは 1 回だけ入力し（#369）、行が出るまでポール。config 変更による再インデックス完了は
+  // indexing-complete → runRefresh() が自動で "cargo" を再検索するため、打ち直しは不要かつ有害。
+  await typeQueryOnce(driver, PATH_QUERY);
   await driver.wait(async () => {
     await switchToLabel(driver, "main");
-    const el = await driver.findElement(By.css(".search-input"));
-    await el.sendKeys(Key.chord(Key.CONTROL, "a"), Key.BACK_SPACE, PATH_QUERY);
     return (await driver.findElements(By.css(".result-row"))).length > 0;
   }, 30_000, "include_path_env = true に切り替え後、PATH 実行ファイルが検索結果に出ない");
 
   // Phase 3: include_path_env = false に戻す → PATH 結果が消える
   await writeFile(backup.path, `${buildE2EConfigToml(fixtureDir)}\n`, "utf8");
 
+  // 打ち直さない（#369: Phase 2 で "cargo" が表示中。打ち直すと一瞬の空表示で ===0 を誤判定する）。
+  // config 無効化 → 再インデックス完了 → runRefresh() が "cargo" を再検索し 0 件に落ちるのをポールする。
   await driver.wait(async () => {
     await switchToLabel(driver, "main");
-    const el = await driver.findElement(By.css(".search-input"));
-    await el.sendKeys(Key.chord(Key.CONTROL, "a"), Key.BACK_SPACE, PATH_QUERY);
     return (await driver.findElements(By.css(".result-row"))).length === 0;
   }, 30_000, "include_path_env = false に切り替え後、PATH 実行ファイルが検索結果に残っている");
 


### PR DESCRIPTION
## 概要

issue #369 の修正。E2E `e2e/tauri.slash.e2e.ts` の再インデックス系 2 件（`:694` `/s 後にインデックス再構築が完了し検索が機能する` / `:725` `include_path_env の切り替えで PATH 実行ファイルが検索結果に出入りする`）が **CI（GitHub Actions windows-latest）で約 2 ヶ月恒常 red**だった問題を解消する。**テスト側のみの修正で、製品コードは無変更**。

## 根本原因（CI 診断で確定）

失敗していた 2 件は `driver.wait` の**毎ポールでクエリを打ち直し**ていた（`Ctrl+A → BACKSPACE → query`）。打ち直しのたびに `query` を一旦空にして再検索し `searchGeneration` を bump するため、**CI の遅い検索 IPC では検索完了前に次のポールが generation を進め、`refreshResults` の staleness ガード（`requestId !== searchGeneration`）が全 in-flight 検索を破棄** → `results()` が空のまま 30s タイムアウトしていた。

CI 上に仕込んだ診断（撤去済み）が層を一意に特定:

```
[DIAG :725] before:            { backendCount: 4, indexing: false, q: "cargo", rows: 0 }
            afterForcedRebuild: { backendCount: 4, indexing: false, q: "cargo", rows: 4 }
```

- バックエンド `search` は 4 件返す（index に cargo あり・`config_watcher` 発火済み）
- `indexing` は false（居座りなし）
- なのにフロント `results()` は 0 行 → 静止 4 秒後（打ち直しなし）は 4 行
- ⇒ backend・indexing・自動再検索（`indexing-complete → runRefresh()`）はすべて健全。**毎ポール打ち直しが検索結果を潰していた**だけ。

## 修正

- `typeQueryOnce(driver, query)` ヘルパーを追加し、**クエリは 1 回だけ入力 → 以降は行数だけポール**する。再インデックス完了は `indexing-complete → runRefresh()` がフロント側で自動再検索するため、打ち直しは不要かつ有害。
- Phase 3（`include_path_env=false` に戻し `=== 0` を期待）は、表示中の結果を打ち直しで一瞬空にして誤判定しないよう、**打ち直さず** 0 件をポールする。

製品コード変更なし。ローカルでは元から PASS（CI 遅延依存のため）。

## 検証

- ✅ **CI（workflow_dispatch、本ブランチ）で全 14 件緑**（run 26825428554、`:694` 1.2s / `:725` 3.2s、32.6s）— 約 2 ヶ月 red だった 2 件が初めて緑
- ✅ ローカル full suite 14 件緑（回帰なし）

## 関連

調査経緯は #369 を参照。診断は別ブランチ（`chore/e2e-reindex-diagnostics`）で実施し、確定後に撤去済み（本 PR には含めない）。

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)
