### PR TITLE
chore(search): #336 の lower_names 共有 ROI 実測関数を追加（enum 化は見送り）

### DIFF
--- a/snotra-core/src/search.rs
+++ b/snotra-core/src/search.rs
@@ -1493,6 +1493,55 @@ mod tests {
         }
     }
 
+    /// lower_names を name と共有する `enum LowerName`（issue #336）の ROI を実測する。
+    /// `Same`（`to_lower_folded(name) == name`）の比率と、Same エントリで排除できる
+    /// ヒープ文字列実体（現状 `Box<str>` で name とは別アロケーション）の削減量を分解計測する。
+    /// - 16B 粒度丸め: 個別ヒープ確保とみなし 16B 境界へ切り上げた実 RSS 寄りの上界
+    fn measure_lower_name_footprint(label: &str, entries: &[AppEntry]) {
+        let n = entries.len().max(1);
+        let mut same = 0usize;
+        let mut saved_requested = 0usize;
+        let mut saved_rounded = 0usize;
+        for e in entries {
+            let lower = to_lower_folded(&e.name);
+            if lower == e.name {
+                same += 1;
+                let bytes = lower.len();
+                saved_requested += bytes;
+                saved_rounded += bytes.max(1).div_ceil(16) * 16;
+            }
+        }
+        let mb = |b: usize| b as f64 / (1024.0 * 1024.0);
+        let pct = same as f64 * 100.0 / n as f64;
+        println!(
+            "[{label}] n={n} Same={same} ({pct:.1}%)\n  \
+             削減（Same のヒープ文字列実体）要求 {saved_requested}B ({:.3}MB) | 16B丸め {saved_rounded}B ({:.3}MB)\n  \
+             全entry平均 要求 {}B/件 / 丸め {}B/件 | 50k換算 丸め {:.3}MB",
+            mb(saved_requested),
+            mb(saved_rounded),
+            saved_requested / n,
+            saved_rounded / n,
+            mb(saved_rounded * 50_000 / n),
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn measure_lower_name_footprint_report() {
+        use crate::config::Config;
+        use crate::indexer::{scan_all, scan_path_env};
+
+        // 本番相当: 既定 scan paths（Start Menu + Desktop の .lnk）+ PATH 実行ファイル。
+        let mut real = scan_all(&Config::default_scan_paths(), false);
+        let path_entries = scan_path_env(&real, false);
+        real.extend(path_entries);
+        measure_lower_name_footprint("real (start menu + desktop + PATH)", &real);
+
+        // 参考: 合成ベンチ（名前パターンが本番非代表＝Same はほぼ出ない）。
+        measure_lower_name_footprint("synthetic ascii    n=10000", &make_bench_entries(10_000));
+        measure_lower_name_footprint("synthetic katakana n=10000", &make_bench_entries_katakana(10_000));
+    }
+
     fn bench_search(label: &str, n: usize, queries: &[&str]) {
         use std::time::Instant;
         let entries = make_bench_entries(n);


### PR DESCRIPTION
## 概要

`enum LowerName`（`lower_names` を `name` と共有してメモリ削減）の着手判断のため実施した
**Phase 0 ROI 実測**の計測関数を、将来の再評価用に追加する。`measure_kana_footprint`（#337）と
同型の `#[ignore]` テスト。**本番コードは無改変**（`#[cfg(test)]` のみ・+49 行）。

enum 化本体は実測 ROI 不足で見送り済み（#336 は NOT_PLANNED でクローズ）。本 PR は判断根拠を
残すツールのみを main へ載せる。

## 実測結果（本番相当: `default_scan_paths()` + PATH、実 366 エントリ）

| 指標 | 実測 | 見積 |
|------|------|------|
| `Same`（`to_lower_folded(name) == name`）一致率 | 43.2% | ~65% 前提 |
| 50k 換算削減（16B 丸め） | **~0.35MB** | ~0.75〜1.0MB（見積の 35〜47%） |

`Same` は PATH の短い実行ファイル stem（`git`/`node` 等）が主で件数の割に実体削減が小さい。
CJK 名主体の構成では Same 比率・削減が大きく化ける（合成カタカナ = 100% Same・1.9MB/50k）ため、
再評価の余地がある場合は `cargo test --release -p snotra-core measure_lower_name_footprint_report
-- --ignored --nocapture` で再現できる。

## テスト

- `cargo clippy -p snotra-core -- -D warnings`: 警告なし
- `cargo test -p snotra-core`: 374 passed / 0 failed / 9 ignored

関連: #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)
