### PR TITLE
fix: アップデーター署名鍵を新規鍵ペアに刷新し pubkey を一致させる

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,7 +46,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI3RkM3ODcwODRBRTBDODIKUldTQ0RLNkVjSGo4SjByd3IrMngvVStZSytxeXU5ZVNNbExUQ1BQd2lGV1gzTTMzM2ozTzhOc2QK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEQwODk3MDc4QjdBNTU1NUQKUldSZFZhVzNlSENKMEZBZ2REdnBnYXdLVCtXNWpnU2lkTXBCcEw1WlBPZjZkQWZiOUQwallyV2sK",
       "endpoints": [
         "https://github.com/finelagusaz/Snotra/releases/latest/download/latest.json"
       ],


### PR DESCRIPTION
## 概要

アプリ内アップデーターの署名検証が `The signature was created with a different key than the one provided` で必ず失敗する不具合を修正する。0.16.0 → 0.17.0 の更新で顕在化した。

## 根本原因

updater の minisign 署名検証で、**CI が署名に使う鍵**と**アプリに埋め込まれた公開鍵**が別の鍵ペアだった。公開済み `latest.json` の署名鍵 ID を実際にデコードして突き合わせた結果、3 つの無関係な鍵が並んでいた：

| 役割 | 鍵 ID | 備考 |
|---|---|---|
| CI が実際に署名 | `78EC8C56B5BB75E4` | v0.14.0〜v0.17.0 の全リリースがこれで署名 |
| アプリ埋め込み pubkey（修正前） | `27FC787084AE0C82` | #289 で `85BD…` から差し替えたが、CI 鍵とは別物 |
| 旧オリジナル pubkey | `85BD5242469DD021` | #289 以前。これも CI 鍵ではない |

埋め込み pubkey は CI の署名鍵と**一度も一致しておらず**、自動更新機能は導入された v0.14.0 以来ずっと壊れていた。NSIS インストーラのインストール時には updater 署名を検証しないため、アプリ内アップデーターを初めて実行した 0.16.0 → 0.17.0 で初めて表面化した。

## 修正内容

- 新規鍵ペア **`D0897078B7A5555D`** を生成（`tauri signer generate`、空パスワード運用＝現行 CI と同じ）。
- `src-tauri/tauri.conf.json` の `plugins.updater.pubkey` を新公開鍵へ差し替え（本 PR の変更はこの 1 行のみ）。

検証：新公開鍵を libsodium（pynacl、minisign と同一の Ed25519 実装）でハーネス検証。有効な minisign 公開鍵であり、既知 3 鍵のいずれとも重複しないことを確認済み。

## マージ後に必要な運用作業（順序が重要）

1. **本 PR を main にマージ**（リポジトリの埋め込み pubkey が `D089…` になる）。
2. **CI Secret を新秘密鍵へ更新**：`gh secret set TAURI_SIGNING_PRIVATE_KEY -R finelagusaz/Snotra < <new private key file>`（パスワード Secret は不要）。
3. **その後**に新タグ（例 `v0.17.1`）を切る。1・2 のどちらか欠けたままタグを切ると署名と pubkey が再びズレるため、必ずこの順序で。
4. リリース後、公開 `latest.json` ＋ インストーラの署名を埋め込み pubkey で end-to-end 検証する。

## 既存ユーザーへの影響（移行）

≤0.17.0 の既存インストールは**旧 pubkey を焼き込んでおり**、新鍵で署名された次リリースを自動更新できない。**この 1 回だけ手動で DL・再インストール**が必要。それ以降は自動更新が回復する。リリースノートで明示する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
