### PR TITLE
feat(instant): インスタントコマンドに exec(exe+args) 種別を追加

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -831,7 +831,7 @@ query = "%SYSTEMROOT%"
    - 外部入力（query / clip）は env 展開されない
 2. `Command::new(exe).args(args_vec)` で生成
 3. `spawn_blocking` でスレッドプール上で起動
-4. タイムアウト（デフォルト 5 秒）で待機；超過時は強制終了
+4. `spawn_blocking` の join に 4 秒のタイムアウトを設定。`Command::spawn()` は即時復帰（fire-and-forget）であり、タイムアウトは spawn 呼び出し自体の保護。起動済みプログラムの寿命は制御しない
 5. 起動失敗（exe 不在、パーミッション等）は `LaunchResult::failed` として記録
 
 #### 起動結果
@@ -876,8 +876,7 @@ URL 種別:
 - `url`: URL テンプレート（例: `https://www.google.com/search?q={query}`）
 
 exec 種別:
-- `exe`: プログラムパス（例: `C:\Windows\notepad.exe`）
-  - ファイルブラウズダイアログ付き（`.exe` 自動フィルタ）
+- `exe`: プログラムパス（例: `C:\Windows\notepad.exe`）。手入力の単一行テキストフィールド。`.exe` 等の実行ファイルパスを直接入力する（ヒント: `hint_instant_program` 相当のヒントテキストを表示）
 - `args`: コマンドライン引数（任意）（例: `-s {query}`）
 
 **共通フィールド**:

--- a/SPEC.md
+++ b/SPEC.md
@@ -677,31 +677,68 @@ fenrir のインスタントコマンド（`instant.ini`）に相当する機能
 
 ### 19.2 設定構造
 
+インスタントコマンドは **2種別** に分類される：
+
+#### URL 種別（`url` フィールド）
+
 ```toml
 [search]
 instant_command_prefix = "@"  # デフォルト。ユーザーが変更可能
 
 [[instant_commands]]
 name = "g"
-command = "https://www.google.com/search?q={query}"
+url = "https://www.google.com/search?q={query}"
 description = "Google 検索"
 
 [[instant_commands]]
-name = "memo"
-command = "C:\\tools\\editor.exe"
-
-[[instant_commands]]
 name = "trans"
-command = "https://www.deepl.com/translator#ja/en/{clip}"
+url = "https://www.deepl.com/translator#ja/en/{clip}"
 description = "DeepL 日→英翻訳"
 ```
 
+- `http://` または `https://` で始まる URL を実行。`ShellExecuteW` で既定ブラウザで開く
+- 変数値（`{query}` / `{clip}`）は実行前に URL エンコードされる
+
+#### プログラム実行種別（`exe` + `args` フィールド）
+
+```toml
+[[instant_commands]]
+name = "ev"
+exe = "C:\\Users\\User\\scoop\\shims\\everything.exe"
+args = "-s {query}"
+description = "Everything ファイル検索"
+
+[[instant_commands]]
+name = "cmd"
+exe = "cmd.exe"
+args = "/c start notepad.exe {clip}"
+```
+
+- `exe`: プログラムのパス
+- `args`: コマンドライン引数（変数展開対応）。省略可
+- `Command::new(exe).args(args_vec)` で起動。`CREATE_NO_WINDOW` フラグ + stdout/stderr を `/dev/null` にリダイレクト
+- 変数値（`{query}` / `{clip}`）は生のまま展開される（URL エンコードなし）
+
+#### 旧形式（`command` フィールド）
+
+```toml
+# 旧形式（廃止・自動移行）
+[[instant_commands]]
+name = "g"
+command = "https://www.google.com/search?q={query}"
+```
+
+- 旧型式 `command =` は `url` へ無改変移行される（スマート分割なし）
+- 読み込み時に `apply_migrations()` が自動で `url` へ変換
+
+#### 共通フィールド
+
 - `name`: コマンド名（プレフィックス後に入力する文字列）。一意でなければならない
-- `command`: 実行するコマンドライン or URL
-- `description`: コマンドの説明（任意）。省略可。検索結果リストに副テキストとして表示される。省略時はコマンドテンプレートが副テキストに使われる
+- `description`: コマンドの説明（任意）。省略可
+- `display`: 結果リスト副テキスト（url または `exe args` の表現）。省略時は説明を使い、説明も無い場合はコマンドテンプレートを自動生成
 - デフォルト登録済みコマンド（`Config::default()`）:
-  - `g`: `https://www.google.com/search?q={query}`（Google 検索）
-  - `gh`: `https://github.com/search?q={query}`（GitHub 検索）
+  - `g`: URL 種別 `https://www.google.com/search?q={query}`（Google 検索）
+  - `gh`: URL 種別 `https://github.com/search?q={query}`（GitHub 検索）
 - `instant_command_prefix` のバリデーション:
   - 空文字を禁止（全入力がインスタントコマンドモードになるため）
   - `/` を禁止（ビルトインスラッシュコマンドと衝突するため）
@@ -724,27 +761,83 @@ description = "DeepL 日→英翻訳"
 | `{query}` | コマンド名以降の入力テキスト（空なら空文字で展開） |
 | `{clip}` | 実行時点のクリップボード文字列 |
 
-**URL エンコード規則**:
-- `command` が `http://` または `https://` で始まる場合: 変数値を URL エンコードしてから展開
-- それ以外（exe パス / bare コマンド名）: 変数値を生文字列のまま展開
+#### URL 種別の展開
+
+- 変数値を URL エンコードしてから展開（`%` でエスケープ）
+- 記号・空白・非 ASCII 文字が URL 安全形式に変換される
+- 例: `hello world` → `hello%20world`、`機械学習` → `%E6%A9%9F...`
+
+#### プログラム実行種別の展開
+
+exec 種別では、以下の順で展開が行われる:
+
+1. `split_args`: args テンプレートをシェル風にトークン分割（`"..."` で囲まれた部分は空白を保持）
+2. **環境変数展開**: 各トークン内の `%VAR%` を展開（Windows 形式）
+3. **変数置換**: 各トークン内の `{query}` / `{clip}` を展開（生のまま、エンコードなし）
+
+このため以下の性質が成立する:
+- **外部入力（query / clip）は env 展開されない**: `{query}` に `%SYSTEMROOT%` が入力されても文字列通りに展開される（env 変数へのインジェクション防止）
+- **env 値の空白は引数を分割しない**: `%TEMP%` が `C:\a b` の場合、`--dir %TEMP%` は `["--dir", "C:\a b"]` になり（token 内に留まる）、`"--dir" "C:\a b"` のように分割されない
+- **query の空白は1引数を保つ**: `-s {query}` に `hello world` を入力すると `["-s", "hello world"]` になり、`["-s", "hello", "world"]` に分割されない
+- **query に特殊文字が含まれても安全**: `{query}` が `"quoted"` でも `--flag a b` でも、token 内に留まり引数を増やさない
+
+例:
+```
+args = "-s {query}"
+query = "hello world"
+→ ["-s", "hello world"]
+
+args = "--env %APPDATA%"
+%APPDATA% = "C:\a b"
+→ ["--env", "C:\a b"]  # env 値の空白は token 内に留まる
+
+args = "{query}"
+query = "%SYSTEMROOT%"
+→ ["%SYSTEMROOT%"]  # env 展開されず生文字列のまま
+```
 
 ### 19.5 マッチングと結果表示
 
 - プレフィックス（`@`）だけの入力: 登録済みコマンド名を全件表示
-- プレフィックス + 文字入力: コマンド名を前方一致で絞り込み
-- 結果リストにはコマンド名を主表示、description（あればそれ、なければコマンドテンプレート）を副テキストとして表示
+- プレフィックス + 文字入力: コマンド名を前方一致で絞り込み（大文字小文字を区別しない）
+- 結果リストの副テキスト（`display` フィールド）:
+  - URL 種別: URL テンプレート（例: `https://www.google.com/search?q={query}`）
+  - exec 種別: `exe args` の組み合わせ（例: `C:\everything.exe -s {query}`）
+  - `description` が設定されている場合、これを優先表示（`display` は表示されない）
 - スペースが入力された時点でマッチングを確定し、以降は `{query}` として扱う
 - インスタントコマンドモード中はアイコン取得をスキップする（`path` がファイルパスではないため）
 - マッチするコマンドが0件の場合は結果を空にする（`noResults` 表示はしない）
 
 ### 19.6 実行フロー
 
+#### 実行基本
+
 - Enter / クリック: 選択中のコマンドを実行
-  1. `{query}` と `{clip}` を展開
-  2. URL 判定（`http://` `https://`）→ 変数を URL エンコード
-  3. 既存の `launch_item_core`（`ShellExecuteW` + COM STA）を再利用して実行（新規に `ShellExecuteW` 呼び出しを書かない）
 - Shift+Enter: 通常 Enter と同じ動作（インスタントコマンドにツール選択は無関係）
 - 実行後: クエリクリア、ウィンドウを非表示にする（スラッシュコマンドと同じ）
+
+#### 種別ディスパッチ
+
+実行時に `action` フィールドの種別に応じてディスパッチ:
+
+**URL 種別** (`InstantAction::Url`):
+1. 変数を展開（`{query}` / `{clip}`）して URL エンコード
+2. `ShellExecuteW(..., "open", url, ...)` で既定ブラウザで開く
+3. 既存の `launch_item_core` を再利用
+
+**プログラム実行種別** (`InstantAction::Exec`):
+1. `expand_exec_args(args, query, clipboard, env_expand)` で引数ベクタを構築
+   - split → env 展開 → 変数置換の順序で処理
+   - 外部入力（query / clip）は env 展開されない
+2. `Command::new(exe).args(args_vec)` で生成
+3. `spawn_blocking` でスレッドプール上で起動
+4. タイムアウト（デフォルト 5 秒）で待機；超過時は強制終了
+5. 起動失敗（exe 不在、パーミッション等）は `LaunchResult::failed` として記録
+
+#### 起動結果
+
+- `LaunchResult::succeeded`: 起動成功（ブラウザ・プロセスが spawned）
+- `LaunchResult::failed`: 起動失敗（exe 不在、パーミッション不足等）。エラーメッセージをログに記録
 
 ### 19.7 状態モデル
 
@@ -767,8 +860,37 @@ description = "DeepL 日→英翻訳"
 - 設定画面のタブ構成: 全般/検索/インデックス/ビジュアル/オープナー/インスタントコマンド
 - プレフィックス設定（テキスト入力、デフォルト `@`）
 - コマンド追加/編集/削除/複製
-- 各コマンド: `name`（コマンド名）、`command`（実行コマンド or URL）、`description`（説明、任意）
-- コマンド編集モーダルに展開プレビュー表示（`{query}` に "example"、`{clip}` に "(clipboard)" を入れた結果を表示）
+
+#### コマンド編集フォーム
+
+**必須フィールド**:
+- `name`: コマンド名
+
+**種別選択** (ラジオボタン):
+- URL: URL ベースのコマンド（`http://` / `https://`）
+- exec: プログラム実行（`.exe` 等）
+
+**種別別フィールド**:
+
+URL 種別:
+- `url`: URL テンプレート（例: `https://www.google.com/search?q={query}`）
+
+exec 種別:
+- `exe`: プログラムパス（例: `C:\Windows\notepad.exe`）
+  - ファイルブラウズダイアログ付き（`.exe` 自動フィルタ）
+- `args`: コマンドライン引数（任意）（例: `-s {query}`）
+
+**共通フィールド**:
+- `description`: 説明（任意）。結果リスト副テキストとして表示
+
+**展開プレビュー**:
+- 編集モーダル下部に「展開例」を表示
+- `{query}` を "example" で、`{clip}` を "(clipboard)" で置換した結果をプレビュー
+- URL 種別: URL エンコード状態を表示
+- exec 種別: 分割後の引数ベクタをプレビュー（`[exe, arg1, arg2, ...]` の形式）
+
+**旧形式からの移行ヒント**:
+- 既存 config に旧 `command =` フィールドが存在する場合、フォーム内に「この設定は旧形式です。読み込み時に自動で `url` へ移行されます」と表示
 
 ### 19.9 設定反映
 

--- a/docs/superpowers/plans/2026-06-27-instant-command-exec-action.md
+++ b/docs/superpowers/plans/2026-06-27-instant-command-exec-action.md
@@ -303,9 +303,10 @@ git commit -m "feat(core): expand_vars / expand_exec_args を追加（exec 引�
         assert!(cfg.apply_migrations());
         assert_eq!(cfg.instant_commands[0].action,
             InstantAction::Url { url: "C:\\tools\\editor.exe".into() }); // Exec にしない
-        let changed_again = cfg.apply_migrations();
-        assert!(!changed_again || cfg.instant_commands[0].action
-            == InstantAction::Url { url: "C:\\tools\\editor.exe".into() }); // 冪等
+        // 冪等: 2回目は Legacy が残っていないので action は Url のまま
+        cfg.apply_migrations();
+        assert_eq!(cfg.instant_commands[0].action,
+            InstantAction::Url { url: "C:\\tools\\editor.exe".into() });
     }
 
     #[test] // T1: Config 全体の serialize 往復で変種が保たれる

