### PR TITLE
fix(core): 永続化保存の失敗を可視化する（must_use + eprintln）

### DIFF
--- a/snotra-core/src/binfmt.rs
+++ b/snotra-core/src/binfmt.rs
@@ -72,8 +72,10 @@ impl BinFile {
     }
 
     /// Atomically save data: write to `.tmp`, remove old file, rename `.tmp`.
-    /// Returns `true` on success.
+    /// Returns `true` on success. `#[must_use]`: callers must check for failure and
+    /// surface it (log/eprintln) rather than silently discard it (issue #428).
     #[allow(deprecated)]
+    #[must_use]
     pub fn save<T: Serialize>(&self, data: &T) -> bool {
         if let Some(dir) = self.path.parent() {
             let _ = fs::create_dir_all(dir);

--- a/snotra-core/src/history.rs
+++ b/snotra-core/src/history.rs
@@ -55,8 +55,10 @@ impl HistoryStore {
     pub fn save(&mut self, top_n: usize) {
         self.prune(top_n);
 
-        if let Some(bf) = Self::bin_file() {
-            bf.save(&self.data);
+        if let Some(bf) = Self::bin_file()
+            && !bf.save(&self.data)
+        {
+            eprintln!("[history] failed to save {}", bf.path().display());
         }
     }
 

--- a/snotra-core/src/indexer.rs
+++ b/snotra-core/src/indexer.rs
@@ -437,7 +437,9 @@ fn save_cache_sorted(entries: &[AppEntry], config_hash: u64) {
         lower_file_names: &lower_file_names,
         normalized_keys: &normalized_keys,
     };
-    bf.save(&cache);
+    if !bf.save(&cache) {
+        eprintln!("[indexer] failed to save {}", bf.path().display());
+    }
 }
 
 /// Force rebuild: scan and save cache, regardless of existing cache.

--- a/snotra-core/src/window_data.rs
+++ b/snotra-core/src/window_data.rs
@@ -66,8 +66,10 @@ fn load_state_v5() -> Option<WindowPlacementState> {
 }
 
 fn save_state(state: &WindowPlacementState) {
-    if let Some(bf) = BinFile::new(WINDOW_MAGIC, WINDOW_VERSION_V5, "window.bin") {
-        bf.save(state);
+    if let Some(bf) = BinFile::new(WINDOW_MAGIC, WINDOW_VERSION_V5, "window.bin")
+        && !bf.save(state)
+    {
+        eprintln!("[window] failed to save {}", bf.path().display());
     }
 }
 


### PR DESCRIPTION
## 変更内容

`BinFile::save` は失敗を `bool` で返すが、履歴・ウィンドウ位置・インデックスキャッシュの保存呼び出しの多くが戻り値を捨てておりログも無かった（`config` だけ `Result<(), String>` で厳格に扱っており非対称）。

- `snotra-core/src/binfmt.rs`: `BinFile::save` に `#[must_use]` を付与し、戻り値の無視をコンパイル時に検出する
- `snotra-core/src/history.rs` (`HistoryStore::save`): 失敗時に `eprintln!("[history] failed to save {path}")` で可視化
- `snotra-core/src/window_data.rs` (`save_state`): 失敗時に `eprintln!("[window] failed to save {path}")` で可視化
- `snotra-core/src/indexer.rs` (`save_cache_sorted`): 失敗時に `eprintln!("[indexer] failed to save {path}")` で可視化

メッセージの `[tag]` 形式は既存の `config.rs` の `eprintln!("[config] ...")` に合わせた。

## 対処箇所一覧（file:line）

| ファイル:行 | 内容 |
|---|---|
| `snotra-core/src/binfmt.rs:76-79` | `BinFile::save` に `#[must_use]` 付与 |
| `snotra-core/src/history.rs:58-61` | `HistoryStore::save` 内の `bf.save()` 呼び出しを失敗時 `eprintln!` |
| `snotra-core/src/window_data.rs:68-73` | `save_state` 内の `bf.save()` 呼び出しを失敗時 `eprintln!` |
| `snotra-core/src/indexer.rs:440-442` | `save_cache_sorted` 内の `bf.save()` 呼び出しを失敗時 `eprintln!` |

## 同一パターン全コードパス検索（AGENTS.md）

`BinFile::save` / `save` 系呼び出しを crate 全体で grep し、以下を確認した。

- `src-tauri/src/icon.rs:83` (`IconCache::save_if_dirty`) — 既に `bf.save(&self.data)` の戻り値を `&&` 条件式で使用しており対処済み（`dirty` フラグのクリア判定に使われている）。`#[must_use]` 追加でも新規警告なし
- `snotra-core/src/config.rs` — `BinFile` を使わず TOML + `Result<(), String>` で独自に保存しており対象外（issue の指摘どおり config のみ既に厳格）
- `snotra-core/src/binfmt.rs` のユニットテスト（8箇所）・`history.rs:528` のテスト — 元々 `assert!(bf.save(...))` で戻り値を使用しており対象外

漏れなく列挙した結果、握りつぶしていたのは issue に記載の3箇所（history.rs / window_data.rs / indexer.rs）のみだった。

## スコープ外

`bool` → `Result` への変換（`try_*` 化）は行っていない。それは #437 のスコープ。今回は可視化（`must_use` + ログ）のみ。

## must_use で新たに検出された箇所

新規警告は無し。既存の呼び出し箇所は上記3箇所（暗黙の破棄）+ 1箇所（`icon.rs`、既に戻り値使用済み）+ テストコード（既に戻り値使用済み）のみで、issue の発見事項と一致した。

## 検証

- `cargo check -p snotra-core -p snotra -p snotra-settings`: green（`must_use` 追加による新規警告なし）
- `cargo clippy -p snotra-core -p snotra -p snotra-settings --all-targets -- -D warnings`: green
- `cargo test -p snotra-core`: 455 passed; 0 failed; 9 ignored

## Test plan

- [x] cargo check green
- [x] cargo clippy (-D warnings) green
- [x] cargo test -p snotra-core green (455 passed)

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)
