### PR TITLE
test(src-tauri): Win32 非依存の純関数にテストを追加（monitor clamp/center・tray ラベル整形）

### DIFF
--- a/src-tauri/src/monitor.rs
+++ b/src-tauri/src/monitor.rs
@@ -102,3 +102,107 @@ unsafe fn work_area_from_hmonitor(
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::WorkArea;
+
+    /// 単一モニター相当の標準的な作業領域（1920x1080、原点は左上）。
+    fn area() -> WorkArea {
+        WorkArea {
+            left: 0,
+            top: 0,
+            right: 1920,
+            bottom: 1080,
+        }
+    }
+
+    #[test]
+    fn clamp_within_bounds_is_unchanged() {
+        let a = area();
+        assert_eq!(a.clamp(100, 100, 400, 300), (100, 100));
+    }
+
+    #[test]
+    fn clamp_position_beyond_bottom_right_clamps_to_max() {
+        let a = area();
+        // max_x = 1920-400=1520, max_y = 1080-300=780
+        assert_eq!(a.clamp(2000, 2000, 400, 300), (1520, 780));
+    }
+
+    #[test]
+    fn clamp_negative_position_clamps_to_top_left() {
+        let a = area();
+        assert_eq!(a.clamp(-500, -500, 400, 300), (0, 0));
+    }
+
+    #[test]
+    fn clamp_exact_boundary_is_stable() {
+        // x/y already equal max_x/max_y: applying clamp again must not shift by one.
+        let a = area();
+        assert_eq!(a.clamp(1520, 780, 400, 300), (1520, 780));
+    }
+
+    #[test]
+    fn clamp_window_wider_than_work_area_aligns_to_left() {
+        // win_w(2000) > width(1920): max_x = (1920-2000).max(left) = left(0)
+        let a = area();
+        assert_eq!(a.clamp(500, 100, 2000, 300), (0, 100));
+    }
+
+    #[test]
+    fn clamp_window_taller_than_work_area_aligns_to_top() {
+        let a = area();
+        assert_eq!(a.clamp(100, 500, 400, 2000), (100, 0));
+    }
+
+    #[test]
+    fn clamp_negative_origin_monitor() {
+        // secondary monitor positioned to the left of the primary (negative coordinates).
+        let a = WorkArea {
+            left: -1920,
+            top: 0,
+            right: 0,
+            bottom: 1080,
+        };
+        assert_eq!(a.clamp(-1000, 500, 400, 300), (-1000, 500));
+        // beyond this monitor's own right edge clamps to its own max_x (-400), not 0.
+        assert_eq!(a.clamp(500, 500, 400, 300), (-400, 500));
+    }
+
+    #[test]
+    fn center_normal_case() {
+        let a = area();
+        assert_eq!(a.center(800, 600), (560, 240));
+    }
+
+    #[test]
+    fn center_truncates_odd_remainder_toward_left_top() {
+        // width 1921 - win_w 800 = 1121 (odd); integer division truncates 560.5 -> 560.
+        let a = WorkArea {
+            left: 0,
+            top: 0,
+            right: 1921,
+            bottom: 1080,
+        };
+        assert_eq!(a.center(800, 600), (560, 240));
+    }
+
+    #[test]
+    fn center_window_larger_than_work_area_goes_negative() {
+        // unlike clamp, center has no lower bound: an oversized window centers off-screen.
+        let a = area();
+        assert_eq!(a.center(2000, 1200), (-40, -60));
+    }
+
+    #[test]
+    fn center_negative_origin_monitor() {
+        let a = WorkArea {
+            left: -1920,
+            top: 0,
+            right: 0,
+            bottom: 1080,
+        };
+        assert_eq!(a.center(800, 600), (-1360, 240));
+    }
+}

--- a/src-tauri/src/platform/tray.rs
+++ b/src-tauri/src/platform/tray.rs
@@ -451,3 +451,76 @@ fn load_tray_icon_from_exe() -> Option<HICON> {
     }
     Some(icon)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::format_recent_history_label;