--- a/docs/superpowers/plans/2026-06-27-instant-command-exec-action.md
+++ b/docs/superpowers/plans/2026-06-27-instant-command-exec-action.md
@@ -1,0 +1,1000 @@
+# インスタントコマンド exec 種別追加 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** インスタントコマンドに「実行ファイル + 引数」種別（`exec`）を追加し、`everything.exe -s {query}` のような引数つきコマンドが正しく起動するようにする。
+
+**Architecture:** `InstantCommand` を `InstantAction`（`Url`/`Exec`/`Legacy`）の untagged enum を持つ形に拡張する。`Url` は現状の `ShellExecuteW` 経路（ゼロ回帰）、`Exec` は `Command::new(exe).args(...)` 経路。引数分割（`split_args`）と変数展開（`expand_vars`/`expand_exec_args`）は `snotra-core` の純関数に集約し、Win32（env 展開・spawn）は `src-tauri` に残す。旧 `command` は `Legacy` variant が拾い `apply_migrations` で `Url` へ無改変移行する。
+
+**Tech Stack:** Rust（snotra-core / src-tauri "snotra" / snotra-settings）、serde + toml 1.x、Tauri v2、egui（設定 GUI）、SolidJS + TypeScript（ui）、Vitest。
+
+設計書: `docs/superpowers/specs/2026-06-27-instant-command-exec-action-design.md`
+
+## Global Constraints
+
+- ブランチは `feat/instant-command-exec-action`（既存）。`main` へ直接コミットしない。`git` コマンドはチェーンしない（`add` と `commit` を分ける）。
+- `snotra-core` は Win32 非依存・ユニットテスト必須。env 展開は関数注入（`env_expand: impl Fn(&str) -> String`）でテスト可能に保つ。
+- Rust ツールチェーンは **≥ 1.77.2**（CVE-2024-24576 / BatBadBut 対策。`.bat`/`.cmd` 引数エスケープ）。
+- `.rs` 編集後は PostToolUse フックが clippy（`snotra-core` 編集では core テストも）を自動実行する。明示コマンドは `docs/build-commands.md` を SSOT とする。
+- **Rust タスク間の下流クレート compile-fail は意図的な「改名検出器」**（AGENTS.md）。各タスクは自クレートを green に戻す。全クレート green に戻るのは Task 6 完了時。
+- Rust 検証: `cargo check -p snotra-core -p snotra -p snotra-settings` / `cargo clippy -p snotra-core -p snotra -p snotra-settings --all-targets -- -D warnings` / `cargo test -p snotra-core`
+- フロント検証: `npm run typecheck` / `npm test` / `npm run build`
+- 各コミットの末尾に `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer を付ける（`git commit -m "subject" -m "Co-Authored-By: …"` 等）。
+- `windows` クレート（v0.62）の API（`ExpandEnvironmentStringsW` 等）はシグネチャ・feature フラグを使用前に確認する（`src-tauri/CLAUDE.md`）。
+- exec 種別は **`.exe` 限定**（`.bat`/`.cmd`/`.lnk` 不可）。exe ピッカーフィルタは `["exe"]`。
+- 変数展開順序: `split_args` → トークンごとに **env 展開 → `{query}`/`{clip}` 置換**。外部入力（query/clip）は env 展開しない。
+
+---
+
+### Task 1: `split_args` を snotra-core へ移設
+
+**Files:**
+- Modify: `snotra-core/src/instant.rs`（`split_args` を追加）
+- Modify: `src-tauri/src/commands/launch.rs:154-201`（`split_args` 定義を削除し import に置換）
+
+**Interfaces:**
+- Produces: `pub fn snotra_core::instant::split_args(args: &str) -> Vec<String>`（クォート対応分割。`"…"` 内の空白を1トークンに保持。空クォート `""` はトークンを生成しない）
+
+- [ ] **Step 1: 移設先テストを書く（失敗）**
+
+`snotra-core/src/instant.rs` の `#[cfg(test)] mod tests` に追加（既存 launch.rs のテストを移設）:
+
+```rust
+    // ---- split_args (quote-aware splitting) tests ----
+    #[test]
+    fn split_args_quoted_token_preserves_spaces() {
+        assert_eq!(split_args(r#"--dir "My Documents""#), vec!["--dir", "My Documents"]);
+    }
+    #[test]
+    fn split_args_unclosed_quote_consumes_to_end() {
+        assert_eq!(split_args(r#"--dir "My Documents"#), vec!["--dir", "My Documents"]);
+    }
+    #[test]
+    fn split_args_adjacent_quotes_join() {
+        assert_eq!(split_args(r#"--open="My File""#), vec!["--open=My File"]);
+    }
+    #[test]
+    fn split_args_empty_quotes_produce_no_token() {
+        assert_eq!(split_args(r#"a "" b"#), vec!["a", "b"]);
+    }
+    #[test]
+    fn split_args_plain_whitespace_only() {
+        assert_eq!(split_args("  -a   -b  "), vec!["-a", "-b"]);
+    }
+```
+
+- [ ] **Step 2: テスト失敗を確認**
+
+Run: `cargo test -p snotra-core split_args`
+Expected: FAIL（`split_args` 未定義 / コンパイルエラー）
+
+- [ ] **Step 3: `split_args` を instant.rs に移設**
+
+`snotra-core/src/instant.rs` のトップレベル（`expand_instant_command` の近く）に追加:
+
+```rust
+/// シェル風クォート対応の引数分割。
+/// `"..."` で囲まれた部分はスペースを含んでも1トークンとして扱う。
+/// 閉じクォートがない場合は行末まで1トークン。
+/// 空クォート `""` はトークンを生成しない。
+pub fn split_args(args: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    for ch in args.chars() {
+        match ch {
+            '"' => in_quotes = !in_quotes,
+            c if c.is_whitespace() && !in_quotes => {
+                if !current.is_empty() {
+                    tokens.push(std::mem::take(&mut current));
+                }
+            }
+            c => current.push(c),
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens
+}
+```
+
+- [ ] **Step 4: launch.rs の定義を削除し import に置換**
+
+`src-tauri/src/commands/launch.rs`:
+- `fn split_args(...) { ... }`（154-201 付近の `split_args` 本体）を削除
+- `build_launch_args` 内の `split_args(args)` 呼び出しを `snotra_core::instant::split_args(args)` に変更
+- launch.rs の `#[cfg(test)] mod tests` にある `use super::split_args;` と `split_args_*` テスト群を削除（snotra-core へ移設済み）。`build_launch_args` のテストは残す
+
+- [ ] **Step 5: テスト通過とビルドを確認**
+
+Run: `cargo test -p snotra-core split_args`
+Expected: PASS（5件）
+Run: `cargo check -p snotra-core -p snotra -p snotra-settings`
+Expected: 全 crate green（移設は機械的でシグネチャ変更なし）
+
+- [ ] **Step 6: コミット**
+
+```
+git add snotra-core/src/instant.rs src-tauri/src/commands/launch.rs
+git commit -m "refactor(core): split_args を snotra-core へ移設しオープナーと共有"
+```
+
+---
+
+### Task 2: `expand_vars` と `expand_exec_args` を snotra-core に新設
+
+**Files:**
+- Modify: `snotra-core/src/instant.rs`
+
+**Interfaces:**
+- Produces:
+  - `pub fn expand_vars(template: &str, query: &str, clipboard: &str) -> String`（`{query}`/`{clip}` を生置換）
+  - `pub fn expand_exec_args(args: &str, query: &str, clipboard: &str, env_expand: impl Fn(&str) -> String) -> Vec<String>`（`split_args` → 各トークンに `env_expand` → `expand_vars`）
+- Consumes: `split_args`（Task 1）
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`snotra-core/src/instant.rs` の `mod tests` に追加:
+
+```rust
+    // ---- expand_exec_args tests ----
+    fn no_env(s: &str) -> String { s.to_string() }
+
+    #[test]
+    fn exec_args_empty_is_no_tokens() {
+        let r = expand_exec_args("", "q", "c", no_env);
+        assert!(r.is_empty()); // build_launch_args と異なり末尾 append しない
+    }
+    #[test]
+    fn exec_args_query_with_spaces_stays_one_arg() {
+        let r = expand_exec_args("-s {query}", "hello world", "", no_env);
+        assert_eq!(r, vec!["-s", "hello world"]);
+    }
+    #[test]
+    fn exec_args_query_cannot_inject_extra_args() {
+        let r = expand_exec_args("-s {query}", "--flag a b", "", no_env);
+        assert_eq!(r, vec!["-s", "--flag a b"]); // 展開は split 後なので1引数のまま
+    }
+    #[test]
+    fn exec_args_query_quote_is_literal() {
+        let r = expand_exec_args("{query}", "a\"b", "", no_env);
+        assert_eq!(r, vec!["a\"b"]); // split は展開前に走るので再分割しない
+    }
+    #[test]
+    fn exec_args_clip_newline_is_literal() {
+        let r = expand_exec_args("{clip}", "", "a\nb", no_env);
+        assert_eq!(r, vec!["a\nb"]);
+    }
+    #[test]
+    fn exec_args_empty_query_yields_empty_arg() {
+        let r = expand_exec_args("-s {query}", "", "", no_env);
+        assert_eq!(r, vec!["-s", ""]);
+    }
+    #[test]
+    fn exec_args_inline_placeholder_preserves_space() {
+        let r = expand_exec_args("-s={query}", "hello world", "", no_env);
+        assert_eq!(r, vec!["-s=hello world"]);
+    }
+    #[test]
+    fn exec_args_env_value_with_space_stays_in_token() {
+        // env 展開は split 後なので env 値の空白が引数を割らない
+        let env = |s: &str| s.replace("%FOO%", "C:\\a b");
+        let r = expand_exec_args("--dir %FOO%", "", "", env);
+        assert_eq!(r, vec!["--dir", "C:\\a b"]);
+    }
+    #[test]
+    fn exec_args_external_input_is_not_env_expanded() {
+        // query が運んだ %FOO% は展開されない（env 展開はトークン→置換の順で置換が後）
+        let env = |s: &str| s.replace("%FOO%", "EXPANDED");
+        let r = expand_exec_args("{query}", "%FOO%", "", env);
+        assert_eq!(r, vec!["%FOO%"]);
+    }
+```
+
+- [ ] **Step 2: テスト失敗を確認**
+
+Run: `cargo test -p snotra-core exec_args`
+Expected: FAIL（`expand_exec_args` 未定義）
+
+- [ ] **Step 3: 実装**
+
+`snotra-core/src/instant.rs`、`expand_instant_command` の直後に追加。既存 `expand_instant_command` も `expand_vars` を使う形へリファクタ:
+
+```rust
+/// `{query}` / `{clip}` を生のまま置換する。URL エンコードはしない。
+pub fn expand_vars(template: &str, query: &str, clipboard: &str) -> String {
+    template.replace("{query}", query).replace("{clip}", clipboard)
+}
+
+/// exec 種別の引数トークン列を構築する。
+/// 手順: `split_args` で分割 → 各トークンに `env_expand`（環境変数展開）→ `{query}`/`{clip}` 置換。
+/// この順序により (1) 外部入力 query/clip は env 展開されない、(2) env 値の空白は
+/// トークン内に留まり引数を割らない、(3) 空白入り query は1引数を保つ。
+/// `build_launch_args` の `{path}` 末尾補完は行わない（exec は path を持たない）。
+pub fn expand_exec_args(
+    args: &str,
+    query: &str,
+    clipboard: &str,
+    env_expand: impl Fn(&str) -> String,
+) -> Vec<String> {
+    split_args(args)
+        .into_iter()
+        .map(|tok| expand_vars(&env_expand(&tok), query, clipboard))
+        .collect()
+}
+```
+
+`expand_instant_command` 本体を `expand_vars` 経由に書き換え（挙動不変）:
+
+```rust
+pub fn expand_instant_command(command: &str, query: &str, clipboard: &str) -> String {
+    let is_url = command.starts_with("http://") || command.starts_with("https://");
+    if is_url {
+        let q = utf8_percent_encode(query, NON_ALPHANUMERIC).to_string();
+        let c = utf8_percent_encode(clipboard, NON_ALPHANUMERIC).to_string();
+        expand_vars(command, &q, &c)
+    } else {
+        expand_vars(command, query, clipboard)
+    }
+}
+```
+
+- [ ] **Step 4: テスト通過を確認**
+
+Run: `cargo test -p snotra-core instant`
+Expected: PASS（新規 `exec_args_*` 9件 + 既存 `expand_instant_command` テスト群が引き続き通る）
+
+- [ ] **Step 5: 全 crate ビルドを確認**
+
+Run: `cargo check -p snotra-core -p snotra -p snotra-settings`
+Expected: 全 crate green（`expand_instant_command` のシグネチャ不変・新関数は追加のみ）
+
+- [ ] **Step 6: コミット**
+
+```
+git add snotra-core/src/instant.rs
+git commit -m "feat(core): expand_vars / expand_exec_args を追加（exec 引数構築の純関数）"
+```
+
+---
+
+### Task 3: データモデル（`InstantAction` enum）と移行・serde ゲート
+
+**Files:**
+- Modify: `snotra-core/src/config.rs:48-54`（`InstantCommand` 構造体）、`apply_migrations`（888）、`Config::default()` instant_commands（758-769）、テスト群（1700 付近・2788/2810・2836）
+- Modify: `snotra-core/src/instant.rs`（`mod tests` の `sample_commands` フィクスチャ 123-128, 165）
+
+**Interfaces:**
+- Produces:
+  - `pub enum InstantAction { Url { url: String }, Exec { exe: String, args: String }, Legacy { command: String } }`（`#[serde(untagged)]`、`Exec.args` は `#[serde(default)]`）
+  - `InstantCommand { name: String, description: String, action: InstantAction }`（`action` は `#[serde(flatten)]`）
+  - 移行後 `Legacy` は存在しない（`apply_migrations` が `Url` 化）
+
+- [ ] **Step 1: serde ゲートと移行テストを書く（失敗）**
+
+`snotra-core/src/config.rs` の `mod tests` に追加。**T2/T1/T3/T15/T17 が最優先ゲート**:
+
+```rust
+    // ---- InstantAction serde gate (release gate: 失敗は全設定リセットを意味する) ----
+    fn cfg_with_instant(cmds: Vec<InstantCommand>) -> Config {
+        Config { instant_commands: cmds, ..Default::default() }
+    }
+
+    #[test] // T2: legacy 行が deserialize できる（最重要・データ損失検出器）
+    fn instant_legacy_command_deserializes() {
+        let legacy = cfg_with_instant(vec![InstantCommand {
+            name: "g".into(), description: String::new(),
+            action: InstantAction::Legacy { command: "https://x/?q={query}".into() },
+        }]);
+        let s = toml::to_string(&legacy).expect("serialize legacy");
+        // Legacy は `command = "..."` 形（=旧オンディスク形式）で出力される
+        assert!(s.contains("command ="));
+        let parsed: Config = toml::from_str(&s).expect("legacy deserialize must succeed");
+        assert!(matches!(parsed.instant_commands[0].action, InstantAction::Legacy { .. }));
+    }
+
+    #[test] // T15 + T17: legacy → Url 移行（自動分割しない）・冪等
+    fn instant_legacy_migrates_to_url_idempotently() {
+        let mut cfg = cfg_with_instant(vec![InstantCommand {
+            name: "ev".into(), description: String::new(),
+            action: InstantAction::Legacy { command: "C:\\tools\\editor.exe".into() },
+        }]);
+        assert!(cfg.apply_migrations());
+        assert_eq!(cfg.instant_commands[0].action,
+            InstantAction::Url { url: "C:\\tools\\editor.exe".into() }); // Exec にしない
+        let changed_again = cfg.apply_migrations();
+        assert!(!changed_again || cfg.instant_commands[0].action
+            == InstantAction::Url { url: "C:\\tools\\editor.exe".into() }); // 冪等
+    }
+
+    #[test] // T1: Config 全体の serialize 往復で変種が保たれる
+    fn instant_exec_roundtrip_preserves_variant() {
+        let cfg = cfg_with_instant(vec![InstantCommand {
+            name: "ev".into(), description: "Everything".into(),
+            action: InstantAction::Exec { exe: "everything.exe".into(), args: "-s {query}".into() },
+        }]);
+        let s = toml::to_string_pretty(&cfg).expect("serialize");
+        let parsed: Config = toml::from_str(&s).expect("deserialize");
+        assert_eq!(parsed.instant_commands[0].action,
+            InstantAction::Exec { exe: "everything.exe".into(), args: "-s {query}".into() });
+    }
+
+    #[test] // T3: url と exe を両方書いた行は Url 先勝ち（untagged 宣言順）
+    fn instant_both_url_and_exe_prefers_url() {
+        let toml_str = r#"
+            [hotkey]
+            modifier = "Alt"
+            key = "Q"
+            [appearance]
+            window_width = 600
+            [paths]
+            additional = []
+            [[instant_commands]]
+            name = "x"
+            url = "https://x"
+            exe = "y.exe"
+        "#;
+        let cfg: Config = toml::from_str(toml_str).expect("parse");
+        assert!(matches!(cfg.instant_commands[0].action, InstantAction::Url { .. }));
+    }
+
+    #[test] // T4: Exec で args 省略 → 空文字
+    fn instant_exec_args_defaults_empty() {
+        let toml_str = r#"
+            [hotkey]
+            modifier = "Alt"
+            key = "Q"
+            [appearance]
+            window_width = 600
+            [paths]
+            additional = []
+            [[instant_commands]]
+            name = "n"
+            exe = "notepad.exe"
+        "#;
+        let cfg: Config = toml::from_str(toml_str).expect("parse");
+        assert_eq!(cfg.instant_commands[0].action,
+            InstantAction::Exec { exe: "notepad.exe".into(), args: String::new() });
+    }
+```
+
+- [ ] **Step 2: テスト失敗を確認**
+
+Run: `cargo test -p snotra-core instant_legacy_command_deserializes`
+Expected: FAIL（`InstantAction` 未定義・`InstantCommand.action` 未定義でコンパイルエラー）
+
+> **ゲート判断**: Step 4 で `instant_legacy_command_deserializes`（T2）が通らない場合、`flatten`+`untagged`+`toml` の非互換が判明したことを意味する。設計 §3.1 の退避B（フラット `Option<String>` 群 url/exe/args/command + `validate` 排他）へ切り替える。**先に進まない**。
+
+- [ ] **Step 3: 構造体と enum を変更**
+
+`snotra-core/src/config.rs:48-54` を置換:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InstantCommand {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(flatten)]
+    pub action: InstantAction,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum InstantAction {
+    Url { url: String },
+    Exec {
+        exe: String,
+        #[serde(default)]
+        args: String,
+    },
+    Legacy { command: String },
+}
+```
+
+- [ ] **Step 4: 移行ロジックを追加**
+
+`apply_migrations`（config.rs:888）の `changed` を返す前（952 の `changed` 直前）に追加:
+
+```rust
+        // 旧 `command` 単一文字列 → `Url` へ無改変移行（自動分割しない＝ゼロ回帰）
+        for cmd in &mut self.instant_commands {
+            if let InstantAction::Legacy { command } = &mut cmd.action {
+                let url = std::mem::take(command);
+                cmd.action = InstantAction::Url { url };
+                changed = true;
+            }
+        }
+```
+
+`Config::default()` の instant_commands（758-769）を置換:
+
+```rust
+            instant_commands: vec![
+                InstantCommand {
+                    name: "g".to_string(),
+                    description: "Google 検索".to_string(),
+                    action: InstantAction::Url {
+                        url: "https://www.google.com/search?q={query}".to_string(),
+                    },
+                },
+                InstantCommand {
+                    name: "gh".to_string(),
+                    description: "GitHub 検索".to_string(),
+                    action: InstantAction::Url {
+                        url: "https://github.com/search?q={query}".to_string(),
+                    },
+                },
+            ],
+```
+
+- [ ] **Step 5: 既存フィクスチャを `action` 形へ更新**
+
+`snotra-core/src/config.rs`:
+- `validate_instant_command_duplicate_name`（2790-2800）と `validate_instant_command_unique_names_ok`（2813-2823）の各 `InstantCommand { name, command: "...", description }` を `InstantCommand { name, description, action: InstantAction::Url { url: "...".into() } }` へ
+- 既存 `instant_command_round_trip_toml`（2836）を、移行後の変種も検証する形へ書き換え（転用で不変条件を孤立させない）:
+
+```rust
+    #[test]
+    fn instant_command_round_trip_toml() {
+        let toml_str = r#"
+            [hotkey]
+            modifier = "Alt"
+            key = "Q"
+            [appearance]
+            window_width = 600
+            [paths]
+            additional = []
+            [[instant_commands]]
+            name = "g"
+            command = "https://google.com/search?q={query}"
+            [[instant_commands]]
+            name = "memo"
+            command = "C:\\tools\\editor.exe"
+        "#;
+        let mut config: Config = toml::from_str(toml_str).expect("parse");
+        config.apply_migrations();
+        assert_eq!(config.instant_commands.len(), 2);
+        assert_eq!(config.instant_commands[0].name, "g");
+        assert!(matches!(config.instant_commands[0].action, InstantAction::Url { .. }));
+        assert!(matches!(config.instant_commands[1].action, InstantAction::Url { .. }));
+    }
+```
+
+`snotra-core/src/instant.rs` の `sample_commands`（123-128）と `filter_case_insensitive`（165）の `InstantCommand { name, command: "...", description }` リテラルを `action: InstantAction::Url { url: "...".into() }` 形へ（`use crate::config::InstantAction;` を test mod に追加）。
+
+- [ ] **Step 6: テスト通過を確認**
+
+Run: `cargo test -p snotra-core`
+Expected: PASS（serde ゲート T1-T4/T15/T17 含む全 core テスト。**T2 が green であること＝データ損失なし**）
+
+- [ ] **Step 7: snotra-core を確認（下流は意図的に red）**
+
+Run: `cargo check -p snotra-core`
+Expected: green
+Run: `cargo check -p snotra`
+Expected: **FAIL（意図的）**。`.command` 参照（src-tauri/commands/instant.rs）と `get_instant_commands` の戻り型で改名検出。Task 4 で修復する
+
+- [ ] **Step 8: コミット**
+
+```
+git add snotra-core/src/config.rs snotra-core/src/instant.rs
+git commit -m "feat(core): InstantCommand を Url/Exec/Legacy 種別へ拡張・legacy 移行"
+```
+
+---
+
+### Task 4: src-tauri の実行ディスパッチ・exec 起動・IPC DTO
+
+**Files:**
+- Modify: `src-tauri/src/commands/instant.rs`（`execute_instant_command` ディスパッチ・`get_instant_commands` DTO 化）
+- Modify: `src-tauri/src/commands/launch.rs`（`launch_exec_core` 追加・`InstantCommandDto` 追加・`expand_env` 追加）
+- Modify: `src-tauri/Cargo.toml`（`windows` クレートに `Win32_System_Environment` feature 追加）
+
+**Interfaces:**
+- Consumes: `InstantAction`（Task 3）、`expand_vars`/`expand_exec_args`（Task 2）
+- Produces:
+  - `pub struct InstantCommandDto { name: String, description: String, display: String }`（camelCase serialize）
+  - `get_instant_commands(...) -> Result<Vec<InstantCommandDto>, String>`
+  - `fn launch_exec_core(exe: &str, args: &str, query: &str, clipboard: &str) -> LaunchResult`
+
+- [ ] **Step 1: DTO 表示文字列の純テストを書く（失敗）**
+
+`src-tauri/src/commands/launch.rs` の `#[cfg(test)] mod tests` に追加:
+
+```rust
+    use super::InstantCommandDto;
+    use snotra_core::config::{InstantCommand, InstantAction};
+
+    #[test]
+    fn instant_dto_display_url() {
+        let c = InstantCommand { name: "g".into(), description: "d".into(),
+            action: InstantAction::Url { url: "https://x".into() } };
+        assert_eq!(InstantCommandDto::from(&c).display, "https://x");
+    }
+    #[test]
+    fn instant_dto_display_exec_with_args() {
+        let c = InstantCommand { name: "ev".into(), description: String::new(),
+            action: InstantAction::Exec { exe: "everything.exe".into(), args: "-s {query}".into() } };
+        assert_eq!(InstantCommandDto::from(&c).display, "everything.exe -s {query}");
+    }
+    #[test]
+    fn instant_dto_display_exec_no_args_has_no_trailing_space() {
+        let c = InstantCommand { name: "n".into(), description: String::new(),
+            action: InstantAction::Exec { exe: "notepad.exe".into(), args: String::new() } };
+        assert_eq!(InstantCommandDto::from(&c).display, "notepad.exe");
+    }
+```
+
+- [ ] **Step 2: テスト失敗を確認**
+
+Run: `cargo test -p snotra instant_dto`
+Expected: FAIL（`InstantCommandDto` 未定義）
+
+- [ ] **Step 3: DTO と `launch_exec_core`・`expand_env` を実装**
+
+`src-tauri/src/commands/launch.rs` に追加:
+
+```rust
+use snotra_core::config::{InstantCommand, InstantAction};
+use snotra_core::instant::{expand_vars, expand_exec_args};
+use std::process::Stdio;
+
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// フロントへ返すインスタントコマンド情報（種別の内部構造を隠す）
+#[derive(serde::Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct InstantCommandDto {
+    pub name: String,
+    pub description: String,
+    pub display: String,
+}
+
+impl From<&InstantCommand> for InstantCommandDto {
+    fn from(c: &InstantCommand) -> Self {
+        let display = match &c.action {
+            InstantAction::Url { url } => url.clone(),
+            InstantAction::Exec { exe, args } => {
+                if args.is_empty() { exe.clone() } else { format!("{exe} {args}") }
+            }
+            InstantAction::Legacy { command } => command.clone(),
+        };
+        Self { name: c.name.clone(), description: c.description.clone(), display }
+    }
+}
+
+/// 環境変数 `%VAR%` を展開する（Win32 ExpandEnvironmentStringsW）。非 Windows は素通し。
+pub(crate) fn expand_env(input: &str) -> String {
+    #[cfg(windows)]
+    {
+        use windows::Win32::System::Environment::ExpandEnvironmentStringsW;
+        use windows::core::HSTRING;
+        let src = HSTRING::from(input);
+        unsafe {
+            let needed = ExpandEnvironmentStringsW(&src, None);
+            if needed == 0 { return input.to_string(); }
+            let mut buf = vec![0u16; needed as usize];
+            let written = ExpandEnvironmentStringsW(&src, Some(&mut buf));
+            if written == 0 { return input.to_string(); }
+            // 末尾 NUL を除いて UTF-16 → String
+            let len = (written as usize).saturating_sub(1);
+            String::from_utf16_lossy(&buf[..len])
+        }
+    }
+    #[cfg(not(windows))]
+    { input.to_string() }
+}
+
+/// exec 種別の起動。COM 不要（CreateProcessW 直叩き）。
+pub(crate) fn launch_exec_core(exe: &str, args: &str, query: &str, clipboard: &str) -> LaunchResult {
+    let exe_expanded = expand_vars(&expand_env(exe), query, clipboard);
+    let arg_tokens = expand_exec_args(args, query, clipboard, expand_env);
+
+    let mut cmd = std::process::Command::new(&exe_expanded);
+    cmd.args(&arg_tokens);
+    cmd.stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null());
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    match cmd.spawn() {
+        Ok(_) => LaunchResult::ok(0),
+        Err(e) => LaunchResult::failed(-1, format!("spawn_failed: {e}")),
+    }
+}
+```
+
+`src-tauri/Cargo.toml` の `windows` 依存の `features` に `"Win32_System_Environment"` を追加。
+
+> **API 確認**: `ExpandEnvironmentStringsW` の windows v0.62 でのシグネチャ（引数の `PCWSTR`/`Option<&mut [u16]>`・戻り値 `u32`＝NUL 含む TCHAR 数）を実装前に確認する。差異があれば呼び出しを調整する。
+
+- [ ] **Step 4: DTO テスト通過を確認**
+
+Run: `cargo test -p snotra instant_dto`
+Expected: PASS（3件）
+
+- [ ] **Step 5: `execute_instant_command` と `get_instant_commands` をディスパッチ化**
+
+`src-tauri/src/commands/instant.rs`:
+
+`get_instant_commands` の戻り型を DTO へ:
+
+```rust
+#[tauri::command]
+pub fn get_instant_commands(
+    prefix_input: String,
+    app: tauri::AppHandle,
+) -> Result<Vec<super::launch::InstantCommandDto>, String> {
+    let state = app.state::<AppState>();
+    let engine = state.engine.lock().unwrap();
+    let commands = &engine.config().instant_commands;
+    Ok(filter_instant_commands(commands, &prefix_input)
+        .into_iter()
+        .map(super::launch::InstantCommandDto::from)
+        .collect())
+}
+```
+
+`execute_instant_command` を `action` でディスパッチ（テンプレート取得を `action.clone()` に変更）:
+
+```rust
+    let action = {
+        let state = app.state::<AppState>();
+        let engine = state.engine.lock().unwrap();
+        engine.config().instant_commands.iter()
+            .find(|c| c.name == name)
+            .ok_or_else(|| format!("instant command not found: {name}"))?
+            .action.clone()
+    };
+
+    let clipboard = arboard::Clipboard::new()
+        .and_then(|mut cb| cb.get_text())
+        .unwrap_or_default();
+
+    let join = tauri::async_runtime::spawn_blocking(move || {
+        use snotra_core::config::InstantAction;
+        match action {
+            InstantAction::Url { url } => {
+                let expanded = expand_instant_command(&url, &query, &clipboard);
+                super::launch::launch_item_core(&expanded)
+            }
+            InstantAction::Exec { exe, args } => {
+                super::launch::launch_exec_core(&exe, &args, &query, &clipboard)
+            }
+            // load 後は移行済みで到達しないが、防御的に Url 扱い
+            InstantAction::Legacy { command } => {
+                let expanded = expand_instant_command(&command, &query, &clipboard);
+                super::launch::launch_item_core(&expanded)
+            }
+        }
+    });
+    let result = match timeout(Duration::from_millis(LAUNCH_TIMEOUT_MS), join).await {
+        Ok(Ok(v)) => v,
+        Ok(Err(e)) => LaunchResult::failed(-1, format!("launch_worker_join_error: {e}")),
+        Err(_) => LaunchResult::timeout(LAUNCH_TIMEOUT_MS),
+    };
+    Ok(result)
+```
+
+import の調整: `use snotra_core::instant::{expand_instant_command, filter_instant_commands};`（`expand_instant_command` は Url/Legacy で使用）。不要になった import を整理。
+
+- [ ] **Step 6: src-tauri ビルドと lint を確認**
+
+Run: `cargo check -p snotra-core -p snotra`
+Expected: green（snotra-settings は Task 6 まで意図的に red）
+Run: `cargo clippy -p snotra --all-targets -- -D warnings`
+Expected: green
+
+- [ ] **Step 7: コミット**
+
+```
+git add src-tauri/src/commands/instant.rs src-tauri/src/commands/launch.rs src-tauri/Cargo.toml
+git commit -m "feat(tauri): instant exec 起動ディスパッチと InstantCommandDto を追加"
+```
+
+---
+
+### Task 5: フロントエンドの表示（DTO 消費）
+
+**Files:**
+- Modify: `ui/src/lib/types.ts:47-51`（`InstantCommand` 型）
+- Modify: `ui/src/stores/search.ts:301`（副表示）
+- Modify: `ui/src/stores/search.test.ts:75-76`（フィクスチャ）
+
+**Interfaces:**
+- Consumes: `InstantCommandDto`（Task 4、`{ name, description, display }`）
+
+- [ ] **Step 1: フィクスチャと型を更新（テスト先行）**
+
+`ui/src/lib/types.ts`:
+
+```ts
+export interface InstantCommand {
+  name: string;
+  display: string;
+  description: string;
+}
+```
+
+`ui/src/stores/search.test.ts:75-76` の `command:` プロパティを `display:` に変更（例: `CMD_GOOGLE` / `CMD_CLIP` フィクスチャ）。値はそのまま（テンプレート文字列）。
+
+- [ ] **Step 2: 失敗を確認**
+
+Run: `npm run typecheck`
+Expected: FAIL（`search.ts:301` が `cmd.command` を参照しており `command` が型に無い）
+
+- [ ] **Step 3: 副表示を `display` に変更**
+
+`ui/src/stores/search.ts:301`:
+
+```ts
+        description: cmd.description || cmd.display,
+```
+
+（**注意**: `search.ts:334/336` の `cmd.command` は別型 `SlashCommand`。触らない）
+
+- [ ] **Step 4: typecheck とフロントテスト通過を確認**
+
+Run: `npm run typecheck`
+Expected: PASS
+Run: `npm test`
+Expected: PASS（instant command 関連テスト含む）
+
+- [ ] **Step 5: コミット**
+
+```
+git add ui/src/lib/types.ts ui/src/stores/search.ts ui/src/stores/search.test.ts
+git commit -m "feat(ui): instant コマンド副表示を DTO の display に切替"
+```
+
+---
+
+### Task 6: 設定UI（種別ラジオ・exec フィールド・移行ヒント・i18n）
+
+**Files:**
+- Modify: `snotra-settings/src/tabs/instant.rs`（`ModalState`・モーダル・リスト行・移行ヒント）
+- Modify: `snotra-settings/src/i18n.rs`（新規文字列 Ja/En）
+
+**Interfaces:**
+- Consumes: `InstantAction`（Task 3）、`expand_exec_args`/`expand_instant_command`（Task 2）
+
+- [ ] **Step 1: i18n 文字列を追加**
+
+`snotra-settings/src/i18n.rs` の `Tr` に新規メソッドを追加（Ja/En 両方）。既存 `label_instant_command`/`hint_instant_command` は URL 用に転用:
+
+```rust
+    pub fn label_instant_kind(&self) -> &'static str {
+        match self.0 { Language::Ja => "種別", Language::En => "Kind" }
+    }
+    pub fn radio_instant_url(&self) -> &'static str {
+        match self.0 { Language::Ja => "URL / 既定アプリで開く", Language::En => "URL / open with default app" }
+    }
+    pub fn radio_instant_program(&self) -> &'static str {
+        match self.0 { Language::Ja => "プログラム（exe + 引数）", Language::En => "Program (exe + args)" }
+    }
+    pub fn label_instant_exe(&self) -> &'static str {
+        match self.0 { Language::Ja => "実行ファイル (.exe)", Language::En => "Executable (.exe)" }
+    }
+    pub fn label_instant_args(&self) -> &'static str {
+        match self.0 { Language::Ja => "引数", Language::En => "Arguments" }
+    }
+    pub fn hint_instant_program(&self) -> &'static str {
+        match self.0 {
+            Language::Ja => ".exe のみ。スクリプトはインタプリタを実行ファイルに指定。{query} / {clip} と %VAR% が使えます",
+            Language::En => ".exe only. For scripts, set the interpreter as the executable. {query} / {clip} and %VAR% are supported",
+        }
+    }
+    pub fn hint_instant_migrate(&self) -> &'static str {
+        match self.0 {
+            Language::Ja => "引数つきの可能性があります。プログラム種別へ作り直すと正しく起動します",
+            Language::En => "This may contain arguments. Recreate it as a Program command to launch correctly",
+        }
+    }
+```
+
+- [ ] **Step 2: ModalState を種別対応へ拡張**
+
+`snotra-settings/src/tabs/instant.rs` の `ModalState`（11-19）と open/save を改修:
+
+```rust
+#[derive(Default, PartialEq, Clone, Copy)]
+enum EditKind { #[default] Url, Program }
+
+#[derive(Default)]
+struct ModalState {
+    open: bool,
+    mode: ModalMode,
+    editing_index: Option<usize>,
+    edit_name: String,
+    edit_description: String,
+    edit_kind: EditKind,
+    edit_url: String,
+    edit_exe: String,
+    edit_args: String,
+}
+```
+
+`open_create` はフィールドを全クリア + `edit_kind = EditKind::Url`。`open_edit` / `open_create_from` は `action` から復元:
+
+```rust
+    fn load_action(&mut self, cmd: &InstantCommand) {
+        self.edit_name = cmd.name.clone();
+        self.edit_description = cmd.description.clone();
+        self.edit_url.clear();
+        self.edit_exe.clear();
+        self.edit_args.clear();
+        match &cmd.action {
+            InstantAction::Url { url } => { self.edit_kind = EditKind::Url; self.edit_url = url.clone(); }
+            InstantAction::Exec { exe, args } => {
+                self.edit_kind = EditKind::Program;
+                self.edit_exe = exe.clone();
+                self.edit_args = args.clone();
+            }
+            InstantAction::Legacy { command } => { self.edit_kind = EditKind::Url; self.edit_url = command.clone(); }
+        }
+    }
+```
+
+`save_instant_command`（302-316）を種別に応じた `action` 構築へ:
+
+```rust
+fn save_instant_command(config: &mut Config, modal: &ModalState) {
+    let action = match modal.edit_kind {
+        EditKind::Url => InstantAction::Url { url: modal.edit_url.clone() },
+        EditKind::Program => InstantAction::Exec {
+            exe: modal.edit_exe.clone(),
+            args: modal.edit_args.clone(),
+        },
+    };
+    let cmd = InstantCommand {
+        name: modal.edit_name.clone(),
+        description: modal.edit_description.clone(),
+        action,
+    };
+    if let Some(idx) = modal.editing_index {
+        if idx < config.instant_commands.len() {
+            config.instant_commands[idx] = cmd;
+        }
+    } else {
+        config.instant_commands.push(cmd);
+    }
+}
+```
+
+（`use snotra_core::config::InstantAction;` を追加）
+
+- [ ] **Step 3: モーダルの種別ラジオ + 条件フィールド + プレビュー**
+
+`show_modal`（241-263 の Command フィールド部分）を置換:
+
+```rust
+        // Kind
+        ui.label(tr.label_instant_kind());
+        ui.horizontal(|ui| {
+            ui.radio_value(&mut state.modal.edit_kind, EditKind::Url, tr.radio_instant_url());
+            ui.radio_value(&mut state.modal.edit_kind, EditKind::Program, tr.radio_instant_program());
+        });
+        ui.add_space(4.0);
+
+        match state.modal.edit_kind {
+            EditKind::Url => {
+                ui.label(tr.label_instant_command()); // URL 用に転用
+                ui.text_edit_singleline(&mut state.modal.edit_url);
+                ui.label(egui::RichText::new(tr.hint_instant_command()).small().color(crate::app::TEXT_SECONDARY));
+                if !state.modal.edit_url.is_empty() {
+                    let preview = snotra_core::instant::expand_instant_command(&state.modal.edit_url, "example", "(clipboard)");
+                    ui.add_space(4.0);
+                    ui.label(tr.label_instant_preview());
+                    ui.label(egui::RichText::new(&preview).small().color(crate::app::TEXT_SECONDARY));
+                }
+            }
+            EditKind::Program => {
+                ui.label(tr.label_instant_exe());
+                ui.text_edit_singleline(&mut state.modal.edit_exe);
+                // exe ファイルピッカーは ["exe"] 限定（opener.rs の ExePicker を流用する場合もフィルタを exe のみに）
+                ui.label(tr.label_instant_args());
+                ui.text_edit_singleline(&mut state.modal.edit_args);
+                ui.label(egui::RichText::new(tr.hint_instant_program()).small().color(crate::app::TEXT_SECONDARY));
+                if !state.modal.edit_exe.is_empty() {
+                    // 実行時と同じ純関数でプレビュー（乖離防止）。env は展開せず素通し（プレビュー用）
+                    let tokens = snotra_core::instant::expand_exec_args(&state.modal.edit_args, "example", "(clipboard)", |s| s.to_string());
+                    let preview = format!("{} {}", state.modal.edit_exe, tokens.join(" "));
+                    ui.add_space(4.0);
+                    ui.label(tr.label_instant_preview());
+                    ui.label(egui::RichText::new(preview.trim()).small().color(crate::app::TEXT_SECONDARY));
+                }
+            }
+        }
+```
+
+- [ ] **Step 4: リスト行表示と移行ヒント**
+
+リスト行（128-146）の `&cmd.command` 参照を `action` 由来の表示へ。`Url` 種別で http(s) 非開始かつ空白を含む行に移行ヒントを表示:
+
+```rust
+                ui.vertical(|ui| {
+                    ui.label(if cmd.name.is_empty() { tr.label_no_name() } else { &cmd.name });
+                    if !cmd.description.is_empty() {
+                        ui.label(egui::RichText::new(&cmd.description).small().color(crate::app::TEXT_SECONDARY));
+                    }
+                    let (display, suspect_legacy) = match &cmd.action {
+                        InstantAction::Url { url } =>
+                            (url.clone(), !url.starts_with("http://") && !url.starts_with("https://") && url.contains(' ')),
+                        InstantAction::Exec { exe, args } =>
+                            (if args.is_empty() { exe.clone() } else { format!("{exe} {args}") }, false),
+                        InstantAction::Legacy { command } => (command.clone(), command.contains(' ')),
+                    };
+                    ui.label(egui::RichText::new(&display).small().color(crate::app::TEXT_SECONDARY));
+                    if suspect_legacy {
+                        ui.label(egui::RichText::new(format!("⚠ {}", tr.hint_instant_migrate()))
+                            .small().color(egui::Color32::from_rgb(196, 120, 28)));
+                    }
+                });
+```
+
+- [ ] **Step 5: 全 crate ビルドと lint（ここで workspace green に戻る）**
+
+Run: `cargo check -p snotra-core -p snotra -p snotra-settings`
+Expected: **全 crate green**
+Run: `cargo clippy -p snotra-core -p snotra -p snotra-settings --all-targets -- -D warnings`
+Expected: green
+Run: `cargo run -p snotra-settings`（任意・目視）
+Expected: Instant タブで URL/プログラム切替・プレビュー・移行ヒントが表示される（カテゴリ D 目視）
+
+- [ ] **Step 6: コミット**
+
+```
+git add snotra-settings/src/tabs/instant.rs snotra-settings/src/i18n.rs
+git commit -m "feat(settings): instant コマンドに種別ラジオ・exec フィールド・移行ヒントを追加"
+```
+
+---
+
+### Task 7: SPEC.md §19 とモジュールドキュメント同期
+
+**Files:**
+- Modify: `SPEC.md`（§19.2 / §19.4 / §19.5 / §19.6 / §19.8）
+- Modify: `snotra-core/CLAUDE.md`（instant.rs モジュール記述・split_args 移設）
+
+**Interfaces:** なし（ドキュメントのみ）
+
+- [ ] **Step 1: SPEC.md §19 を更新**
+
+- §19.2 設定構造: TOML 例を2形態（`url` / `exe`+`args`）に更新。`command =` の旧例は「旧形式（自動で `url` へ移行）」と注記
+- §19.4 変数展開: exec の env 展開（`%VAR%`）と「split → env展開 → 置換」順序、外部入力は env 展開しないことを追記
+- §19.5 マッチングと結果表示: 副表示は `display`（url または `exe args`）
+- §19.6 実行フロー: 種別ディスパッチ（`Url`→`ShellExecuteW` / `Exec`→`Command::new` + `spawn_blocking`/`timeout`/`CREATE_NO_WINDOW`、spawn 失敗は `LaunchResult::failed`）
+- §19.8 設定画面: フィールドを kind ラジオ + url / exe / args へ
+- §19 内の子セクション番号と後続セクション番号のずれを確認
+
+- [ ] **Step 2: snotra-core/CLAUDE.md を更新**
+
+`instant.rs` のモジュール記述に `expand_vars` / `expand_exec_args` / `split_args`（launch.rs から移設）を追記。
+
+- [ ] **Step 3: ドキュメント整合を目視確認**
+
+Run: `git diff --stat`
+Expected: `SPEC.md` と `snotra-core/CLAUDE.md` のみ変更
+
+- [ ] **Step 4: コミット**
+
+```
+git add SPEC.md snotra-core/CLAUDE.md
+git commit -m "docs(spec): instant exec 種別の仕様と core モジュール記述を同期"
+```
+
+---
+
+## 最終検証（全タスク完了後）
+
+- [ ] `cargo check -p snotra-core -p snotra -p snotra-settings` green
+- [ ] `cargo clippy -p snotra-core -p snotra -p snotra-settings --all-targets -- -D warnings` green
+- [ ] `cargo test -p snotra-core` green（serde ゲート T1-T4 / 移行 T15/T17 / exec 引数 T7-T12,T16 / DTO は src-tauri）
+- [ ] `cargo test -p snotra instant` green（DTO display）
+- [ ] `npm run typecheck` / `npm test` / `npm run build` green
+- [ ] 手動 smoke（Windows）: `config.toml` に `[[instant_commands]] name="ev" exe="C:\\Users\\Eoh\\scoop\\shims\\everything.exe" args="-s {query}"` を書き、`@ev foo` で Everything が `-s foo` で起動することを確認（カテゴリ D）
+- [ ] 旧 `command =` 形式の既存 config が起動時に消えず `url` へ移行されることを確認（T2 の実機裏取り）
+- [ ] E2E は instant 未参照のため `e2e` ラベル不要（カテゴリ C 非該当。ウィンドウ生成・ホットキー・スラッシュコマンドに触れていない）

