### PR TITLE
chore: Agent worktree isolation の制約を緩和し .claude/worktrees/ を gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ Desktop.ini
 .claude/settings.local.json
 scripts/test-win.sh
 
+# Agent worktrees (Agent isolation: "worktree") — 変更ありの worktree は手動 cleanup
+.claude/worktrees/
+
 # Sidecar binaries (built by scripts/prepare-sidecar.ps1)
 src-tauri/binaries/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@
 
 ## 環境制約
 
-- Agent `isolation: "worktree"` を使わない（Windows でパスが壊れてゴミフォルダが残る）
+- Agent `isolation: "worktree"` は使用可（worktree は `.claude/worktrees/agent-<id>/` に作られ、パス破壊は起きない／Git 2.54.0.windows.1 で検証済み）。変更なしの worktree は自動 cleanup されるが、**ファイルを変更した worktree は成果保全のため自動削除されず残る**ため、`git worktree remove --force <path>` + `git branch -D worktree-agent-<id>` で手動 cleanup する（`.claude/worktrees/` は `.gitignore` 済み＝誤コミット防止）
 - Win32 依存モジュール（`src-tauri/src/ime.rs`, `src-tauri/src/platform/` 内の `hotkey.rs` 等）はユニットテスト前提にしない
 - モジュール固有の不変条件・TDD ルールは各サブディレクトリの `CLAUDE.md` を参照（実装前チェックは `.claude/rules/` で自動配送）
 


### PR DESCRIPTION
## 背景

AGENTS.md は Agent `isolation: "worktree"` を「Windows でパスが壊れてゴミフォルダが残る」として禁止していた。この記述が現環境でも as-built かを実証検証した。

## 検証結果（Git 2.54.0.windows.1 / 現行 Claude Code）

| 対象 | 結果 |
|------|------|
| native `git worktree`（add/list/status/remove） | ✅ 完全クリーン・残骸ゼロ |
| Agent `isolation:"worktree"` 変更なし経路 | ✅ 動作・auto-clean（空の親 dir のみ） |
| Agent `isolation:"worktree"` 変更あり経路 | ✅ 動作・worktree は**設計上保持**（成果保全） |

- **「パス破壊」は再現せず** — worktree は整形済みパス `.claude/worktrees/agent-<id>/` に正しく作成された（`pwd` / `git rev-parse --show-toplevel` 一貫）。当時の古い Claude Code のパス構築バグが修正済みと推測。
- 「ゴミが残る」は **"auto-cleaned if unchanged" の設計**であり破壊ではない。ファイルを変更した worktree は成果を失わないよう意図的に残る。`git worktree remove --force` + `git branch -D` で確実に除去できる。
- 唯一の現実的 footgun: 変更あり経路で本体リポジトリの `git status` に `?? .claude/worktrees/` が現れる（gitignore 未対応のため誤コミットしうる）。

## 変更

- **AGENTS.md**: 環境制約を「使わない」→「使用可・変更ありの worktree は手動 cleanup」へ as-built 更新
- **.gitignore**: `.claude/worktrees/` を追加し worktree の誤コミットを防止

## 検証した不変条件

- native `git worktree` は add→remove で folder・branch・`.git/worktrees` 管理 dir すべてを残骸なく除去する
- `.claude/worktrees/` 配下が `git check-ignore` でマッチする（誤コミット防止が実効）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
