### PR TITLE
fix(ci): リリースを build 後も draft に保ち即時公開を防ぐ

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,11 @@ jobs:
         with:
           tag_name: ${{ env.TAG_NAME }}
           name: ${{ env.TAG_NAME }}
+          # draft を維持する: create-release.yml は draft: true で下書きを作るが、
+          # このアップロードで draft 指定を省くと softprops の既定 (draft=false) に
+          # 上書きされ、署名済み成果物が即時公開されてしまう。署名を人手で検証して
+          # から手動 publish する検証ゲートを残すため、ここで明示的に draft: true を指定する。
+          draft: true
           prerelease: ${{ steps.meta.outputs.prerelease }}
           files: |
             Snotra-${{ env.TAG_NAME }}.zip


### PR DESCRIPTION
## 概要

`create-release` 経由のリリースが、ビルド完了と同時に**即時公開**されてしまう挙動を修正する。署名済み成果物を公開前に検証する「draft ゲート」を復活させる。

## 背景

`create-release.yml` は `draft: true` で下書きリリースを作るが、続けて呼ばれる `release.yml` のアップロードステップ（`softprops/action-gh-release`）が `draft` を指定していなかった。softprops の既定は `draft: false` で、既存リリースを更新する際にこの既定が適用されて **draft が解除＝即時公開**されていた。

このため v0.17.1（#372）のリリースでも、署名を end-to-end 検証する前にリリースが公開済みになっていた。

## 変更

- `release.yml` のアップロードステップに `draft: true` を明示（再発防止のため理由をコメントで併記）。

## 影響

- 今後 `create-release` を dispatch すると、ビルド後もリリースは **draft のまま**になる。
- リリース担当は draft の成果物（`latest.json` ＋ インストーラ）の署名を検証し、問題なければ **GitHub 上で手動 publish** する。
- updater エンドポイントは "latest"（公開済み）しか参照しないため、draft の間はユーザーへ配信されない＝安全な検証ゲートになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