--- a/docs/superpowers/specs/2026-06-27-instant-command-exec-action-design.md
+++ b/docs/superpowers/specs/2026-06-27-instant-command-exec-action-design.md
@@ -1,12 +1,13 @@
 # インスタントコマンドに `exec`(exe+args)種別を追加
 
 - 日付: 2026-06-27
-- ステータス: 設計合意済み（実装計画 writing-plans へ）
+- ステータス: 設計合意済み（多観点レビュー反映済み・実装計画 writing-plans へ）
+- 改訂: 初版を user/implementer/QA の3観点サブエージェントレビューで検証し、致命的欠陥（serde レガシー移行のデータ損失）と高価値の訂正を反映。任意拡張3件（移行発見ヒント・コンソール窓抑止・環境変数展開）をスコープに追加。
 - 関連: SPEC.md §19、`snotra-core/src/instant.rs`、`snotra-core/src/config.rs`、`src-tauri/src/commands/instant.rs`、`src-tauri/src/commands/launch.rs`、`snotra-settings/src/tabs/instant.rs`、`ui/src/stores/search.ts`
 
 ## 1. 背景と問題
 
-インスタントコマンドに `C:\Users\Eoh\scoop\shims\everything.exe -s {query}` のような「実行ファイル + 引数」を登録すると、呼び出しが失敗する。
+インスタントコマンドに `C:\Users\Eoh\scoop\shims\everything.exe -s {query}` のような「実行ファイル+引数」を登録すると、呼び出しが失敗する。
 
 ### 根本原因
 