+    use snotra_core::ui_types::SearchResult;
+
+    fn item(name: &str, path: &str) -> SearchResult {
+        SearchResult {
+            name: name.to_string(),
+            path: path.to_string(),
+            is_folder: false,
+            is_error: false,
+        }
+    }
+
+    #[test]
+    fn empty_name_falls_back_to_path_only() {
+        let label = format_recent_history_label(&item("", "C:/Users/foo/bar.exe"));
+        assert_eq!(label, "C:/Users/foo/bar.exe");
+    }
+
+    #[test]
+    fn name_equal_to_path_dedupes_to_path_only() {
+        let label = format_recent_history_label(&item("C:/Users/foo/bar.exe", "C:/Users/foo/bar.exe"));
+        assert_eq!(label, "C:/Users/foo/bar.exe");
+    }
+
+    #[test]
+    fn both_empty_yields_empty_label() {
+        // name.is_empty() は true なので path (空文字) をそのまま返す。
+        let label = format_recent_history_label(&item("", ""));
+        assert_eq!(label, "");
+    }
+
+    #[test]
+    fn distinct_name_and_path_formats_as_name_dash_path() {
+        let label = format_recent_history_label(&item("bar.exe", "C:/Users/foo/bar.exe"));
+        assert_eq!(label, "bar.exe - C:/Users/foo/bar.exe");
+    }
+
+    #[test]
+    fn exactly_max_len_is_not_truncated() {
+        // MAX_LABEL_LEN(90) ちょうどでは "..." を付けない（境界値）。
+        let path = "x".repeat(90);
+        let label = format_recent_history_label(&item("", &path));
+        assert_eq!(label, path);
+        assert_eq!(label.chars().count(), 90);
+    }
+
+    #[test]
+    fn one_over_max_len_truncates_to_87_chars_plus_ellipsis() {
+        // 91 文字は 87 文字 + "..." の合計 90 文字に切り詰められる。
+        let path = "x".repeat(91);
+        let label = format_recent_history_label(&item("", &path));
+        let expected = format!("{}...", "x".repeat(87));
+        assert_eq!(label, expected);
+        assert_eq!(label.chars().count(), 90);
+    }
+
+    #[test]
+    fn multibyte_truncation_cuts_on_char_boundary_not_byte_boundary() {
+        // 日本語（1文字3バイト）で 103 文字のラベルを構築し、マルチバイト境界での
+        // 切り詰めがパニックせず、文字単位（バイト単位ではない）で 87 文字に切り詰められることを検証する。
+        let name = "あ".repeat(50);
+        let path = "い".repeat(50);
+        let label = format_recent_history_label(&item(&name, &path));
+
+        // base = "あ"*50 + " - " + "い"*50 = 103 文字。先頭 87 文字 = "あ"*50 + " - " + "い"*34。
+        let expected = format!("{}{}{}...", "あ".repeat(50), " - ", "い".repeat(34));
+        assert_eq!(label, expected);
+        assert_eq!(label.chars().count(), 90);
+    }
+}


### PR DESCRIPTION
## 概要

#427 の指摘どおり、Win32 非依存の純関数（`monitor.rs` の `WorkArea::clamp` / `center`、`platform/tray.rs` の `format_recent_history_label`）に境界値テストを追加する。テスト追加のみで、プロダクションコードの変更・可視性変更は行っていない（両関数とも既存の可視性のまま同一ファイル内の `#[cfg(test)] mod tests` から参照可能）。

## 追加テスト

### `src-tauri/src/monitor.rs`（`WorkArea::clamp` / `center`、11 本）

- `clamp_within_bounds_is_unchanged`
- `clamp_position_beyond_bottom_right_clamps_to_max`
- `clamp_negative_position_clamps_to_top_left`
- `clamp_exact_boundary_is_stable`（x/y が既に max_x/max_y のとき再クランプで off-by-one が起きない）
- `clamp_window_wider_than_work_area_aligns_to_left`
- `clamp_window_taller_than_work_area_aligns_to_top`
- `clamp_negative_origin_monitor`（プライマリの左に位置する副モニター相当の負座標）
- `center_normal_case`
- `center_truncates_odd_remainder_toward_left_top`（整数除算の 0 方向切り捨て）
- `center_window_larger_than_work_area_goes_negative`（clamp と異なり center は範囲外を許容）
- `center_negative_origin_monitor`

### `src-tauri/src/platform/tray.rs`（`format_recent_history_label`、7 本）

- `empty_name_falls_back_to_path_only`
- `name_equal_to_path_dedupes_to_path_only`
- `both_empty_yields_empty_label`
- `distinct_name_and_path_formats_as_name_dash_path`
- `exactly_max_len_is_not_truncated`（90 文字ちょうどの境界値）
- `one_over_max_len_truncates_to_87_chars_plus_ellipsis`（91 文字 → 87+"..." = 90 文字）
- `multibyte_truncation_cuts_on_char_boundary_not_byte_boundary`（日本語 103 文字がバイト境界ではなく文字単位で切り詰められ、パニックしないことを検証）

## 検証した不変条件

- `WorkArea::clamp` は常に `[left, max_x] x [top, max_y]` に収まり、window が work area より大きい場合は left/top 側に寄せる
- `WorkArea::center` は clamp と異なり範囲外（負値・画面外）を許容する
- `format_recent_history_label` の 90 文字境界は `chars().count()`（Unicode scalar 単位）で判定され、マルチバイト文字を含んでもバイト境界破壊によるパニックが起きない

## 検証コマンドと結果

- `cargo check -p snotra-core -p snotra -p snotra-settings` — 成功
- `cargo clippy -p snotra-core -p snotra -p snotra-settings --all-targets -- -D warnings` — warning 0
- `cargo test -p snotra` — 61 passed（新規 18 本含む）; 0 failed

## プロダクションコードへの変更

なし（テスト追加のみ。可視性変更も不要だった）。

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)
