### PR TITLE
chore(clippy): テストコードの clippy lint 8 件を解消し CI を --all-targets に拡張

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,7 +21,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "input=$(cat); if echo \"$input\" | grep -q '\\.rs\"'; then cargo clippy -p snotra-core -p snotra -p snotra-settings --message-format short -- -D warnings 2>&1 | head -20; fi"
+            "command": "input=$(cat); if echo \"$input\" | grep -q '\\.rs\"'; then cargo clippy -p snotra-core -p snotra -p snotra-settings --all-targets --message-format short -- -D warnings 2>&1 | head -20; fi"
           },
           {
             "type": "command",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,4 +69,4 @@ jobs:
         run: cargo test -p snotra-core
 
       - name: cargo clippy
-        run: cargo clippy -p snotra-core -p snotra -p snotra-settings -- -D warnings
+        run: cargo clippy -p snotra-core -p snotra -p snotra-settings --all-targets -- -D warnings

--- a/snotra-core/src/config.rs
+++ b/snotra-core/src/config.rs
@@ -2156,8 +2156,10 @@ mod tests {
 
     #[test]
     fn normalize_openers_returns_true_when_changed() {
-        let mut config = Config::default();
-        config.openers = vec![make_rule("ext:png,jpg", &[("Viewer", "viewer.exe", "")])];
+        let mut config = Config {
+            openers: vec![make_rule("ext:png,jpg", &[("Viewer", "viewer.exe", "")])],
+            ..Default::default()
+        };
 
         assert!(config.normalize_openers());
         assert_eq!(config.openers[0].target, "ext:.jpg,.png");
@@ -2165,20 +2167,24 @@ mod tests {
 
     #[test]
     fn normalize_openers_returns_false_when_no_change() {
-        let mut config = Config::default();
-        config.openers = vec![make_rule("ext:.jpg,.png", &[("Viewer", "viewer.exe", "")])];
+        let mut config = Config {
+            openers: vec![make_rule("ext:.jpg,.png", &[("Viewer", "viewer.exe", "")])],
+            ..Default::default()
+        };
 
         assert!(!config.normalize_openers());
     }
 
     #[test]
     fn normalize_openers_returns_false_when_multiple_already_sorted() {
-        let mut config = Config::default();
-        config.openers = vec![
-            make_rule("folder:c:\\workspace", &[("Terminal", "wt.exe", "")]),
-            make_rule("folder", &[("Explorer", "explorer.exe", "")]),
-            make_rule("ext:.md", &[("Typora", "typora.exe", "")]),
-        ];
+        let mut config = Config {
+            openers: vec![
+                make_rule("folder:c:\\workspace", &[("Terminal", "wt.exe", "")]),
+                make_rule("folder", &[("Explorer", "explorer.exe", "")]),
+                make_rule("ext:.md", &[("Typora", "typora.exe", "")]),
+            ],
+            ..Default::default()
+        };
         assert!(!config.normalize_openers());
     }
 
@@ -2548,19 +2554,21 @@ mod tests {
 
     #[test]
     fn validate_instant_command_duplicate_name() {
-        let mut config = Config::default();
-        config.instant_commands = vec![
-            InstantCommand {
-                name: "google".to_string(),
-                command: "https://google.com".to_string(),
-                description: String::new(),
-            },
-            InstantCommand {
-                name: "google".to_string(),
-                command: "https://google.co.jp".to_string(),
-                description: String::new(),
-            },
-        ];
+        let config = Config {
+            instant_commands: vec![
+                InstantCommand {
+                    name: "google".to_string(),
+                    command: "https://google.com".to_string(),
+                    description: String::new(),
+                },
+                InstantCommand {
+                    name: "google".to_string(),
+                    command: "https://google.co.jp".to_string(),
+                    description: String::new(),
+                },
+            ],
+            ..Default::default()
+        };
         let errors = config.validate();
         assert!(errors.contains(&ConfigError::InstantCommandDuplicateName {
             name: "google".to_string(),
@@ -2569,19 +2577,21 @@ mod tests {
 
     #[test]
     fn validate_instant_command_unique_names_ok() {
-        let mut config = Config::default();
-        config.instant_commands = vec![
-            InstantCommand {
-                name: "google".to_string(),
-                command: "https://google.com".to_string(),
-                description: String::new(),
-            },
-            InstantCommand {
-                name: "bing".to_string(),
-                command: "https://bing.com".to_string(),
-                description: String::new(),
-            },
-        ];
+        let config = Config {
+            instant_commands: vec![
+                InstantCommand {
+                    name: "google".to_string(),
+                    command: "https://google.com".to_string(),
+                    description: String::new(),
+                },
+                InstantCommand {
+                    name: "bing".to_string(),
+                    command: "https://bing.com".to_string(),
+                    description: String::new(),
+                },
+            ],
+            ..Default::default()
+        };
         let errors = config.validate();
         assert!(
             !errors.iter().any(|e| matches!(e, ConfigError::InstantCommandDuplicateName { .. })),

--- a/snotra-core/src/search.rs
+++ b/snotra-core/src/search.rs
@@ -1162,7 +1162,7 @@ mod tests {
             path: "C:\\A\\tool.exe".to_string(),
             is_folder: false,
         };
-        let mut scored = vec![ra, rb];
+        let mut scored = [ra, rb];
         scored.sort();
         assert_eq!(scored[0].path, "C:\\A\\tool.exe");
         assert_eq!(scored[1].path, "C:\\B\\tool.exe");

--- a/snotra-settings/src/tabs/backup.rs
+++ b/snotra-settings/src/tabs/backup.rs
@@ -232,6 +232,49 @@ fn extract_backtick(s: &str) -> Option<&str> {
     Some(&s[start..end])
 }
 
+/// Returns (message, is_error). None message = cancelled.
+fn handle_export_result(path: Option<PathBuf>, tr: &Tr) -> (Option<String>, bool) {
+    let Some(dest) = path else {
+        return (None, false); // Cancelled
+    };
+    let Some(src) = Config::config_path() else {
+        return (Some(format!("{}config dir not found", tr.status_export_failed())), true);
+    };
+    match std::fs::copy(&src, &dest) {
+        Ok(_) => (Some(tr.status_export_success().to_string()), false),
+        Err(e) => (Some(format!("{}{}", tr.status_export_failed(), first_line(&e.to_string()))), true),
+    }
+}
+
+/// Returns (message, is_error, imported_config). None message = cancelled.
+fn handle_import_result(path: Option<PathBuf>, tr: &Tr) -> (Option<String>, bool, Option<Config>) {
+    let Some(src) = path else {
+        return (None, false, None); // Cancelled
+    };
+    let content = match std::fs::read_to_string(&src) {
+        Ok(c) => c,
+        Err(e) => {
+            return (Some(format!("{}{}", tr.status_import_failed(), first_line(&e.to_string()))), true, None);
+        }
+    };
+    let mut config = match Config::from_toml_str(&content) {
+        Ok(c) => c,
+        Err(e) => {
+            return (Some(format!("{}{}", tr.status_import_failed(), localize_toml_error(&e, tr))), true, None);
+        }
+    };
+    // Apply the same migrations as Config::load() (legacy field migration, normalization, etc.)
+    config.apply_migrations();
+    let errors = config.validate();
+    if !errors.is_empty() {
+        return (Some(format!("{}{}", tr.status_import_validation_error(), config_error_message(&errors[0], tr))), true, None);
+    }
+    if let Err(e) = config.save() {
+        return (Some(format!("{}{}", tr.status_import_failed(), first_line(&e))), true, None);
+    }
+    (Some(tr.status_import_success().to_string()), false, Some(config))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -292,47 +335,4 @@ mod tests {
         assert_eq!(extract_backtick("missing field `target`"), Some("target"));
         assert_eq!(extract_backtick("no backticks here"), None);
     }
-}
-
-/// Returns (message, is_error). None message = cancelled.
-fn handle_export_result(path: Option<PathBuf>, tr: &Tr) -> (Option<String>, bool) {
-    let Some(dest) = path else {
-        return (None, false); // Cancelled
-    };
-    let Some(src) = Config::config_path() else {
-        return (Some(format!("{}config dir not found", tr.status_export_failed())), true);
-    };
-    match std::fs::copy(&src, &dest) {
-        Ok(_) => (Some(tr.status_export_success().to_string()), false),
-        Err(e) => (Some(format!("{}{}", tr.status_export_failed(), first_line(&e.to_string()))), true),
-    }
-}
-
-/// Returns (message, is_error, imported_config). None message = cancelled.
-fn handle_import_result(path: Option<PathBuf>, tr: &Tr) -> (Option<String>, bool, Option<Config>) {
-    let Some(src) = path else {
-        return (None, false, None); // Cancelled
-    };
-    let content = match std::fs::read_to_string(&src) {
-        Ok(c) => c,
-        Err(e) => {
-            return (Some(format!("{}{}", tr.status_import_failed(), first_line(&e.to_string()))), true, None);
-        }
-    };
-    let mut config = match Config::from_toml_str(&content) {
-        Ok(c) => c,
-        Err(e) => {
-            return (Some(format!("{}{}", tr.status_import_failed(), localize_toml_error(&e, tr))), true, None);
-        }
-    };
-    // Apply the same migrations as Config::load() (legacy field migration, normalization, etc.)
-    config.apply_migrations();
-    let errors = config.validate();
-    if !errors.is_empty() {
-        return (Some(format!("{}{}", tr.status_import_validation_error(), config_error_message(&errors[0], tr))), true, None);
-    }
-    if let Err(e) = config.save() {
-        return (Some(format!("{}{}", tr.status_import_failed(), first_line(&e))), true, None);
-    }
-    (Some(tr.status_import_success().to_string()), false, Some(config))
 }

--- a/src-tauri/src/platform/hotkey.rs
+++ b/src-tauri/src/platform/hotkey.rs
@@ -43,6 +43,16 @@ pub fn parse_vk(s: &str) -> u32 {
     }
 }
 
+pub fn register(config: &HotkeyConfig) -> bool {
+    let modifiers = parse_modifier(&config.modifier);
+    let vk = parse_vk(&config.key);
+    unsafe { RegisterHotKey(Some(HWND::default()), HOTKEY_ID, modifiers, vk) }.is_ok()
+}
+
+pub fn unregister() {
+    let _ = unsafe { UnregisterHotKey(Some(HWND::default()), HOTKEY_ID) };
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -65,14 +75,4 @@ mod tests {
         assert_eq!(parse_vk("pageup"), 0x21);
         assert_eq!(parse_vk("delete"), 0x2E);
     }
-}
-
-pub fn register(config: &HotkeyConfig) -> bool {
-    let modifiers = parse_modifier(&config.modifier);
-    let vk = parse_vk(&config.key);
-    unsafe { RegisterHotKey(Some(HWND::default()), HOTKEY_ID, modifiers, vk) }.is_ok()
-}
-
-pub fn unregister() {
-    let _ = unsafe { UnregisterHotKey(Some(HWND::default()), HOTKEY_ID) };
 }


### PR DESCRIPTION
## 背景

CI（`.github/workflows/ci.yml`）と PostToolUse フックの clippy が `--tests` / `--all-targets` を
張っておらず、**`#[cfg(test)]` コードが lint ゲートの死角**になっていた。素の `cargo clippy` は
lib/bin ターゲットのみをコンパイルし、テストコードを lint しないため。新しい clippy（1.94）で
`cargo clippy --all-targets` を回したところ、テストコードに 8 件の lint が蓄積していたことが判明した。

## 修正内容

### テストコードの lint 8 件を解消

| lint | 箇所 | 対応 |
|------|------|------|
| `field_reassign_with_default` ×5 | `snotra-core/src/config.rs` | `Config::default()` 後のフィールド再代入を struct update 構文（`..Default::default()`）へ。`openers` は `normalize_openers(&mut self)` のため `mut` 維持、`instant_commands` は `validate(&self)` のため `mut` 除去 |
| `useless_vec` ×1 | `snotra-core/src/search.rs` | `vec![ra, rb]` → `[ra, rb]`（`sort` はスライスメソッドで配列に適用可） |
| `items_after_test_module` ×2 | `src-tauri/src/platform/hotkey.rs`、`snotra-settings/src/tabs/backup.rs` | `#[cfg(test)] mod tests` の後ろにあった本番関数を前へ移動（**ロジック不変・並べ替えのみ**） |

すべてテストコードの style/配置 lint で、**本番ロジック・挙動は不変**。

### 再発防止: ゲートを `--all-targets` に拡張（2 系統）

テストコードを恒久的に lint 対象にして死角を塞ぐ:

- `.github/workflows/ci.yml`: clippy を `--all-targets` 付きに（**権威的ゲート**）
- `.claude/settings.json`: PostToolUse フックの clippy も `--all-targets` に（ローカル即時フィードバック）

## テスト

- `cargo clippy -p snotra-core -p snotra -p snotra-settings --all-targets -- -D warnings`: 警告なし（新ゲート緑）
- `cargo test -p snotra-core`: 緑 / `cargo test -p snotra-settings`: 6 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