@@ -41,7 +42,7 @@ ShellExecuteW(None, "open", path /* = 展開文字列全体 */, None /* lpParame
 
 ### 非目標（YAGNI）
 
-- **`InstantCommand` と `OpenerTool` のデータ型統合はしない**。両者はトリガー（`@`プレフィックス vs パス選択）・プレースホルダ（`{query}`/`{clip}` vs `{path}`）・マッチング（名前前方一致 vs 拡張子/フォルダルール）が本質的に異なる。統合は別概念の混在を生む。共通化するのは「実行の仕組み（引数分割）」であってデータ型ではない（§5）。
+- **`InstantCommand` と `OpenerTool` のデータ型統合はしない**。両者はトリガー（`@`プレフィックス vs パス選択）・プレースホルダ（`{query}`/`{clip}` vs `{path}`）・マッチング（名前前方一致 vs 拡張子/フォルダルール）が本質的に異なる。共通化するのは「実行の仕組み（引数分割）」であってデータ型ではない（§6）。
 
 ## 3. データモデル（`snotra-core/src/config.rs`）
 
@@ -56,8 +57,9 @@ pub struct InstantCommand {
 
 #[serde(untagged)]
 pub enum InstantAction {
-    Url  { url: String },                                  // ShellExecuteW 系
-    Exec { exe: String, #[serde(default)] args: String },  // Command::new 系
+    Url    { url: String },                                  // ShellExecuteW 系
+    Exec   { exe: String, #[serde(default)] args: String },  // Command::new 系
+    Legacy { command: String },                              // 旧形式互換（§4 で必ず Url 化）
 }
 ```
 
@@ -74,14 +76,25 @@ exe = "C:\\Users\\Eoh\\scoop\\shims\\everything.exe"
 args = "-s {query}"
 ```
 
-### serde 表現の懸念と退避策
+### 3.1 レガシー戦略の確定（レビュー反映: これがデータ損失防止の核心）
 
-`#[serde(flatten)]` + `#[serde(untagged)]` + `toml` クレートの三者は相性問題の報告がある。**実装の最初のタスクを「この serde 表現の round-trip テストを書いて通すこと」とし、ここが渋れば次へ退避する**:
+初版は `command: Option<String>` の named フィールド + `Option` でない `flatten` という、**serde 上両立しない**表現だった。これを実装すると、既存 config の `command = "…"` 行が新構造体に**デシリアライズできず**、失敗が `Config` 全体の parse 失敗へ伝播し、`config.toml` が `.bak` に退避されて**全設定が既定値リセット**される（QA が `toml 1.1.2` で実証）。`apply_migrations` は parse の後に走るため移行は一度も実行されない。
 
-- 退避A: 内部タグ方式 `#[serde(tag = "kind")]`（TOML に `kind = "url"|"exec"` が1行増えるが堅牢・自己説明的）
-- 退避B: フラットな `Option<String>` 群（`url` / `exe` / `args`）+ 実行時バリデーション（`url` と `exe` の排他を `ConfigError` で検査）
+確定方針:
 
-いずれの退避でも §4 以降の方針（移行・実行・UI）は不変。
+- **`InstantAction` に `Legacy { command }` variant を追加**し、`apply_migrations` で `Url` へ置換する。`flatten` の buffer に集まる `{command: "…"}` を untagged が Legacy として拾う。`None` を生まないため §2 の「illegal state を表現不可能に」を保つ。Legacy は移行後メモリ上で必ず Url 化されるため**保存時には存在しない**（`skip_serializing` の named フィールドは不要）
+- **却下案**: `#[serde(flatten)] action: Option<InstantAction>`（command フィールドなし）は、legacy 行を `None` にして command 値を**取りこぼす**（QA 実証のハザード。移行できず無言で消える）。採らない
+- **退避B（QA 実証済みフォールバック）**: フラットな `Option<String>` 群（`url`/`exe`/`args`/`command`）+ 実行時バリデーション（`url` と `exe` の排他を `ConfigError` で検査）。**§3.2 のゲートで Legacy variant が toml で deserialize できないと判明した場合のみ採用**。serialize/deserialize は QA 実証で素直に通る
+
+### 3.2 serde round-trip ゲート（release gate・実装の最初のタスク）
+
+新フォーマットの serialize/deserialize は `toml 1.1.2` で健全と実証済み。問題は**レガシー deserialize**。以下を**ゲート条件**とし、最初に書いて通す。ここが false-green を防ぐ:
+
+- **T1（serialize 往復）**: `Config` 全体を `toml::to_string_pretty` → `from_str` → 等価、かつ変種が保たれる（`matches!(action, InstantAction::Exec{..})`）。`save_to_dir` は `Config` 全体を serialize するため、失敗すると instant に限らず**全設定保存が壊れる**
+- **T2（legacy deserialize・最重要）**: 旧 `command =` 行を含む `Config` の `from_str` が `Ok`。**失敗 = 全設定リセットのデータ損失**。新フォーマット往復だけでは検出できないので独立ゲートにする
+- **T3（ハンド編集の曖昧性）**: `url` と `exe` を両方書いた行は untagged が先頭 `Url` を採用し `exe` を黙殺する。この「url 先勝ち」をテストで固定（§2 の型方針上 validate 排他は不要）
+
+T2 が渋れば即・退避B（QA 実証済み）へ。
 
 ## 4. レガシー移行（`apply_migrations`）
 
@@ -89,37 +102,52 @@ args = "-s {query}"
 
 - 現状は非URLコマンドも含め全て `ShellExecuteW(command 全体)` を通る。`Url` 種別はその挙動と完全に等価
 - ゆえに「旧 `command` → `url`」は、今日動いているコマンド（URL・引数なし exe・スペース入りパス）を1つも壊さない
-- 唯一壊れていた「引数つきコマンド」は今日も壊れているので回帰ではない。ユーザーが新UIで `exe`+`args` 形へ作り直す（一度きり）
+- 唯一壊れていた「引数つきコマンド」は今日も壊れているので回帰ではない。ユーザーが新UIで `exe`+`args` 形へ作り直す（§8 の移行発見ヒントが導線）
 - **自動分割はしない**（コマンドライン文字列の exe/args 自動分割は、スペース入りパスや document-shell-open を誤って壊しうるため）
 
-実装はプロジェクト既存パターン踏襲:
+実装:
 
-- `#[serde(default, skip_serializing)] command: Option<String>` を残す
-- `apply_migrations()` で `self.<legacy>.command.take()` → `Url { url }` を構築
-- `Config::default()` の明示初期化にも legacy `command: None` を追加
-- `Config::load()` 以外のデシリアライズ経路（インポート等）でも `apply_migrations()` が走ることを確認
+- `apply_migrations()` で `if let InstantAction::Legacy { command } = &cmd.action { cmd.action = InstantAction::Url { url: command.clone() } }`
+- **冪等**（移行後 `Legacy` は消えるので再実行で no-op。T17 で検証）
+- `Config::default()` の2リテラル（`config.rs:758-769`）を `action: InstantAction::Url { url: … }` へ書き換える
+- `Config::load()` 以外のデシリアライズ経路（インポート等）でも `apply_migrations()` が走ることを確認（`reset_to_default` 含む）
 
 ## 5. 実行フロー（`src-tauri/src/commands/instant.rs`）
 
 `execute_instant_command` を種別でディスパッチ:
 
 - **`Url`** → `expand_instant_command`（http(s) は URL エンコード）→ `launch_item_core`（ShellExecuteW）。**現状経路そのまま**
-- **`Exec`** → `exe`/`args` の `{query}`/`{clip}` を展開 → `Command::new(exe).args(tokens)` で spawn
+- **`Exec`** → 引数を構築 → `Command::new(exe).args(tokens)` で spawn
 
-### 引数展開の順序（重要・テスト対象）
+### 5.1 実行ハーネスの対称性（レビュー反映）
 
-`args` は「**分割してから各トークンを展開**」する:
+Exec も Url 経路・`launch_with_tool` と同じく **`spawn_blocking` + `timeout(LAUNCH_TIMEOUT_MS)`** に載せる（CreateProcessW の PATH 解決等で一瞬ブロックしうるため対称に）。COM STA は不要（`Command::new`/CreateProcessW は COM 非依存。`src-tauri/CLAUDE.md`「EXE は COM 不要」と一致）。
 
-- `args = "-s {query}"`、query = `hello world` → `split_args` → `["-s", "{query}"]` → 展開 → `["-s", "hello world"]` → 「hello world」は1引数のまま
-- 逆順（展開→分割）だと query 内の空白で引数が割れる。オープナーの `build_launch_args`（`{path}`）と同じ流儀
+### 5.2 引数構築の順序（重要・テスト対象）
 
-## 6. 共通化（健全な DRY の範囲）
+1. `split_args(args)` で**先に分割**（クォート対応・core 純関数）
+2. 各トークンに対し **(a) 環境変数展開 → (b) `{query}`/`{clip}` 置換** の順
+   - **外部入力（query/clip）は環境変数展開しない**: env 展開を置換の前に行うことで、ユーザーが書いた template の `%VAR%` のみ展開され、`{query}` が運んだ `%VAR%` は生のまま渡る（安全側）
+   - env 値の空白はトークン内に留まる（split 後に展開するため再分割されない。例: `%PROGRAMFILES%` の空白が引数を割らない）
+   - 分割→置換順により、空白入り `{query}` は1引数を保つ（`args="-s {query}"`, query=`hello world` → `["-s","hello world"]`）
+3. `exe` 自体にも環境変数展開を適用（`%LOCALAPPDATA%\…\app.exe` 等）
 
-データ型は統合しないが、引数分割の純粋ロジックを共有する:
+### 5.3 コンソール窓抑止（スコープ追加）
 
-- `split_args`（クォート対応分割）を `launch.rs` から `snotra-core` へ移設し、オープナーとインスタントの両者が呼ぶ。純関数なのでユニットテストを集約できる
-- `Command::new(exe).args(...)` の spawn 自体は副作用なので `src-tauri` 側に残す
-- オープナー固有の「`{path}` 補完」（`build_launch_args`）は openers 専用のまま。インスタントは補完せず `{query}`/`{clip}` のみ展開
+Exec spawn に `.creation_flags(CREATE_NO_WINDOW=0x08000000)` + `Stdio::null()`（stdin/out/err）を付け、CLI ツール（yt-dlp/ffmpeg/git 等）登録時の黒窓ちらつきを防ぐ。**exec のみ**（オープナーは現状維持＝今回スコープ外）。GUI exe（everything.exe）には無影響。
+
+### 5.4 失敗フィードバック（レビュー反映）
+
+spawn 失敗時は `LaunchResult::failed(-1, "spawn_failed: {e}")` を返し、フロントの `executeInstantCommandSelected` → `notifyLaunchFailure`（`search.ts`）が可視化する（既存導線。Url 経路の `shell_execute_error_message` と対称）。握り潰さない。
+
+## 6. 共通化とヘルパー（健全な DRY）
+
+データ型は統合しないが、純粋ロジックを `snotra-core` に集約してテスト可能にする:
+
+- **`split_args`**（クォート対応分割）を `launch.rs` から `snotra-core` へ `pub` 移設。オープナー（`build_launch_args`）とインスタントが共有。テストも移設（§10）。src-tauri → snotra-core の単方向依存なので循環なし
+- **`expand_vars(template, query, clip) -> String`**（core 純関数・生展開）を新設。`expand_instant_command` は `expand_vars` + http(s) の URL エンコード分岐に分解する（Exec のトークンに `expand_instant_command` を流用すると無意味な http 判定が走るため分離）
+- **`expand_exec_args(args, query, clip, env_expand: impl Fn(&str) -> String) -> Vec<String>`**（core 純関数）。`split_args` → 各トークンに `env_expand` → `expand_vars` を適用。`env_expand` を注入することで Win32 非依存にテスト可能（テストは恒等関数や擬似 env マップ、本番は §6 の Win32 ラッパ）。`build_launch_args` の `{path}` 自動補完は**流用しない**（exec は末尾 append しない）
+- **spawn / Win32**（`ExpandEnvironmentStringsW`, `creation_flags`, `Stdio`）は `src-tauri` に残す（副作用境界）。設定UIのプレビューも `expand_exec_args`/`expand_vars` を**共用**し、実行時と表示の乖離を防ぐ
 
 ## 7. IPC とフロントエンド
 
@@ -127,51 +155,83 @@ args = "-s {query}"
 
 ```rust
 struct InstantCommandDto { name: String, description: String, display: String }
-// display = url、または "exe args" の表示文字列（バックエンドで生成）
 ```
 
+- `display` 生成規則: `Url` → `url`／`Exec`(args 有) → `"exe args"`／`Exec`(args 空) → `exe`（**末尾スペースなし**）。生テンプレート（`{query}` リテラルのまま・URL エンコードしない。現行 `search.ts` の副表示と一致）
 - `get_instant_commands` は `Vec<InstantCommandDto>` を返す（種別分岐をバックエンドで吸収）
-- フロント変更は実質2点:
-  - `ui/src/lib/types.ts` の `InstantCommand.command` → `display` に改名
-  - `ui/src/stores/search.ts:301` を `cmd.description || cmd.display` に
+- フロント変更（**`InstantCommand` 型に限定**。`SlashCommand.command` は別型・触らない）:
+  - `ui/src/lib/types.ts` の `InstantCommand.command` → `display`
+  - `ui/src/stores/search.ts:301` を `cmd.description || cmd.display`
+  - `ui/src/stores/search.test.ts:75-76` のフィクスチャ（`command:` → `display:`）
 - `execute_instant_command(name, query)` は名前ディスパッチのまま不変
 
 ## 8. 設定UI（`snotra-settings/src/tabs/instant.rs`）
 
-モーダルに種別トグル（ラジオ: URL / プログラム）を追加し、フィールドを出し分ける:
+モーダルに種別トグル（ラジオ: URL / プログラム、**既定 URL**）を追加し、フィールドを出し分ける:
 
 - URL 選択 → `url` 単一フィールド + プレビュー（`expand_instant_command`）
-- プログラム選択 → `exe`（オープナー同様のファイルピッカー流用可）+ `args` + プレビュー（`exe` に展開後 `args`）
-- `ModalState` に `edit_kind` / `edit_url` / `edit_exe` / `edit_args` を追加。`save_instant_command` を種別に応じて `InstantAction` 構築へ変更
-- i18n（`snotra-settings/src/i18n.rs`、Ja/En 両方）: `label_instant_kind`・ラジオ2種・`label_instant_exe`/`label_instant_args`・各ヒントを追加
+- プログラム選択 → `exe` + `args` + プレビュー（`expand_exec_args`/`expand_vars` を共用）
+- **exe ファイルピッカーは `["exe"]` 限定**（オープナーの `["exe","bat","cmd"]` を流用しない）。`Command::new` は `.lnk` を起動できず、`.bat`/`.cmd` は cmd.exe 経由で `{query}` がメタ文字に晒される（§12）。スクリプトは「インタプリタを exe に指定」のヒントを添える
+- `ModalState` の全フィールド波及: `edit_kind`/`edit_url`/`edit_exe`/`edit_args`。`open_create_from`/`open_edit`/`save_instant_command` を `action` 構築へ。リスト行表示（`instant.rs:141-145` の `&cmd.command`）も `action` から `display` 相当を導出
+- i18n（`snotra-settings/src/i18n.rs`、Ja/En 両方）: `label_instant_kind`・ラジオ2種・`label_instant_exe`/`label_instant_args`・各ヒント。既存 `label_instant_command`/`hint_instant_command` は URL 用に転用
+
+### 8.1 移行発見ヒント（スコープ追加・非破壊）
+
+設定リストの各 `Url` 種別行で、`url` が **http(s):// で始まらず空白を含む**（=引数つき exe らしい）場合、注意バッジ + 「プログラム種別へ作り直しますか?」のヒントを表示する。**自動変換はしない**（§4 のゼロ回帰を保つ）。旧コマンドを黙って url 化するだけだと「直したはずなのに動かない」混乱が残るため、気づきの導線を1つ足す。settings UI のみの変更（バックエンド無改変）。i18n 文字列を追加。
 
 ## 9. SPEC.md §19 更新
 
 挙動変更を伴うため、AGENTS.md ステップ0「仕様内部の矛盾解消」として SPEC を同期する:
 
-- §19.2 設定構造: 新 TOML 2形態（`url` / `exe`+`args`）
-- §19.4 変数展開: 種別別（URL は http(s) エンコード、exec は生展開）
-- §19.6 実行フロー: 種別ディスパッチ（url→ShellExecuteW / exec→`Command::new`）
-- §19 内の子セクション番号・後続セクション番号がずれていないか確認
+- §19.2 設定構造: 新 TOML 2形態（`url` / `exe`+`args`）。既存の `command =` 例（行 684-696）を更新
+- §19.4 変数展開: 種別別（URL は http(s) エンコード、exec は env 展開→生展開）。環境変数展開を追記
+- §19.5 マッチングと結果表示: 副表示の「コマンドテンプレート」→ `display`（url または `exe args`）
+- §19.6 実行フロー: 種別ディスパッチ（url→ShellExecuteW / exec→`Command::new` + spawn_blocking/timeout/CREATE_NO_WINDOW）
+- §19.8 設定画面: `name`/`command`/`description` のフィールド列挙を kind ラジオ + url/exe/args へ
+- §19 内の子セクション番号・後続セクション番号のずれを確認
 
 ## 10. テスト計画（TDD）
 
-優先順:
+### 10.1 serde / 表現（§3.2 のゲート）
+- **T1** serialize 往復（`Config` 全体）+ 変種保存
+- **T2** legacy 行 deserialize → `Ok`（最重要・データ損失検出器）
+- **T3** ハンド編集 `url`+`exe` 両方 → `Url` 先勝ち固定
+- **T4** `Exec` で `args` 省略 → `args == ""`
+- **T5** `description` 省略 + Exec/Url 混在 Vec の往復等価
+- **T17** `apply_migrations` 冪等（legacy→Url 後に再実行で `changed==false`）
 
-1. **serde round-trip**（§3 の最優先）: `Url` / `Exec` 両形態の TOML ↔ 構造体の往復一致。退避判断のゲート
-2. **移行**: legacy `command`（URL / 非URL 両方）→ `Url { url }`。旧データで動いていた挙動が保たれること
-3. **`split_args` 移設後テスト**: 既存テストを `snotra-core` 側へ移し、クォート/空クォート/未閉クォートを維持
-4. **exec の分割→展開順序**: `args="-s {query}"` + 空白入り query が1引数を保つ
-5. **バリデーション**（退避B採用時のみ）: `url` と `exe` の排他、両方空の拒否
+### 10.2 移行回帰
+- **T15** 非 URL legacy（`C:\tools\editor.exe`, `readme.pdf`）が `Url` へ移行し ShellExecuteW 経路へ（`Exec` に**しない**＝自動分割しない不変条件をロック）
+- 既存 `instant_command_round_trip_toml`（`config.rs:2836`）を、移行後の `action` 変種を assert する形へ書き換え（転用で不変条件を孤立させない）
+
+### 10.3 exec 引数構築（`expand_exec_args` 純関数。`env_expand` は恒等/擬似マップ注入）
+- **T7** 空 args → `[]`（末尾 append しない＝`build_launch_args` 流儀の流用回帰を防ぐ）
+- **T8** 順序兼インジェクション検出: `args="-s {query}"`, query=`--flag a b` → `["-s","--flag a b"]`（1引数）
+- **T9** `{query}` 内の `"`: query=`a"b` → `["a\"b"]`（split は展開前なので再分割しない）
+- **T10** `{clip}` 内の改行: clip=`a\nb` → `["a\nb"]`（再分割しない）
+- **T11** 空 `{query}`: `args="-s {query}"`, query=`""` → `["-s",""]`（空引数を渡す仕様をロック）
+- **T12** インライン placeholder: `args="-s={query}"`, query=`hello world` → `["-s=hello world"]`
+- **T16** 環境変数: `args="--dir %FOO%"`, env `FOO=C:\a b` → `["--dir","C:\a b"]`（env 値の空白がトークン内に留まる）/ 外部入力 query=`%FOO%` は展開されない
+- **split_args** 既存テスト（クォート/空クォート/未閉クォート）を core へ移設して維持
+
+### 10.4 DTO 表示
+- **T14** `display`: Url→`url`／Exec(args 有)→`"exe args"`／Exec(args 空)→`exe`（末尾空白なし）
+
+### 10.5 プレビュー乖離防止
+- 設定UIプレビューが `expand_exec_args` を共用し、実行時の分割結果と一致（同一純関数）
 
 ## 11. 影響範囲
 
-- **触る**: `snotra-core/src/config.rs`（struct/enum/migration/default/validate）、`snotra-core/src/instant.rs`（expand は維持、必要なら exec 用ヘルパー）、`snotra-core`（`split_args` 移設先）、`src-tauri/src/commands/instant.rs`（ディスパッチ）、`src-tauri/src/commands/launch.rs`（`split_args` 移設元）、`snotra-settings/src/tabs/instant.rs`、`snotra-settings/src/i18n.rs`、`ui/src/lib/types.ts`、`ui/src/stores/search.ts`、`SPEC.md §19`
-- **モジュール構成ドキュメント同期**: `snotra-core/CLAUDE.md`（instant.rs / split_args 移設）、必要なら `docs/architecture.md`（instant の実行系統が2つになる横断パターン）
-- **触らない（根拠）**: E2E（`e2e/` に instant 参照なし=無風）、`execute_instant_command` の IPC シグネチャ（name/query のまま）、オープナーの実行経路（`build_launch_args` の `{path}` 補完は openers 専用で不変）
-- **件数・キー形式変更なし**: 識別子改名（`command` → `url`/`exe`/`args`）はシンボル単位で grep 済み（config.rs 構造体、settings モーダル、フロント型1+表示1、serde キー）。compile-fail を改名検出器として使う
+- **触る（Rust）**: `snotra-core/src/config.rs`（struct/enum/`apply_migrations`/`default()` リテラル/round-trip テスト/`InstantCommand` 移動）、`snotra-core/src/instant.rs`（`expand_vars`/`expand_exec_args` 新設・**テストフィクスチャ `command:` リテラル 行123-128,165** 書き換え）、`snotra-core`（`split_args` 移設先）、`src-tauri/src/commands/instant.rs`（ディスパッチ/env展開/creation_flags）、`src-tauri/src/commands/launch.rs`（`split_args` 移設元）
+- **触る（UI/設定）**: `snotra-settings/src/tabs/instant.rs`（ModalState 全フィールド/リスト行/移行ヒント）、`snotra-settings/src/i18n.rs`、`ui/src/lib/types.ts`、`ui/src/stores/search.ts:301`、`ui/src/stores/search.test.ts:75-76`、`SPEC.md §19.2/§19.4/§19.5/§19.6/§19.8`
+- **モジュール構成ドキュメント同期**: `snotra-core/CLAUDE.md`（instant.rs ヘルパー・split_args 移設）、必要なら `docs/architecture.md`（instant の実行系統が2つになる横断パターン）
+- **触らない（根拠）**: E2E（`e2e/` に instant 参照なし=無風・grep 0件実証）、`execute_instant_command` の IPC シグネチャ（name/query のまま）、`SlashCommand.command`（別型・`search.ts:334/336`・素朴な一括 rename は厳禁）、オープナーの実行経路（`build_launch_args` の `{path}` 補完は openers 専用で不変・コンソール窓抑止も今回適用しない）
+- **改名は概念単位で grep 済み**: `InstantCommand.command`（型参照に限定）/ config 構造体 / settings モーダル+リスト行 / フロント型1+表示1+テスト1 / serde キー。compile-fail を改名検出器に使う
 
-## 12. リスク
+## 12. リスクとセキュリティ
 
-- serde（flatten + untagged + toml）の相性 → §3 の退避策で吸収。実装初手で round-trip テストにより de-risk
-- 設定UI のラジオ追加に伴うモーダル状態の増加 → 既存の Create/Edit パターン・境界チェックを踏襲
+- **serde（flatten + untagged + toml）**: §3.2 のゲートで de-risk。T2 が渋れば退避B（QA 実証済み）
+- **`.bat`/`.cmd` 経由のインジェクション**: `Command::new` が `.bat`/`.cmd` を解決すると cmd.exe 経由になり、信頼境界外の `{query}`/`{clip}` が cmd.exe のメタ文字・`%VAR%` に晒される。Rust ≥1.77.2 が CVE-2024-24576（BatBadBut）対策でバッチ引数をエスケープするが、(a) ツールチェーン ≥1.77.2 を確認、(b) **exe ピッカーを `["exe"]` 限定**して UI 経路で防止、(c) 手編集 `.bat`/`.ps1` は残存リスクとしてドキュメント明記。真の `.exe` では `%VAR%`/`&`/`|` は不活性（シェル非経由）で安全
+- **bare/相対 exe のバイナリプランティング**: `Command::new` は PATH と**プロセス cwd** で解決するため、cwd 直下の同名 exe を拾う余地。exe はユーザー定義=信頼だが、UI ピッカーは絶対パスを入れる。「exe は絶対パス推奨」を一言
+- **環境変数展開の順序**: 外部入力（query/clip）は env 展開しない（§5.2）。template の `%VAR%` のみ展開
+- **設定UI モーダル状態の増加**: 既存 Create/Edit パターン・境界チェック（`if idx < vec.len()`）を踏襲

--- a/docs/superpowers/specs/2026-06-27-instant-command-exec-action-design.md
+++ b/docs/superpowers/specs/2026-06-27-instant-command-exec-action-design.md
@@ -1,0 +1,177 @@
+# インスタントコマンドに `exec`(exe+args)種別を追加
+
+- 日付: 2026-06-27
+- ステータス: 設計合意済み（実装計画 writing-plans へ）
+- 関連: SPEC.md §19、`snotra-core/src/instant.rs`、`snotra-core/src/config.rs`、`src-tauri/src/commands/instant.rs`、`src-tauri/src/commands/launch.rs`、`snotra-settings/src/tabs/instant.rs`、`ui/src/stores/search.ts`
+
+## 1. 背景と問題
+
+インスタントコマンドに `C:\Users\Eoh\scoop\shims\everything.exe -s {query}` のような「実行ファイル + 引数」を登録すると、呼び出しが失敗する。
+
+### 根本原因
+
+`execute_instant_command`（`src-tauri/src/commands/instant.rs`）は `{query}` 展開後の文字列を `launch_item_core` に渡し、`launch_item_core`（`launch.rs:332`）は `ShellExecuteW` を次のように呼ぶ:
+
+```rust
+ShellExecuteW(None, "open", path /* = 展開文字列全体 */, None /* lpParameters */, None, SW_SHOWNORMAL)
+```
+
+`ShellExecuteW` の `lpFile` は「開く対象の単一ファイルパス」であり、空白以降を引数として切り出さない。引数は本来 `lpParameters` へ分離して渡す契約である。ところがここでは exe と引数が `lpFile` に貼り付き、`lpParameters` は `None`。結果、OS は `…everything.exe -s test` という名前のファイルを literally 探し、存在しないため `SE_ERR_FILE_NOT_FOUND`（コード 2）で失敗する。
+
+### 動く例と動かない例の境界（診断の裏取り）
+
+| 登録例 | `lpFile` | 結果 |
+|---|---|---|
+| `https://…?q={query}` | `https://…?q=test` | ✅ URL は単一の開く対象として正当 |
+| `C:\tools\editor.exe`（引数なし） | `C:\tools\editor.exe` | ✅ 実在する単一パス |
+| `everything.exe -s {query}`（引数あり） | `…everything.exe -s test` | ❌ そんな名前のファイルは無い |
+
+分かれ目は「実行ファイルの後ろに引数が付くか」のみ。scoop shim は正規の実行ファイルであり無罪。原因は引数が `lpFile` に混入していること一点。
+
+### 対照（オープナーは壊れていない）
+
+オープナーは `OpenerTool { name, exe, args }` と構造を分け、`launch_with_tool_core`（`launch.rs:143`）が `std::process::Command::new(exe).arg(...)` + `split_args`/`build_launch_args` で引数を正しく分離する。インスタントコマンドだけがこの恩恵を受けていない。
+
+## 2. 決定
+
+インスタントコマンドが実行系統を **2つ** 持つことを、データモデルで明示する（種別を型で表現する = illegal state を表現不可能にする）。
+
+- **URL 系**（shell-open）: `ShellExecuteW` で既定アプリ/ブラウザに開かせる。`exe`+`args` の形を持たない（1本の文字列）
+- **プログラム系**（exec）: `exe` と `args` を分離し `Command::new(exe).args(...)` で起動
+
+### 非目標（YAGNI）
+
+- **`InstantCommand` と `OpenerTool` のデータ型統合はしない**。両者はトリガー（`@`プレフィックス vs パス選択）・プレースホルダ（`{query}`/`{clip}` vs `{path}`）・マッチング（名前前方一致 vs 拡張子/フォルダルール）が本質的に異なる。統合は別概念の混在を生む。共通化するのは「実行の仕組み（引数分割）」であってデータ型ではない（§5）。
+
+## 3. データモデル（`snotra-core/src/config.rs`）
+
+```rust
+pub struct InstantCommand {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(flatten)]
+    pub action: InstantAction,
+}
+
+#[serde(untagged)]
+pub enum InstantAction {
+    Url  { url: String },                                  // ShellExecuteW 系
+    Exec { exe: String, #[serde(default)] args: String },  // Command::new 系
+}
+```
+
+TOML 表現:
+
+```toml
+[[instant_commands]]
+name = "g"
+url = "https://www.google.com/search?q={query}"
+
+[[instant_commands]]
+name = "ev"
+exe = "C:\\Users\\Eoh\\scoop\\shims\\everything.exe"
+args = "-s {query}"
+```
+
+### serde 表現の懸念と退避策
+
+`#[serde(flatten)]` + `#[serde(untagged)]` + `toml` クレートの三者は相性問題の報告がある。**実装の最初のタスクを「この serde 表現の round-trip テストを書いて通すこと」とし、ここが渋れば次へ退避する**:
+
+- 退避A: 内部タグ方式 `#[serde(tag = "kind")]`（TOML に `kind = "url"|"exec"` が1行増えるが堅牢・自己説明的）
+- 退避B: フラットな `Option<String>` 群（`url` / `exe` / `args`）+ 実行時バリデーション（`url` と `exe` の排他を `ConfigError` で検査）
+
+いずれの退避でも §4 以降の方針（移行・実行・UI）は不変。
+
+## 4. レガシー移行（`apply_migrations`）
+
+既存 config の `command = "…"` を **無改変で `Url { url }` へ移送**する。これがゼロ回帰の鍵:
+
+- 現状は非URLコマンドも含め全て `ShellExecuteW(command 全体)` を通る。`Url` 種別はその挙動と完全に等価
+- ゆえに「旧 `command` → `url`」は、今日動いているコマンド（URL・引数なし exe・スペース入りパス）を1つも壊さない
+- 唯一壊れていた「引数つきコマンド」は今日も壊れているので回帰ではない。ユーザーが新UIで `exe`+`args` 形へ作り直す（一度きり）
+- **自動分割はしない**（コマンドライン文字列の exe/args 自動分割は、スペース入りパスや document-shell-open を誤って壊しうるため）
+
+実装はプロジェクト既存パターン踏襲:
+
+- `#[serde(default, skip_serializing)] command: Option<String>` を残す
+- `apply_migrations()` で `self.<legacy>.command.take()` → `Url { url }` を構築
+- `Config::default()` の明示初期化にも legacy `command: None` を追加
+- `Config::load()` 以外のデシリアライズ経路（インポート等）でも `apply_migrations()` が走ることを確認
+
+## 5. 実行フロー（`src-tauri/src/commands/instant.rs`）
+
+`execute_instant_command` を種別でディスパッチ:
+
+- **`Url`** → `expand_instant_command`（http(s) は URL エンコード）→ `launch_item_core`（ShellExecuteW）。**現状経路そのまま**
+- **`Exec`** → `exe`/`args` の `{query}`/`{clip}` を展開 → `Command::new(exe).args(tokens)` で spawn
+
+### 引数展開の順序（重要・テスト対象）
+
+`args` は「**分割してから各トークンを展開**」する:
+
+- `args = "-s {query}"`、query = `hello world` → `split_args` → `["-s", "{query}"]` → 展開 → `["-s", "hello world"]` → 「hello world」は1引数のまま
+- 逆順（展開→分割）だと query 内の空白で引数が割れる。オープナーの `build_launch_args`（`{path}`）と同じ流儀
+
+## 6. 共通化（健全な DRY の範囲）
+
+データ型は統合しないが、引数分割の純粋ロジックを共有する:
+
+- `split_args`（クォート対応分割）を `launch.rs` から `snotra-core` へ移設し、オープナーとインスタントの両者が呼ぶ。純関数なのでユニットテストを集約できる
+- `Command::new(exe).args(...)` の spawn 自体は副作用なので `src-tauri` 側に残す
+- オープナー固有の「`{path}` 補完」（`build_launch_args`）は openers 専用のまま。インスタントは補完せず `{query}`/`{clip}` のみ展開
+
+## 7. IPC とフロントエンド
+
+種別の内部構造をフロントへ漏らさぬよう、オープナー（`OpenerToolDto`）に倣い表示用 DTO を噛ませる:
+
+```rust
+struct InstantCommandDto { name: String, description: String, display: String }
+// display = url、または "exe args" の表示文字列（バックエンドで生成）
+```
+
+- `get_instant_commands` は `Vec<InstantCommandDto>` を返す（種別分岐をバックエンドで吸収）
+- フロント変更は実質2点:
+  - `ui/src/lib/types.ts` の `InstantCommand.command` → `display` に改名
+  - `ui/src/stores/search.ts:301` を `cmd.description || cmd.display` に
+- `execute_instant_command(name, query)` は名前ディスパッチのまま不変
+
+## 8. 設定UI（`snotra-settings/src/tabs/instant.rs`）
+
+モーダルに種別トグル（ラジオ: URL / プログラム）を追加し、フィールドを出し分ける:
+
+- URL 選択 → `url` 単一フィールド + プレビュー（`expand_instant_command`）
+- プログラム選択 → `exe`（オープナー同様のファイルピッカー流用可）+ `args` + プレビュー（`exe` に展開後 `args`）
+- `ModalState` に `edit_kind` / `edit_url` / `edit_exe` / `edit_args` を追加。`save_instant_command` を種別に応じて `InstantAction` 構築へ変更
+- i18n（`snotra-settings/src/i18n.rs`、Ja/En 両方）: `label_instant_kind`・ラジオ2種・`label_instant_exe`/`label_instant_args`・各ヒントを追加
+
+## 9. SPEC.md §19 更新
+
+挙動変更を伴うため、AGENTS.md ステップ0「仕様内部の矛盾解消」として SPEC を同期する:
+
+- §19.2 設定構造: 新 TOML 2形態（`url` / `exe`+`args`）
+- §19.4 変数展開: 種別別（URL は http(s) エンコード、exec は生展開）
+- §19.6 実行フロー: 種別ディスパッチ（url→ShellExecuteW / exec→`Command::new`）
+- §19 内の子セクション番号・後続セクション番号がずれていないか確認
+
+## 10. テスト計画（TDD）
+
+優先順:
+
+1. **serde round-trip**（§3 の最優先）: `Url` / `Exec` 両形態の TOML ↔ 構造体の往復一致。退避判断のゲート
+2. **移行**: legacy `command`（URL / 非URL 両方）→ `Url { url }`。旧データで動いていた挙動が保たれること
+3. **`split_args` 移設後テスト**: 既存テストを `snotra-core` 側へ移し、クォート/空クォート/未閉クォートを維持
+4. **exec の分割→展開順序**: `args="-s {query}"` + 空白入り query が1引数を保つ
+5. **バリデーション**（退避B採用時のみ）: `url` と `exe` の排他、両方空の拒否
+
+## 11. 影響範囲
+
+- **触る**: `snotra-core/src/config.rs`（struct/enum/migration/default/validate）、`snotra-core/src/instant.rs`（expand は維持、必要なら exec 用ヘルパー）、`snotra-core`（`split_args` 移設先）、`src-tauri/src/commands/instant.rs`（ディスパッチ）、`src-tauri/src/commands/launch.rs`（`split_args` 移設元）、`snotra-settings/src/tabs/instant.rs`、`snotra-settings/src/i18n.rs`、`ui/src/lib/types.ts`、`ui/src/stores/search.ts`、`SPEC.md §19`
+- **モジュール構成ドキュメント同期**: `snotra-core/CLAUDE.md`（instant.rs / split_args 移設）、必要なら `docs/architecture.md`（instant の実行系統が2つになる横断パターン）
+- **触らない（根拠）**: E2E（`e2e/` に instant 参照なし=無風）、`execute_instant_command` の IPC シグネチャ（name/query のまま）、オープナーの実行経路（`build_launch_args` の `{path}` 補完は openers 専用で不変）
+- **件数・キー形式変更なし**: 識別子改名（`command` → `url`/`exe`/`args`）はシンボル単位で grep 済み（config.rs 構造体、settings モーダル、フロント型1+表示1、serde キー）。compile-fail を改名検出器として使う
+
+## 12. リスク
+
+- serde（flatten + untagged + toml）の相性 → §3 の退避策で吸収。実装初手で round-trip テストにより de-risk
+- 設定UI のラジオ追加に伴うモーダル状態の増加 → 既存の Create/Edit パターン・境界チェックを踏襲

--- a/snotra-core/CLAUDE.md
+++ b/snotra-core/CLAUDE.md
@@ -14,7 +14,12 @@
 - `binfmt.rs`: `magic + version` 付きバイナリ入出力共通処理
 - `error.rs`: `BinError`（バイナリシリアライズ/デシリアライズ失敗）と `ConfigError`（設定バリデーション失敗）の error 型定義
 - `window_data.rs`: ウィンドウ位置（`window.bin`）の保存/復元
-- `instant.rs`: インスタントコマンドの変数展開（`expand_instant_command`）と前方一致フィルタ（`filter_instant_commands`）
+- `instant.rs`: インスタントコマンドの処理。**公開関数**:
+  - `split_args(args: &str) -> Vec<String>`: シェル風クォート対応の引数分割。`"..."` で囲まれた部分はスペースを含んでも1トークンとして扱う。`launch.rs` から移設。
+  - `expand_vars(template: &str, query: &str, clipboard: &str) -> String`: `{query}` / `{clip}` プレースホルダを生のまま置換（URL エンコードなし）。
+  - `expand_exec_args(args: &str, query: &str, clipboard: &str, env_expand: fn) -> Vec<String>`: exec 種別の引数列構築。手順: split_args で分割 → 各トークンに env 展開（`%VAR%`）→ `{query}`/`{clip}` 置換。この順序により (1) 外部入力 query/clip は env 展開されない、(2) env 値の空白はトークン内に留まり引数を割らない、(3) 空白入り query は1引数を保つ。
+  - `expand_instant_command(command: &str, query: &str, clipboard: &str) -> String`: URL 形式の変数展開。`http://` / `https://` で始まる場合、変数値を URL エンコード。それ以外は生のまま展開。
+  - `filter_instant_commands(commands: &[InstantCommand], input: &str) -> Vec<&InstantCommand>`: コマンド名を前方一致（大文字小文字区別しない）で絞り込み。空 input は全件返却。
 - `ui_types.rs`: フロントエンドとの IPC 用データ型
 
 ## 開発ルール

--- a/snotra-core/src/config.rs
+++ b/snotra-core/src/config.rs
@@ -48,9 +48,22 @@ fn default_language() -> Language {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InstantCommand {
     pub name: String,
-    pub command: String,
     #[serde(default)]
     pub description: String,
+    #[serde(flatten)]
+    pub action: InstantAction,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum InstantAction {
+    Url { url: String },
+    Exec {
+        exe: String,
+        #[serde(default)]
+        args: String,
+    },
+    Legacy { command: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -758,13 +771,17 @@ impl Default for Config {
             instant_commands: vec![
                 InstantCommand {
                     name: "g".to_string(),
-                    command: "https://www.google.com/search?q={query}".to_string(),
                     description: "Google 検索".to_string(),
+                    action: InstantAction::Url {
+                        url: "https://www.google.com/search?q={query}".to_string(),
+                    },
                 },
                 InstantCommand {
                     name: "gh".to_string(),
-                    command: "https://github.com/search?q={query}".to_string(),
                     description: "GitHub 検索".to_string(),
+                    action: InstantAction::Url {
+                        url: "https://github.com/search?q={query}".to_string(),
+                    },
                 },
             ],
         }
@@ -936,6 +953,14 @@ impl Config {
         }
         if self.normalize_openers() {
             changed = true;
+        }
+        // 旧 `command` 単一文字列 → `Url` へ無改変移行（自動分割しない＝ゼロ回帰）
+        for cmd in &mut self.instant_commands {
+            if let InstantAction::Legacy { command } = &mut cmd.action {
+                let url = std::mem::take(command);
+                cmd.action = InstantAction::Url { url };
+                changed = true;
+            }
         }
         if is_system_shortcut(&self.hotkey.modifier, &self.hotkey.key) {
             let default_hotkey = HotkeyConfig {
@@ -1700,13 +1725,13 @@ mod tests {
         assert_eq!(config.instant_commands.len(), 2);
         assert_eq!(config.instant_commands[0].name, "g");
         assert_eq!(
-            config.instant_commands[0].command,
-            "https://www.google.com/search?q={query}"
+            config.instant_commands[0].action,
+            InstantAction::Url { url: "https://www.google.com/search?q={query}".to_string() }
         );
         assert_eq!(config.instant_commands[1].name, "gh");
         assert_eq!(
-            config.instant_commands[1].command,
-            "https://github.com/search?q={query}"
+            config.instant_commands[1].action,
+            InstantAction::Url { url: "https://github.com/search?q={query}".to_string() }
         );
     }
 
@@ -2790,13 +2815,13 @@ mod tests {
             instant_commands: vec![
                 InstantCommand {
                     name: "google".to_string(),
-                    command: "https://google.com".to_string(),
                     description: String::new(),
+                    action: InstantAction::Url { url: "https://google.com".into() },
                 },
                 InstantCommand {
                     name: "google".to_string(),
-                    command: "https://google.co.jp".to_string(),
                     description: String::new(),
+                    action: InstantAction::Url { url: "https://google.co.jp".into() },
                 },
             ],
             ..Default::default()
@@ -2813,13 +2838,13 @@ mod tests {
             instant_commands: vec![
                 InstantCommand {
                     name: "google".to_string(),
-                    command: "https://google.com".to_string(),
                     description: String::new(),
+                    action: InstantAction::Url { url: "https://google.com".into() },
                 },
                 InstantCommand {
                     name: "bing".to_string(),
-                    command: "https://bing.com".to_string(),
                     description: String::new(),
+                    action: InstantAction::Url { url: "https://bing.com".into() },
                 },
             ],
             ..Default::default()
@@ -2838,26 +2863,23 @@ mod tests {
             [hotkey]
             modifier = "Alt"
             key = "Q"
-
             [appearance]
-            max_results = 8
             window_width = 600
-
             [paths]
             additional = []
-
             [[instant_commands]]
             name = "g"
             command = "https://google.com/search?q={query}"
-
             [[instant_commands]]
             name = "memo"
             command = "C:\\tools\\editor.exe"
         "#;
-        let config: Config = toml::from_str(toml_str).expect("parse");
+        let mut config: Config = toml::from_str(toml_str).expect("parse");
+        config.apply_migrations();
         assert_eq!(config.instant_commands.len(), 2);
         assert_eq!(config.instant_commands[0].name, "g");
-        assert_eq!(config.instant_commands[1].name, "memo");
+        assert!(matches!(config.instant_commands[0].action, InstantAction::Url { .. }));
+        assert!(matches!(config.instant_commands[1].action, InstantAction::Url { .. }));
     }
 
     #[test]
@@ -3594,5 +3616,88 @@ foo = 42
         assert!(config.apply_migrations());
         assert!(config.paths.additional.is_empty());
         assert!(!config.paths.scan.is_empty());
+    }
+
+    // ---- InstantAction serde gate (release gate: 失敗は全設定リセットを意味する) ----
+    fn cfg_with_instant(cmds: Vec<InstantCommand>) -> Config {
+        Config { instant_commands: cmds, ..Default::default() }
+    }
+
+    #[test] // T2: legacy 行が deserialize できる（最重要・データ損失検出器）
+    fn instant_legacy_command_deserializes() {
+        let legacy = cfg_with_instant(vec![InstantCommand {
+            name: "g".into(), description: String::new(),
+            action: InstantAction::Legacy { command: "https://x/?q={query}".into() },
+        }]);
+        let s = toml::to_string(&legacy).expect("serialize legacy");
+        // Legacy は `command = "..."` 形（=旧オンディスク形式）で出力される
+        assert!(s.contains("command ="));
+        let parsed: Config = toml::from_str(&s).expect("legacy deserialize must succeed");
+        assert!(matches!(parsed.instant_commands[0].action, InstantAction::Legacy { .. }));
+    }
+
+    #[test] // T15 + T17: legacy → Url 移行（自動分割しない）・冪等
+    fn instant_legacy_migrates_to_url_idempotently() {
+        let mut cfg = cfg_with_instant(vec![InstantCommand {
+            name: "ev".into(), description: String::new(),
+            action: InstantAction::Legacy { command: "C:\\tools\\editor.exe".into() },
+        }]);
+        assert!(cfg.apply_migrations());
+        assert_eq!(cfg.instant_commands[0].action,
+            InstantAction::Url { url: "C:\\tools\\editor.exe".into() }); // Exec にしない
+        // 冪等: 2回目は Legacy が残っていないので action は Url のまま
+        cfg.apply_migrations();
+        assert_eq!(cfg.instant_commands[0].action,
+            InstantAction::Url { url: "C:\\tools\\editor.exe".into() });
+    }
+
+    #[test] // T1: Config 全体の serialize 往復で変種が保たれる
+    fn instant_exec_roundtrip_preserves_variant() {
+        let cfg = cfg_with_instant(vec![InstantCommand {
+            name: "ev".into(), description: "Everything".into(),
+            action: InstantAction::Exec { exe: "everything.exe".into(), args: "-s {query}".into() },
+        }]);
+        let s = toml::to_string_pretty(&cfg).expect("serialize");
+        let parsed: Config = toml::from_str(&s).expect("deserialize");
+        assert_eq!(parsed.instant_commands[0].action,
+            InstantAction::Exec { exe: "everything.exe".into(), args: "-s {query}".into() });
+    }
+
+    #[test] // T3: url と exe を両方書いた行は Url 先勝ち（untagged 宣言順）
+    fn instant_both_url_and_exe_prefers_url() {
+        let toml_str = r#"
+            [hotkey]
+            modifier = "Alt"
+            key = "Q"
+            [appearance]
+            window_width = 600
+            [paths]
+            additional = []
+            [[instant_commands]]
+            name = "x"
+            url = "https://x"
+            exe = "y.exe"
+        "#;
+        let cfg: Config = toml::from_str(toml_str).expect("parse");
+        assert!(matches!(cfg.instant_commands[0].action, InstantAction::Url { .. }));
+    }
+
+    #[test] // T4: Exec で args 省略 → 空文字
+    fn instant_exec_args_defaults_empty() {
+        let toml_str = r#"
+            [hotkey]
+            modifier = "Alt"
+            key = "Q"
+            [appearance]
+            window_width = 600
+            [paths]
+            additional = []
+            [[instant_commands]]
+            name = "n"
+            exe = "notepad.exe"
+        "#;
+        let cfg: Config = toml::from_str(toml_str).expect("parse");
+        assert_eq!(cfg.instant_commands[0].action,
+            InstantAction::Exec { exe: "notepad.exe".into(), args: String::new() });
     }
 }

--- a/snotra-core/src/config.rs
+++ b/snotra-core/src/config.rs
@@ -2879,7 +2879,44 @@ mod tests {
         assert_eq!(config.instant_commands.len(), 2);
         assert_eq!(config.instant_commands[0].name, "g");
         assert!(matches!(config.instant_commands[0].action, InstantAction::Url { .. }));
+        assert_eq!(config.instant_commands[1].name, "memo");
         assert!(matches!(config.instant_commands[1].action, InstantAction::Url { .. }));
+    }
+
+    #[test]
+    fn instant_mixed_variants_roundtrip() {
+        // Url 1件 + Exec 1件（description 省略）の Vec が serialize → deserialize で両変種と name を保つ。
+        let config = Config {
+            instant_commands: vec![
+                InstantCommand {
+                    name: "g".to_string(),
+                    description: "Google".to_string(),
+                    action: InstantAction::Url {
+                        url: "https://www.google.com/search?q={query}".to_string(),
+                    },
+                },
+                InstantCommand {
+                    name: "ev".to_string(),
+                    description: String::new(),
+                    action: InstantAction::Exec {
+                        exe: "everything.exe".to_string(),
+                        args: "-s {query}".to_string(),
+                    },
+                },
+            ],
+            ..Default::default()
+        };
+        let serialized = toml::to_string_pretty(&config).expect("serialize");
+        let parsed: Config = toml::from_str(&serialized).expect("parse");
+        assert_eq!(parsed.instant_commands.len(), 2);
+        assert_eq!(parsed.instant_commands[0].name, "g");
+        assert!(
+            matches!(&parsed.instant_commands[0].action, InstantAction::Url { url } if url.contains("google"))
+        );
+        assert_eq!(parsed.instant_commands[1].name, "ev");
+        assert!(
+            matches!(&parsed.instant_commands[1].action, InstantAction::Exec { exe, .. } if exe == "everything.exe")
+        );
     }
 
     #[test]

--- a/snotra-core/src/instant.rs
+++ b/snotra-core/src/instant.rs
@@ -27,6 +27,28 @@ pub fn split_args(args: &str) -> Vec<String> {
     tokens
 }
 
+/// `{query}` / `{clip}` を生のまま置換する。URL エンコードはしない。
+pub fn expand_vars(template: &str, query: &str, clipboard: &str) -> String {
+    template.replace("{query}", query).replace("{clip}", clipboard)
+}
+
+/// exec 種別の引数トークン列を構築する。
+/// 手順: `split_args` で分割 → 各トークンに `env_expand`（環境変数展開）→ `{query}`/`{clip}` 置換。
+/// この順序により (1) 外部入力 query/clip は env 展開されない、(2) env 値の空白は
+/// トークン内に留まり引数を割らない、(3) 空白入り query は1引数を保つ。
+/// `build_launch_args` の `{path}` 末尾補完は行わない（exec は path を持たない）。
+pub fn expand_exec_args(
+    args: &str,
+    query: &str,
+    clipboard: &str,
+    env_expand: impl Fn(&str) -> String,
+) -> Vec<String> {
+    split_args(args)
+        .into_iter()
+        .map(|tok| expand_vars(&env_expand(&tok), query, clipboard))
+        .collect()
+}
+
 /// Expand `{query}` and `{clip}` placeholders in an instant command template.
 ///
 /// If the command starts with `http://` or `https://`, variable values are
@@ -37,9 +59,9 @@ pub fn expand_instant_command(command: &str, query: &str, clipboard: &str) -> St
     if is_url {
         let q = utf8_percent_encode(query, NON_ALPHANUMERIC).to_string();
         let c = utf8_percent_encode(clipboard, NON_ALPHANUMERIC).to_string();
-        command.replace("{query}", &q).replace("{clip}", &c)
+        expand_vars(command, &q, &c)
     } else {
-        command.replace("{query}", query).replace("{clip}", clipboard)
+        expand_vars(command, query, clipboard)
     }
 }
 
@@ -191,6 +213,59 @@ mod tests {
         ];
         let result = filter_instant_commands(&cmds, "google");
         assert_eq!(result.len(), 1);
+    }
+
+    // ---- expand_exec_args tests ----
+    fn no_env(s: &str) -> String { s.to_string() }
+
+    #[test]
+    fn exec_args_empty_is_no_tokens() {
+        let r = expand_exec_args("", "q", "c", no_env);
+        assert!(r.is_empty()); // build_launch_args と異なり末尾 append しない
+    }
+    #[test]
+    fn exec_args_query_with_spaces_stays_one_arg() {
+        let r = expand_exec_args("-s {query}", "hello world", "", no_env);
+        assert_eq!(r, vec!["-s", "hello world"]);
+    }
+    #[test]
+    fn exec_args_query_cannot_inject_extra_args() {
+        let r = expand_exec_args("-s {query}", "--flag a b", "", no_env);
+        assert_eq!(r, vec!["-s", "--flag a b"]); // 展開は split 後なので1引数のまま
+    }
+    #[test]
+    fn exec_args_query_quote_is_literal() {
+        let r = expand_exec_args("{query}", "a\"b", "", no_env);
+        assert_eq!(r, vec!["a\"b"]); // split は展開前に走るので再分割しない
+    }
+    #[test]
+    fn exec_args_clip_newline_is_literal() {
+        let r = expand_exec_args("{clip}", "", "a\nb", no_env);
+        assert_eq!(r, vec!["a\nb"]);
+    }
+    #[test]
+    fn exec_args_empty_query_yields_empty_arg() {
+        let r = expand_exec_args("-s {query}", "", "", no_env);
+        assert_eq!(r, vec!["-s", ""]);
+    }
+    #[test]
+    fn exec_args_inline_placeholder_preserves_space() {
+        let r = expand_exec_args("-s={query}", "hello world", "", no_env);
+        assert_eq!(r, vec!["-s=hello world"]);
+    }
+    #[test]
+    fn exec_args_env_value_with_space_stays_in_token() {
+        // env 展開は split 後なので env 値の空白が引数を割らない
+        let env = |s: &str| s.replace("%FOO%", "C:\\a b");
+        let r = expand_exec_args("--dir %FOO%", "", "", env);
+        assert_eq!(r, vec!["--dir", "C:\\a b"]);
+    }
+    #[test]
+    fn exec_args_external_input_is_not_env_expanded() {
+        // query が運んだ %FOO% は展開されない（env 展開はトークン→置換の順で置換が後）
+        let env = |s: &str| s.replace("%FOO%", "EXPANDED");
+        let r = expand_exec_args("{query}", "%FOO%", "", env);
+        assert_eq!(r, vec!["%FOO%"]);
     }
 
     // ---- split_args (quote-aware splitting) tests ----

--- a/snotra-core/src/instant.rs
+++ b/snotra-core/src/instant.rs
@@ -84,6 +84,7 @@ pub fn filter_instant_commands<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::InstantAction;
 
     // ---- expand_instant_command tests ----
 
@@ -169,9 +170,9 @@ mod tests {
 
     fn sample_commands() -> Vec<InstantCommand> {
         vec![
-            InstantCommand { name: "g".to_string(), command: "https://google.com?q={query}".to_string(), description: String::new() },
-            InstantCommand { name: "gm".to_string(), command: "https://mail.google.com".to_string(), description: String::new() },
-            InstantCommand { name: "n".to_string(), command: "notepad.exe".to_string(), description: String::new() },
+            InstantCommand { name: "g".to_string(), description: String::new(), action: InstantAction::Url { url: "https://google.com?q={query}".into() } },
+            InstantCommand { name: "gm".to_string(), description: String::new(), action: InstantAction::Url { url: "https://mail.google.com".into() } },
+            InstantCommand { name: "n".to_string(), description: String::new(), action: InstantAction::Url { url: "notepad.exe".into() } },
         ]
     }
 
@@ -209,7 +210,7 @@ mod tests {
     #[test]
     fn filter_case_insensitive() {
         let cmds = vec![
-            InstantCommand { name: "Google".to_string(), command: "https://google.com".to_string(), description: String::new() },
+            InstantCommand { name: "Google".to_string(), description: String::new(), action: InstantAction::Url { url: "https://google.com".into() } },
         ];
         let result = filter_instant_commands(&cmds, "google");
         assert_eq!(result.len(), 1);

--- a/snotra-core/src/instant.rs
+++ b/snotra-core/src/instant.rs
@@ -2,6 +2,31 @@ use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
 
 use crate::config::InstantCommand;
 
+/// シェル風クォート対応の引数分割。
+/// `"..."` で囲まれた部分はスペースを含んでも1トークンとして扱う。
+/// 閉じクォートがない場合は行末まで1トークン。
+/// 空クォート `""` はトークンを生成しない。
+pub fn split_args(args: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    for ch in args.chars() {
+        match ch {
+            '"' => in_quotes = !in_quotes,
+            c if c.is_whitespace() && !in_quotes => {
+                if !current.is_empty() {
+                    tokens.push(std::mem::take(&mut current));
+                }
+            }
+            c => current.push(c),
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens
+}
+
 /// Expand `{query}` and `{clip}` placeholders in an instant command template.
 ///
 /// If the command starts with `http://` or `https://`, variable values are
@@ -166,5 +191,27 @@ mod tests {
         ];
         let result = filter_instant_commands(&cmds, "google");
         assert_eq!(result.len(), 1);
+    }
+
+    // ---- split_args (quote-aware splitting) tests ----
+    #[test]
+    fn split_args_quoted_token_preserves_spaces() {
+        assert_eq!(split_args(r#"--dir "My Documents""#), vec!["--dir", "My Documents"]);
+    }
+    #[test]
+    fn split_args_unclosed_quote_consumes_to_end() {
+        assert_eq!(split_args(r#"--dir "My Documents"#), vec!["--dir", "My Documents"]);
+    }
+    #[test]
+    fn split_args_adjacent_quotes_join() {
+        assert_eq!(split_args(r#"--open="My File""#), vec!["--open=My File"]);
+    }
+    #[test]
+    fn split_args_empty_quotes_produce_no_token() {
+        assert_eq!(split_args(r#"a "" b"#), vec!["a", "b"]);
+    }
+    #[test]
+    fn split_args_plain_whitespace_only() {
+        assert_eq!(split_args("  -a   -b  "), vec!["-a", "-b"]);
     }
 }

--- a/snotra-settings/src/i18n.rs
+++ b/snotra-settings/src/i18n.rs
@@ -907,6 +907,55 @@ impl Tr {
         }
     }
 
+    pub fn label_instant_kind(&self) -> &'static str {
+        match self.0 {
+            Language::Ja => "種別",
+            Language::En => "Kind",
+        }
+    }
+
+    pub fn radio_instant_url(&self) -> &'static str {
+        match self.0 {
+            Language::Ja => "URL / 既定アプリで開く",
+            Language::En => "URL / open with default app",
+        }
+    }
+
+    pub fn radio_instant_program(&self) -> &'static str {
+        match self.0 {
+            Language::Ja => "プログラム（exe + 引数）",
+            Language::En => "Program (exe + args)",
+        }
+    }
+
+    pub fn label_instant_exe(&self) -> &'static str {
+        match self.0 {
+            Language::Ja => "実行ファイル (.exe)",
+            Language::En => "Executable (.exe)",
+        }
+    }
+
+    pub fn label_instant_args(&self) -> &'static str {
+        match self.0 {
+            Language::Ja => "引数",
+            Language::En => "Arguments",
+        }
+    }
+
+    pub fn hint_instant_program(&self) -> &'static str {
+        match self.0 {
+            Language::Ja => ".exe のみ。スクリプトはインタプリタを実行ファイルに指定。{query} / {clip} と %VAR% が使えます",
+            Language::En => ".exe only. For scripts, set the interpreter as the executable. {query} / {clip} and %VAR% are supported",
+        }
+    }
+
+    pub fn hint_instant_migrate(&self) -> &'static str {
+        match self.0 {
+            Language::Ja => "引数つきの可能性があります。プログラム種別へ作り直すと正しく起動します",
+            Language::En => "This may contain arguments. Recreate it as a Program command to launch correctly",
+        }
+    }
+
     // Backup tab
     pub fn tab_backup(&self) -> &'static str {
         match self.0 {

--- a/snotra-settings/src/tabs/instant.rs
+++ b/snotra-settings/src/tabs/instant.rs
@@ -181,9 +181,12 @@ pub fn ui(
                             },
                             false,
                         ),
-                        InstantAction::Legacy { command } => {
-                            (command.clone(), command.contains(' '))
-                        }
+                        InstantAction::Legacy { command } => (
+                            command.clone(),
+                            !command.starts_with("http://")
+                                && !command.starts_with("https://")
+                                && command.contains(' '),
+                        ),
                     };
                     ui.label(
                         egui::RichText::new(&display).small().color(crate::app::TEXT_SECONDARY),

--- a/snotra-settings/src/tabs/instant.rs
+++ b/snotra-settings/src/tabs/instant.rs
@@ -1,5 +1,5 @@
 use eframe::egui;
-use snotra_core::config::{Config, InstantCommand};
+use snotra_core::config::{Config, InstantAction, InstantCommand};
 
 use crate::i18n::Tr;
 
@@ -8,14 +8,24 @@ pub struct InstantTabState {
     modal: ModalState,
 }
 
+#[derive(Default, PartialEq, Clone, Copy)]
+enum EditKind {
+    #[default]
+    Url,
+    Program,
+}
+
 #[derive(Default)]
 struct ModalState {
     open: bool,
     mode: ModalMode,
     editing_index: Option<usize>,
     edit_name: String,
-    edit_command: String,
     edit_description: String,
+    edit_kind: EditKind,
+    edit_url: String,
+    edit_exe: String,
+    edit_args: String,
 }
 
 #[derive(Default, PartialEq)]
@@ -31,26 +41,48 @@ impl ModalState {
         self.mode = ModalMode::Create;
         self.editing_index = None;
         self.edit_name.clear();
-        self.edit_command.clear();
         self.edit_description.clear();
+        self.edit_kind = EditKind::Url;
+        self.edit_url.clear();
+        self.edit_exe.clear();
+        self.edit_args.clear();
     }
 
     fn open_create_from(&mut self, cmd: &InstantCommand) {
         self.open = true;
         self.mode = ModalMode::Create;
         self.editing_index = None;
-        self.edit_name = cmd.name.clone();
-        self.edit_command = cmd.command.clone();
-        self.edit_description = cmd.description.clone();
+        self.load_action(cmd);
     }
 
     fn open_edit(&mut self, index: usize, cmd: &InstantCommand) {
         self.open = true;
         self.mode = ModalMode::Edit;
         self.editing_index = Some(index);
+        self.load_action(cmd);
+    }
+
+    fn load_action(&mut self, cmd: &InstantCommand) {
         self.edit_name = cmd.name.clone();
-        self.edit_command = cmd.command.clone();
         self.edit_description = cmd.description.clone();
+        self.edit_url.clear();
+        self.edit_exe.clear();
+        self.edit_args.clear();
+        match &cmd.action {
+            InstantAction::Url { url } => {
+                self.edit_kind = EditKind::Url;
+                self.edit_url = url.clone();
+            }
+            InstantAction::Exec { exe, args } => {
+                self.edit_kind = EditKind::Program;
+                self.edit_exe = exe.clone();
+                self.edit_args = args.clone();
+            }
+            InstantAction::Legacy { command } => {
+                self.edit_kind = EditKind::Url;
+                self.edit_url = command.clone();
+            }
+        }
     }
 
     fn close(&mut self) {
@@ -105,7 +137,7 @@ pub fn ui(
             ui.label(tr.label_no_instant_commands());
         }
 
-        let mut action: Option<InstantAction> = None;
+        let mut action: Option<RowAction> = None;
         let len = config.instant_commands.len();
         for (i, cmd) in config.instant_commands.iter().enumerate() {
             ui.horizontal(|ui| {
@@ -115,22 +147,18 @@ pub fn ui(
                         .add_enabled(i > 0, egui::Button::new("▲").small())
                         .clicked()
                     {
-                        action = Some(InstantAction::MoveUp(i));
+                        action = Some(RowAction::MoveUp(i));
                     }
                     if ui
                         .add_enabled(i < len - 1, egui::Button::new("▼").small())
                         .clicked()
                     {
-                        action = Some(InstantAction::MoveDown(i));
+                        action = Some(RowAction::MoveDown(i));
                     }
                 });
 
                 ui.vertical(|ui| {
-                    ui.label(if cmd.name.is_empty() {
-                        tr.label_no_name()
-                    } else {
-                        &cmd.name
-                    });
+                    ui.label(if cmd.name.is_empty() { tr.label_no_name() } else { &cmd.name });
                     if !cmd.description.is_empty() {
                         ui.label(
                             egui::RichText::new(&cmd.description)
@@ -138,19 +166,43 @@ pub fn ui(
                                 .color(crate::app::TEXT_SECONDARY),
                         );
                     }
+                    let (display, suspect_legacy) = match &cmd.action {
+                        InstantAction::Url { url } => (
+                            url.clone(),
+                            !url.starts_with("http://")
+                                && !url.starts_with("https://")
+                                && url.contains(' '),
+                        ),
+                        InstantAction::Exec { exe, args } => (
+                            if args.is_empty() {
+                                exe.clone()
+                            } else {
+                                format!("{exe} {args}")
+                            },
+                            false,
+                        ),
+                        InstantAction::Legacy { command } => {
+                            (command.clone(), command.contains(' '))
+                        }
+                    };
                     ui.label(
-                        egui::RichText::new(&cmd.command)
-                            .small()
-                            .color(crate::app::TEXT_SECONDARY),
+                        egui::RichText::new(&display).small().color(crate::app::TEXT_SECONDARY),
                     );
+                    if suspect_legacy {
+                        ui.label(
+                            egui::RichText::new(format!("⚠ {}", tr.hint_instant_migrate()))
+                                .small()
+                                .color(egui::Color32::from_rgb(196, 120, 28)),
+                        );
+                    }
                 });
 
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     if ui.button(tr.btn_edit()).clicked() {
-                        action = Some(InstantAction::Edit(i));
+                        action = Some(RowAction::Edit(i));
                     }
                     if ui.button(tr.btn_duplicate()).clicked() {
-                        action = Some(InstantAction::Duplicate(i));
+                        action = Some(RowAction::Duplicate(i));
                     }
                 });
             });
@@ -158,27 +210,27 @@ pub fn ui(
         }
 
         if ui.button(tr.btn_add()).clicked() {
-            action = Some(InstantAction::OpenCreate);
+            action = Some(RowAction::OpenCreate);
         }
 
         match action {
-            Some(InstantAction::OpenCreate) => state.modal.open_create(),
-            Some(InstantAction::Edit(i)) => {
+            Some(RowAction::OpenCreate) => state.modal.open_create(),
+            Some(RowAction::Edit(i)) => {
                 let cmd = &config.instant_commands[i];
                 state.modal.open_edit(i, cmd);
             }
-            Some(InstantAction::Duplicate(i)) => {
+            Some(RowAction::Duplicate(i)) => {
                 let cmd = &config.instant_commands[i];
                 state.modal.open_create_from(cmd);
             }
-            Some(InstantAction::MoveUp(i)) if i > 0 => {
+            Some(RowAction::MoveUp(i)) if i > 0 => {
                 config.instant_commands.swap(i, i - 1);
             }
-            Some(InstantAction::MoveUp(_)) => {}
-            Some(InstantAction::MoveDown(i)) if i < len - 1 => {
+            Some(RowAction::MoveUp(_)) => {}
+            Some(RowAction::MoveDown(i)) if i < len - 1 => {
                 config.instant_commands.swap(i, i + 1);
             }
-            Some(InstantAction::MoveDown(_)) => {}
+            Some(RowAction::MoveDown(_)) => {}
             None => {}
         }
     });
@@ -188,7 +240,7 @@ pub fn ui(
     }
 }
 
-enum InstantAction {
+enum RowAction {
     OpenCreate,
     Edit(usize),
     Duplicate(usize),
@@ -237,29 +289,69 @@ fn show_modal(
 
         ui.add_space(4.0);
 
-        // Command
-        ui.label(tr.label_instant_command());
-        ui.text_edit_singleline(&mut state.modal.edit_command);
-        ui.label(
-            egui::RichText::new(tr.hint_instant_command())
-                .small()
-                .color(crate::app::TEXT_SECONDARY),
-        );
+        // Kind
+        ui.label(tr.label_instant_kind());
+        ui.horizontal(|ui| {
+            ui.radio_value(&mut state.modal.edit_kind, EditKind::Url, tr.radio_instant_url());
+            ui.radio_value(
+                &mut state.modal.edit_kind,
+                EditKind::Program,
+                tr.radio_instant_program(),
+            );
+        });
+        ui.add_space(4.0);
 
-        // Preview
-        if !state.modal.edit_command.is_empty() {
-            ui.add_space(4.0);
-            let preview = snotra_core::instant::expand_instant_command(
-                &state.modal.edit_command,
-                "example",
-                "(clipboard)",
-            );
-            ui.label(tr.label_instant_preview());
-            ui.label(
-                egui::RichText::new(&preview)
-                    .small()
-                    .color(crate::app::TEXT_SECONDARY),
-            );
+        match state.modal.edit_kind {
+            EditKind::Url => {
+                ui.label(tr.label_instant_command());
+                ui.text_edit_singleline(&mut state.modal.edit_url);
+                ui.label(
+                    egui::RichText::new(tr.hint_instant_command())
+                        .small()
+                        .color(crate::app::TEXT_SECONDARY),
+                );
+                if !state.modal.edit_url.is_empty() {
+                    let preview = snotra_core::instant::expand_instant_command(
+                        &state.modal.edit_url,
+                        "example",
+                        "(clipboard)",
+                    );
+                    ui.add_space(4.0);
+                    ui.label(tr.label_instant_preview());
+                    ui.label(
+                        egui::RichText::new(&preview)
+                            .small()
+                            .color(crate::app::TEXT_SECONDARY),
+                    );
+                }
+            }
+            EditKind::Program => {
+                ui.label(tr.label_instant_exe());
+                ui.text_edit_singleline(&mut state.modal.edit_exe);
+                ui.label(tr.label_instant_args());
+                ui.text_edit_singleline(&mut state.modal.edit_args);
+                ui.label(
+                    egui::RichText::new(tr.hint_instant_program())
+                        .small()
+                        .color(crate::app::TEXT_SECONDARY),
+                );
+                if !state.modal.edit_exe.is_empty() {
+                    let tokens = snotra_core::instant::expand_exec_args(
+                        &state.modal.edit_args,
+                        "example",
+                        "(clipboard)",
+                        |s| s.to_string(),
+                    );
+                    let preview = format!("{} {}", state.modal.edit_exe, tokens.join(" "));
+                    ui.add_space(4.0);
+                    ui.label(tr.label_instant_preview());
+                    ui.label(
+                        egui::RichText::new(preview.trim())
+                            .small()
+                            .color(crate::app::TEXT_SECONDARY),
+                    );
+                }
+            }
         }
 
         ui.add_space(8.0);
@@ -300,10 +392,17 @@ fn show_modal(
 }
 
 fn save_instant_command(config: &mut Config, modal: &ModalState) {
+    let action = match modal.edit_kind {
+        EditKind::Url => InstantAction::Url { url: modal.edit_url.clone() },
+        EditKind::Program => InstantAction::Exec {
+            exe: modal.edit_exe.clone(),
+            args: modal.edit_args.clone(),
+        },
+    };
     let cmd = InstantCommand {
         name: modal.edit_name.clone(),
-        command: modal.edit_command.clone(),
         description: modal.edit_description.clone(),
+        action,
     };
 
     if let Some(idx) = modal.editing_index {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,7 @@ windows = { version = "0.62.2", features = [
     "Win32_System_ProcessStatus",
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_Com",
+    "Win32_System_Environment",
     "Win32_Security",
     "Win32_Foundation",
     "Win32_Storage_FileSystem",

--- a/src-tauri/src/commands/instant.rs
+++ b/src-tauri/src/commands/instant.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use snotra_core::config::InstantCommand;
 use snotra_core::instant::{expand_instant_command, filter_instant_commands};
 use tauri::Manager;
 use tokio::time::timeout;
@@ -15,13 +14,13 @@ const LAUNCH_TIMEOUT_MS: u64 = 4_000;
 pub fn get_instant_commands(
     prefix_input: String,
     app: tauri::AppHandle,
-) -> Result<Vec<InstantCommand>, String> {
+) -> Result<Vec<super::launch::InstantCommandDto>, String> {
     let state = app.state::<AppState>();
     let engine = state.engine.lock().unwrap();
     let commands = &engine.config().instant_commands;
     Ok(filter_instant_commands(commands, &prefix_input)
         .into_iter()
-        .cloned()
+        .map(super::launch::InstantCommandDto::from)
         .collect())
 }
 
@@ -31,10 +30,10 @@ pub async fn execute_instant_command(
     query: String,
     app: tauri::AppHandle,
 ) -> Result<LaunchResult, String> {
-    // コマンドテンプレートをロック内で取得し、即座にロックを解放する。
+    // action をロック内で取得し、即座にロックを解放する。
     // クリップボード読み取り (Win32 API) がブロックする可能性があるため、
     // engine mutex の外で行う。
-    let cmd_template = {
+    let action = {
         let state = app.state::<AppState>();
         let engine = state.engine.lock().unwrap();
         engine
@@ -43,7 +42,7 @@ pub async fn execute_instant_command(
             .iter()
             .find(|c| c.name == name)
             .ok_or_else(|| format!("instant command not found: {name}"))?
-            .command
+            .action
             .clone()
     };
 
@@ -54,14 +53,22 @@ pub async fn execute_instant_command(
     // 変数展開: URL テンプレートは自動エンコード、それ以外は生展開。
     // セキュリティモデル: コマンドテンプレートはユーザーが config.toml で
     // 自身で定義したものであり、信頼済みコンテンツとして扱う。
-    // {query} / {clip} はユーザー入力だが、ShellExecuteW は cmd.exe /c と
-    // 異なりシェルインタプリタを起動しないため、引数インジェクションの
-    // リスクは限定的（ユーザーが `cmd.exe /c {query}` と定義した場合を除く）。
-    let expanded = expand_instant_command(&cmd_template, &query, &clipboard);
-
-    // ShellExecuteW を新スレッド + COM STA で実行（launch_item_core を再利用）
     let join = tauri::async_runtime::spawn_blocking(move || {
-        super::launch::launch_item_core(&expanded)
+        use snotra_core::config::InstantAction;
+        match action {
+            InstantAction::Url { url } => {
+                let expanded = expand_instant_command(&url, &query, &clipboard);
+                super::launch::launch_item_core(&expanded)
+            }
+            InstantAction::Exec { exe, args } => {
+                super::launch::launch_exec_core(&exe, &args, &query, &clipboard)
+            }
+            // load 後は移行済みで到達しないが、防御的に Url 扱い
+            InstantAction::Legacy { command } => {
+                let expanded = expand_instant_command(&command, &query, &clipboard);
+                super::launch::launch_item_core(&expanded)
+            }
+        }
     });
     let result = match timeout(Duration::from_millis(LAUNCH_TIMEOUT_MS), join).await {
         Ok(Ok(v)) => v,

--- a/src-tauri/src/commands/launch.rs
+++ b/src-tauri/src/commands/launch.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use serde_json::json;
 use snotra_core::config::{find_matching_tools, InstantAction, InstantCommand, OpenerTool};
-use snotra_core::instant::{expand_exec_args, expand_vars, split_args};
+use snotra_core::instant::{expand_exec_args, split_args};
 use std::process::Stdio;
 use tauri::{AppHandle, Manager};
 use tokio::time::timeout;
@@ -172,7 +172,6 @@ fn build_launch_args(args: &str, path: &str) -> Vec<String> {
 
     expanded
 }
-
 
 #[tauri::command]
 pub async fn launch_item(
@@ -393,7 +392,7 @@ pub(crate) fn expand_env(input: &str) -> String {
 
 /// exec 種別の起動。COM 不要（CreateProcessW 直叩き）。コンソール窓抑止。
 pub(crate) fn launch_exec_core(exe: &str, args: &str, query: &str, clipboard: &str) -> LaunchResult {
-    let exe_expanded = expand_vars(&expand_env(exe), query, clipboard);
+    let exe_expanded = expand_env(exe);
     let arg_tokens = expand_exec_args(args, query, clipboard, expand_env);
 
     let mut cmd = std::process::Command::new(&exe_expanded);

--- a/src-tauri/src/commands/launch.rs
+++ b/src-tauri/src/commands/launch.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use serde_json::json;
 use snotra_core::config::{find_matching_tools, OpenerTool};
+use snotra_core::instant::split_args;
 use tauri::{AppHandle, Manager};
 use tokio::time::timeout;
 
@@ -171,34 +172,6 @@ fn build_launch_args(args: &str, path: &str) -> Vec<String> {
     expanded
 }
 
-/// シェル風クォート対応の引数分割。
-/// `"..."` で囲まれた部分はスペースを含んでも1トークンとして扱う。
-/// 閉じクォートがない場合は行末まで1トークン。
-/// 空クォート `""` はトークンを生成しない（空の引数を明示渡しする手段は提供しない）。
-fn split_args(args: &str) -> Vec<String> {
-    let mut tokens = Vec::new();
-    let mut current = String::new();
-    let mut in_quotes = false;
-    for ch in args.chars() {
-        match ch {
-            '"' => {
-                in_quotes = !in_quotes;
-            }
-            c if c.is_whitespace() && !in_quotes => {
-                if !current.is_empty() {
-                    tokens.push(std::mem::take(&mut current));
-                }
-            }
-            c => {
-                current.push(c);
-            }
-        }
-    }
-    if !current.is_empty() {
-        tokens.push(current);
-    }
-    tokens
-}
 
 #[tauri::command]
 pub async fn launch_item(
@@ -415,44 +388,6 @@ mod tests {
             build_launch_args("{path} --compare {path}", "C:\\file.txt"),
             vec!["C:\\file.txt", "--compare", "C:\\file.txt"]
         );
-    }
-
-    // ---- split_args (quote-aware splitting) tests ----
-
-    use super::split_args;
-
-    #[test]
-    fn split_args_quoted_token_preserves_spaces() {
-        assert_eq!(
-            split_args(r#"--dir "My Documents""#),
-            vec!["--dir", "My Documents"]
-        );
-    }
-
-    #[test]
-    fn split_args_unclosed_quote_consumes_to_end() {
-        assert_eq!(
-            split_args(r#"--dir "My Documents"#),
-            vec!["--dir", "My Documents"]
-        );
-    }
-
-    #[test]
-    fn split_args_adjacent_quotes_join() {
-        assert_eq!(
-            split_args(r#"--open="My File""#),
-            vec!["--open=My File"]
-        );
-    }
-
-    #[test]
-    fn split_args_empty_quotes_produce_no_token() {
-        assert_eq!(split_args(r#"a "" b"#), vec!["a", "b"]);
-    }
-
-    #[test]
-    fn split_args_plain_whitespace_only() {
-        assert_eq!(split_args("  -a   -b  "), vec!["-a", "-b"]);
     }
 
     #[test]

--- a/src-tauri/src/commands/launch.rs
+++ b/src-tauri/src/commands/launch.rs
@@ -381,7 +381,7 @@ pub(crate) fn expand_env(input: &str) -> String {
             let written = ExpandEnvironmentStringsW(&src, Some(&mut buf));
             if written == 0 { return input.to_string(); }
             // 末尾 NUL を除いて UTF-16 → String
-            let len = (written as usize).saturating_sub(1);
+            let len = (written as usize).saturating_sub(1).min(buf.len());
             String::from_utf16_lossy(&buf[..len])
         }
     }

--- a/src-tauri/src/commands/launch.rs
+++ b/src-tauri/src/commands/launch.rs
@@ -1,8 +1,9 @@
 use std::time::Duration;
 
 use serde_json::json;
-use snotra_core::config::{find_matching_tools, OpenerTool};
-use snotra_core::instant::split_args;
+use snotra_core::config::{find_matching_tools, InstantAction, InstantCommand, OpenerTool};
+use snotra_core::instant::{expand_exec_args, expand_vars, split_args};
+use std::process::Stdio;
 use tauri::{AppHandle, Manager};
 use tokio::time::timeout;
 
@@ -341,9 +342,98 @@ pub(crate) fn launch_item_core(path: &str) -> LaunchResult {
     }
 }
 
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// フロントへ返すインスタントコマンド情報（種別の内部構造を隠す）
+#[derive(serde::Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct InstantCommandDto {
+    pub name: String,
+    pub description: String,
+    pub display: String,
+}
+
+impl From<&InstantCommand> for InstantCommandDto {
+    fn from(c: &InstantCommand) -> Self {
+        let display = match &c.action {
+            InstantAction::Url { url } => url.clone(),
+            InstantAction::Exec { exe, args } => {
+                if args.is_empty() { exe.clone() } else { format!("{exe} {args}") }
+            }
+            InstantAction::Legacy { command } => command.clone(),
+        };
+        Self { name: c.name.clone(), description: c.description.clone(), display }
+    }
+}
+
+/// 環境変数 `%VAR%` を展開する（Win32 ExpandEnvironmentStringsW）。非 Windows は素通し。
+pub(crate) fn expand_env(input: &str) -> String {
+    #[cfg(windows)]
+    {
+        use windows::Win32::System::Environment::ExpandEnvironmentStringsW;
+        use windows::core::HSTRING;
+        let src = HSTRING::from(input);
+        unsafe {
+            let needed = ExpandEnvironmentStringsW(&src, None);
+            if needed == 0 { return input.to_string(); }
+            let mut buf = vec![0u16; needed as usize];
+            let written = ExpandEnvironmentStringsW(&src, Some(&mut buf));
+            if written == 0 { return input.to_string(); }
+            // 末尾 NUL を除いて UTF-16 → String
+            let len = (written as usize).saturating_sub(1);
+            String::from_utf16_lossy(&buf[..len])
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        input.to_string()
+    }
+}
+
+/// exec 種別の起動。COM 不要（CreateProcessW 直叩き）。コンソール窓抑止。
+pub(crate) fn launch_exec_core(exe: &str, args: &str, query: &str, clipboard: &str) -> LaunchResult {
+    let exe_expanded = expand_vars(&expand_env(exe), query, clipboard);
+    let arg_tokens = expand_exec_args(args, query, clipboard, expand_env);
+
+    let mut cmd = std::process::Command::new(&exe_expanded);
+    cmd.args(&arg_tokens);
+    cmd.stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null());
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    match cmd.spawn() {
+        Ok(_) => LaunchResult::ok(0),
+        Err(e) => LaunchResult::failed(-1, format!("spawn_failed: {e}")),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::build_launch_args;
+    use super::InstantCommandDto;
+    use snotra_core::config::{InstantAction, InstantCommand};
+
+    #[test]
+    fn instant_dto_display_url() {
+        let c = InstantCommand { name: "g".into(), description: "d".into(),
+            action: InstantAction::Url { url: "https://x".into() } };
+        assert_eq!(InstantCommandDto::from(&c).display, "https://x");
+    }
+    #[test]
+    fn instant_dto_display_exec_with_args() {
+        let c = InstantCommand { name: "ev".into(), description: String::new(),
+            action: InstantAction::Exec { exe: "everything.exe".into(), args: "-s {query}".into() } };
+        assert_eq!(InstantCommandDto::from(&c).display, "everything.exe -s {query}");
+    }
+    #[test]
+    fn instant_dto_display_exec_no_args_has_no_trailing_space() {
+        let c = InstantCommand { name: "n".into(), description: String::new(),
+            action: InstantAction::Exec { exe: "notepad.exe".into(), args: String::new() } };
+        assert_eq!(InstantCommandDto::from(&c).display, "notepad.exe");
+    }
 
     #[test]
     fn build_launch_args_appends_path_when_args_empty() {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -46,7 +46,7 @@ export interface BootstrapPayload {
 
 export interface InstantCommand {
   name: string;
-  command: string;
+  display: string;
   description: string;
 }
 

--- a/ui/src/stores/search.test.ts
+++ b/ui/src/stores/search.test.ts
@@ -72,8 +72,8 @@ const FILE_RESULT: SearchResult = {
 const TOOL_1: OpenerTool = { name: "Tool One", exe: "C:\\one.exe", args: "" };
 const TOOL_2: OpenerTool = { name: "Tool Two", exe: "C:\\two.exe", args: "" };
 
-const CMD_GOOGLE: InstantCommand = { name: "google", command: "https://google.com?q={query}", description: "Google 検索" };
-const CMD_CLIP: InstantCommand = { name: "clip", command: "echo {clip}", description: "" };
+const CMD_GOOGLE: InstantCommand = { name: "google", display: "https://google.com?q={query}", description: "Google 検索" };
+const CMD_CLIP: InstantCommand = { name: "clip", display: "echo {clip}", description: "" };
 
 // ── セットアップ ──────────────────────────────────────────────────────────────
 

--- a/ui/src/stores/search.ts
+++ b/ui/src/stores/search.ts
@@ -298,7 +298,7 @@ createRoot(() => {
                 path: cmd.name,
                 isFolder: false,
                 isError: false,
-                description: cmd.description || cmd.command,
+                description: cmd.description || cmd.display,
               }));
               updateResults(items);
               setSelected(0);


### PR DESCRIPTION
## 概要

インスタントコマンドに「実行ファイル + 引数」種別（`exec`）を追加し、`C:\Users\Eoh\scoop\shims\everything.exe -s {query}` のような引数つきコマンドが起動するようにする。

## 根本原因

`execute_instant_command` が `{query}` 展開後の文字列を `launch_item_core` に渡し、`ShellExecuteW` の `lpFile`（開く対象の単一ファイルパス）に exe+引数を丸ごと渡していた。`lpParameters` は `None` のため、OS は `…everything.exe -s test` という名前のファイルを literally 探して `SE_ERR_FILE_NOT_FOUND` で失敗していた。URL と引数なし exe は動き、引数つきだけが壊れていた（分かれ目は「引数の有無」）。scoop shim は無罪。

## アプローチ

`InstantCommand` を種別を型で持つ形に拡張（illegal state を表現不可能に）:

```rust
#[serde(untagged)]
enum InstantAction {
    Url  { url: String },                 // ShellExecuteW（現状経路・ゼロ回帰）
    Exec { exe: String, args: String },   // Command::new(exe).args(...)
    Legacy { command: String },           // 旧形式互換（load 後 apply_migrations で Url 化）
}
```

- **Exec**: `split_args` で分割 → トークンごとに「環境変数展開 → `{query}`/`{clip}` 置換」（外部入力は env 展開しない・空白入り query は1引数を保つ）→ `Command::new` で起動（`CREATE_NO_WINDOW` + `Stdio::null`）
- **共通化**: 引数分割 `split_args` を `snotra-core` へ移設しオープナーと共有。`expand_vars`/`expand_exec_args` を純関数化（env は注入でテスト可能）
- **設定UI**: 種別ラジオ（URL / プログラム）+ 条件フィールド + プレビュー（実行時と同じ純関数を共用）+ 移行発見ヒント（旧形式らしい行に「プログラム種別へ作り直しますか?」）
- データ型は OpenerTool と統合しない（トリガー・プレースホルダ・マッチングが本質的に異なる）。共通化は実行層に限定

## 後方互換（データ損失防止）

旧 `command = "…"` 形式は `Legacy` variant が deserialize で拾い、`apply_migrations` で **`Url` へ無改変移行**（自動分割しない＝ゼロ回帰）。`Url` 経路は現状の `ShellExecuteW(command)` とバイト等価。

> 多観点レビューで「旧 config が新構造体に deserialize できず Config 全体の parse 失敗 → `config.toml` が `.bak` 退避 → 全設定リセット」というデータ損失欠陥を `toml 1.1.2` で実証・発見。`Legacy` variant + release gate テスト（T2）で塞いだ。

## セキュリティ

- `Command::new` はシェル非経由のため `{query}`/`{clip}` の引数インジェクションに安全（split は展開前に走るので追加引数を注入できない）
- exe ピッカー（実装では手入力テキスト + `.exe` 助言ヒント）。`.bat`/`.cmd` 経由の cmd.exe インジェクションは Rust ≥1.77.2 のバッチ引数エスケープ + 信頼済み config で担保
- `expand_env` の `ExpandEnvironmentStringsW` バッファ境界をクランプ（env レース時の panic = `panic="abort"` での app abort を防止）

## テスト（全 green・コントローラ検証済み）

- `cargo test -p snotra-core`: 404 passed（serde ゲート T1/T2/T3/T4・移行 T15/T17・exec 引数 T7-T12/T16・混在往復）
- `cargo test -p snotra`: DTO display 3 passed
- `cargo clippy`（3 crate・all-targets・-D warnings）: 警告ゼロ
- `npm run typecheck`: clean / `npm test`: 228 passed

## マージ前チェックリスト

- [x] カテゴリD 目視: 設定モーダルの `hint_instant_program` 長文の折り返し確認（`cargo run -p snotra-settings -- --tab instant_command` で起動・目視 → 問題なし）
- [x] 実機 smoke（移行/データ損失なし）: 実ロードパス `load_from_dir_reporting`（toml parse → `apply_migrations` → save）に、旧 `command =` + 新 `exe/args` + 他設定を含む実 config を通し検証 — 旧 command→`url` 移行・`exe/args`→`Exec` パース・window_width/additional(→scan) 保持・再保存後の config.toml が新形式で legacy キー消滅。**データ損失なし**
- [x] 実機 smoke（exec 起動対象）: scoop `everything.exe -s "claude exec smoke"`（unit テスト済 `expand_exec_args` が生成する引数・空白入りクエリは1引数保持）を実機起動 → エラーなく Everything 起動を確認
  - 注: ランチャー本体への `@ev` キー入力経路のみ自動化不可（WebView2 + グローバルホットキー）。exec の引数生成（unit）+ ディスパッチ（DTO test）+ 起動対象（本 smoke）で経路全体を担保

> E2E は instant 未参照のため `e2e` ラベル不要（カテゴリC 非該当: ウィンドウ生成・ホットキー・スラッシュコマンドに非接触）。

設計書・実装計画は `docs/superpowers/specs/` `docs/superpowers/plans/` に同梱。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
