### PR TITLE
refactor(core): BinFile に dir 注入口を追加し永続化ラウンドトリップをテスト可能にする

### DIFF
--- a/snotra-core/src/binfmt.rs
+++ b/snotra-core/src/binfmt.rs
@@ -23,11 +23,17 @@ impl BinFile {
     /// Create a new BinFile handle. Returns `None` if config dir is unavailable.
     pub fn new(magic: [u8; 4], version: u32, filename: &str) -> Option<Self> {
         let dir = Config::config_dir()?;
-        Some(Self {
+        Some(Self::new_in(&dir, magic, version, filename))
+    }
+
+    /// Create a new BinFile handle rooted at `dir` (injectable, e.g. for tests).
+    /// Infallible: unlike `new`, the caller already resolved the directory.
+    pub fn new_in(dir: &Path, magic: [u8; 4], version: u32, filename: &str) -> Self {
+        Self {
             magic,
             version,
             path: dir.join(filename),
-        })
+        }
     }
 
     /// Load data from the file using the current version (postcard format).
@@ -218,11 +224,17 @@ mod tests {
 
     /// Helper: create a BinFile pointing to a specific directory (bypasses Config::config_dir)
     fn bin_file_in(dir: &Path, magic: [u8; 4], version: u32, filename: &str) -> BinFile {
-        BinFile {
-            magic,
-            version,
-            path: dir.join(filename),
-        }
+        BinFile::new_in(dir, magic, version, filename)
+    }
+
+    #[test]
+    fn binfile_new_in_joins_dir_and_filename() {
+        let dir = temp_dir("binfile_new_in");
+        let bf = BinFile::new_in(&dir, *b"TEST", 1, "data.bin");
+        assert_eq!(bf.path(), dir.join("data.bin"));
+        assert_eq!(bf.magic, *b"TEST");
+        assert_eq!(bf.version, 1);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -372,11 +384,7 @@ mod tests {
     fn binfile_save_creates_parent_directories() {
         let dir = temp_dir("binfile_mkdir");
         let nested = dir.join("sub").join("dir");
-        let bf = BinFile {
-            magic: *b"TEST",
-            version: 1,
-            path: nested.join("data.bin"),
-        };
+        let bf = BinFile::new_in(&nested, *b"TEST", 1, "data.bin");
 
         assert!(bf.save(&Dummy { value: 1 }));
         assert!(bf.path().exists());

--- a/snotra-core/src/history.rs
+++ b/snotra-core/src/history.rs
@@ -1,8 +1,10 @@
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::binfmt::BinFile;
+use crate::config::Config;
 use crate::indexer::normalize_entry_key;
 use crate::query::normalize_history_query_key;
 
@@ -37,13 +39,25 @@ impl HistoryStore {
     /// 引数で受け取る（live-read 化、issue #348）。これにより `result_limit` の設定変更が
     /// 再起動なしで反映され、`HistoryStore.top_n` の焼き込みによるドリフトが構造的に発生しない。
     pub fn load() -> Self {
-        let (loaded_data, loaded_version) = Self::bin_file()
-            .and_then(|bf| bf.load_with_fallback(HISTORY_FALLBACKS))
-            .unwrap_or((HistoryData::default(), HISTORY_VERSION));
+        match Config::config_dir() {
+            Some(dir) => Self::load_in(&dir),
+            None => Self::from_loaded(HistoryData::default(), HISTORY_VERSION),
+        }
+    }
 
+    /// `load()` と同じ読み込みを `dir` 注入で行う（統合テスト用、issue #429）。
+    pub fn load_in(dir: &Path) -> Self {
+        let (loaded_data, loaded_version) = Self::bin_file_in(dir)
+            .load_with_fallback(HISTORY_FALLBACKS)
+            .unwrap_or((HistoryData::default(), HISTORY_VERSION));
+        Self::from_loaded(loaded_data, loaded_version)
+    }
+
+    /// 読み込んだ生データに対し、バージョン別マイグレーションを適用して Self を組み立てる。
+    /// `load()` / `load_in()` の共有ロジック。
+    fn from_loaded(loaded_data: HistoryData, loaded_version: u32) -> Self {
         let data = migrate_time_unit_if_legacy(loaded_version, loaded_data);
         let data = migrate_normalize_keys(data);
-
         Self {
             data,
             dirty_count: 0,
@@ -53,11 +67,18 @@ impl HistoryStore {
     /// `top_n` 件まで剪定してから永続化する。`top_n` は呼び出し側（`Engine`）が
     /// 現在の config から渡す（live-read）。
     pub fn save(&mut self, top_n: usize) {
+        match Config::config_dir() {
+            Some(dir) => self.save_in(top_n, &dir),
+            None => self.prune(top_n),
+        }
+    }
+
+    /// `save()` と同じ剪定+永続化を `dir` 注入で行う（統合テスト用、issue #429）。
+    pub fn save_in(&mut self, top_n: usize, dir: &Path) {
         self.prune(top_n);
 
-        if let Some(bf) = Self::bin_file()
-            && !bf.save(&self.data)
-        {
+        let bf = Self::bin_file_in(dir);
+        if !bf.save(&self.data) {
             eprintln!("[history] failed to save {}", bf.path().display());
         }
     }
@@ -191,8 +212,8 @@ impl HistoryStore {
             .unwrap_or(0)
     }
 
-    fn bin_file() -> Option<BinFile> {
-        BinFile::new(HISTORY_MAGIC, HISTORY_VERSION, "history.bin")
+    fn bin_file_in(dir: &Path) -> BinFile {
+        BinFile::new_in(dir, HISTORY_MAGIC, HISTORY_VERSION, "history.bin")
     }
 
     /// `top_n` 件まで剪定する。`top_n` は引数で受け取る（焼き込まない＝live-read、issue #348）。
@@ -279,16 +300,6 @@ mod tests {
     use super::*;
     use crate::binfmt::{deserialize_with_header, serialize_with_header};
     use crate::query::normalize_query;
-    use std::path::Path;
-
-    /// Helper: create a BinFile pointing to a specific directory (bypasses Config::config_dir)
-    fn bin_file_in(dir: &Path) -> BinFile {
-        BinFile {
-            magic: HISTORY_MAGIC,
-            version: HISTORY_VERSION,
-            path: dir.join("history.bin"),
-        }
-    }
 
     fn temp_dir(tag: &str) -> std::path::PathBuf {
         let dir = std::env::temp_dir().join(format!("snotra_hist_test_{}", tag));
@@ -499,7 +510,7 @@ mod tests {
         );
         let bytes = serialize_with_header(HISTORY_MAGIC, HISTORY_VERSION_POSTCARD_V2, &data)
             .expect("serialize v2 postcard");
-        let bf = bin_file_in(&dir);
+        let bf = HistoryStore::bin_file_in(&dir);
         std::fs::write(bf.path(), &bytes).unwrap();
         let (loaded, version): (HistoryData, u32) =
             bf.load_with_fallback(HISTORY_FALLBACKS).expect("load v2 postcard");
@@ -524,7 +535,7 @@ mod tests {
                 last_launched: 1_700_000_000_000,
             },
         );
-        let bf = bin_file_in(&dir);
+        let bf = HistoryStore::bin_file_in(&dir);
         assert!(bf.save(&data));
         let (loaded, version): (HistoryData, u32) =
             bf.load_with_fallback(HISTORY_FALLBACKS).expect("load v3 postcard");
@@ -794,5 +805,53 @@ mod tests {
         let twice = migrate_normalize_keys(once.clone());
         assert_eq!(once.query["tool\\editor"]["c:\\tool\\editor\\app.exe"], 3);
         assert_eq!(twice.query["tool\\editor"]["c:\\tool\\editor\\app.exe"], 3);
+    }
+
+    // --- save_in / load_in ラウンドトリップ（issue #429, dir 注入で統合テスト可能に）---
+
+    #[test]
+    fn save_in_load_in_roundtrip_preserves_data() {
+        let dir = temp_dir("save_load_roundtrip");
+        let mut store = fresh_store();
+        store.record_launch("C:\\fake\\app.lnk", "app query");
+        store.record_launch("C:\\fake\\app.lnk", "app query");
+        store.record_folder_expansion("C:\\Projects");
+
+        store.save_in(100, &dir);
+
+        let loaded = HistoryStore::load_in(&dir);
+        assert_eq!(loaded.global_count("C:\\fake\\app.lnk"), 2);
+        assert_eq!(loaded.query_count("app query", "C:\\fake\\app.lnk"), 2);
+        assert_eq!(loaded.folder_expansion_count("C:\\Projects"), 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn save_in_prunes_before_persisting_and_load_in_reflects_pruned_data() {
+        // save_in は prune → 永続化の順（HistoryStore::save_in 実装どおり）。
+        // top_n=2 で保存した内容を dir から読み直し、低カウントの entry が
+        // ディスク上でも剪定されていること（インメモリだけの剪定ではないこと）を検証する。
+        let dir = temp_dir("save_prune_roundtrip");
+        let mut store = fresh_store();
+        for (name, count) in [("a", 10u32), ("b", 5), ("c", 1)] {
+            let path = format!("c:\\{}.lnk", name);
+            for _ in 0..count {
+                store.record_launch(&path, "");
+            }
+        }
+
+        store.save_in(2, &dir);
+
+        let loaded = HistoryStore::load_in(&dir);
+        assert_eq!(loaded.global_count("c:\\a.lnk"), 10);
+        assert_eq!(loaded.global_count("c:\\b.lnk"), 5);
+        assert_eq!(
+            loaded.global_count("c:\\c.lnk"),
+            0,
+            "low-count entry should be pruned before persisting to disk"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/snotra-core/src/indexer.rs
+++ b/snotra-core/src/indexer.rs
@@ -14,7 +14,7 @@ use windows::Win32::System::Threading::{
 };
 
 use crate::binfmt::{BinFile, try_deserialize_with_header};
-use crate::config::ScanPath;
+use crate::config::{Config, ScanPath};
 use crate::query::{char_bitmask, to_lower_folded};
 
 const INDEX_MAGIC: [u8; 4] = *b"INDX";
@@ -278,8 +278,8 @@ fn compute_config_hash(scan: &[ScanPath], show_hidden_system: bool) -> u64 {
     hasher.finish()
 }
 
-fn cache_bin_file() -> Option<BinFile> {
-    BinFile::new(INDEX_MAGIC, INDEX_CACHE_VERSION, "index.bin")
+fn cache_bin_file_in(dir: &Path) -> BinFile {
+    BinFile::new_in(dir, INDEX_MAGIC, INDEX_CACHE_VERSION, "index.bin")
 }
 
 /// Load cached entries or scan the filesystem. Returns `(entries, cache_changed)`
@@ -391,9 +391,15 @@ fn sort_entries_canonical(entries: &mut [AppEntry]) {
 }
 
 fn save_cache_sorted(entries: &[AppEntry], config_hash: u64) {
-    let Some(bf) = cache_bin_file() else {
+    let Some(dir) = Config::config_dir() else {
         return;
     };
+    save_cache_sorted_in(&dir, entries, config_hash);
+}
+
+/// `save_cache_sorted` と同じ保存処理を `dir` 注入で行う（統合テスト用、issue #429）。
+fn save_cache_sorted_in(dir: &Path, entries: &[AppEntry], config_hash: u64) {
+    let bf = cache_bin_file_in(dir);
 
     // マスクを計算してキャッシュに含める。起動時に SearchEngine::new_with_cached_masks()
     // がマスク再計算をスキップできるようにする。
@@ -463,7 +469,13 @@ struct LoadCacheResult {
 }
 
 fn load_cache(config_hash: u64) -> Option<LoadCacheResult> {
-    let bf = cache_bin_file()?;
+    let dir = Config::config_dir()?;
+    load_cache_in(&dir, config_hash)
+}
+
+/// `load_cache` と同じ読み込みを `dir` 注入で行う（統合テスト用、issue #429）。
+fn load_cache_in(dir: &Path, config_hash: u64) -> Option<LoadCacheResult> {
+    let bf = cache_bin_file_in(dir);
     let bytes = bf.load_bytes()?;
 
     // v4 (現行): ビットマスク + lower names / normalized_keys を含む
@@ -1074,6 +1086,46 @@ mod tests {
                 .expect("roundtrip");
         assert_eq!(restored.entries.len(), 2);
         assert_eq!(restored.normalized_keys, normalized_keys);
+    }
+
+    #[test]
+    fn save_cache_sorted_in_then_load_cache_in_roundtrip() {
+        // issue #429: BinFile の dir 注入経路（save_cache_sorted_in / load_cache_in）が
+        // 実ファイル I/O を通して往復することを検証する（旧来は config_dir 固定で統合テスト不可）。
+        let dir = temp_dir("cache_dir_injection_roundtrip");
+        let entries = vec![
+            AppEntry {
+                name: "Firefox".to_string(),
+                target_path: "C:\\apps\\firefox.lnk".to_string(),
+                is_folder: false,
+            },
+            AppEntry {
+                name: "Projects".to_string(),
+                target_path: "C:\\Projects".to_string(),
+                is_folder: true,
+            },
+        ];
+        let config_hash = 42u64;
+
+        save_cache_sorted_in(&dir, &entries, config_hash);
+
+        let result = load_cache_in(&dir, config_hash).expect("load cache written to dir");
+        assert_eq!(result.entries.len(), 2);
+        assert_eq!(result.entries[0].name, "Firefox");
+        assert_eq!(result.entries[1].name, "Projects");
+        let masks = result.cached_masks.expect("v4 cache should include masks");
+        assert_eq!(
+            masks.normalized_keys,
+            Some(vec![
+                "c:\\apps\\firefox.lnk".to_string(),
+                "c:\\projects".to_string(),
+            ])
+        );
+
+        // config_hash が異なると stale 扱いで None
+        assert!(load_cache_in(&dir, config_hash.wrapping_add(1)).is_none());
+
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/snotra-core/src/window_data.rs
+++ b/snotra-core/src/window_data.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 
 use crate::binfmt::BinFile;
+use crate::config::Config;
 
 const WINDOW_MAGIC: [u8; 4] = *b"WNDW";
 const WINDOW_VERSION_V4: u32 = 4; // postcard, 絶対座標（旧）
@@ -45,15 +47,25 @@ pub fn save_settings_placement(placement: WindowPlacement) {
     save_state(&state);
 }
 
+fn bin_file_in(dir: &Path, version: u32) -> BinFile {
+    BinFile::new_in(dir, WINDOW_MAGIC, version, "window.bin")
+}
+
 /// Load V5 state, falling back to V4 with search placement cleared
 /// (V4 stored absolute coordinates which are meaningless as relative).
 fn load_state_v5() -> Option<WindowPlacementState> {
-    let bf_v5 = BinFile::new(WINDOW_MAGIC, WINDOW_VERSION_V5, "window.bin")?;
+    let dir = Config::config_dir()?;
+    load_state_v5_in(&dir)
+}
+
+/// `load_state_v5` と同じ移行ロジックを `dir` 注入で行う（統合テスト用、issue #429）。
+fn load_state_v5_in(dir: &Path) -> Option<WindowPlacementState> {
+    let bf_v5 = bin_file_in(dir, WINDOW_VERSION_V5);
     if let Some(state) = bf_v5.load::<WindowPlacementState>() {
         return Some(state);
     }
     // V4 fallback: load settings/settings_size but discard search placement.
-    let bf_v4 = BinFile::new(WINDOW_MAGIC, WINDOW_VERSION_V4, "window.bin")?;
+    let bf_v4 = bin_file_in(dir, WINDOW_VERSION_V4);
     let v4_state = bf_v4.load::<WindowPlacementState>()?;
     let migrated = WindowPlacementState {
         search: None, // Discard absolute coordinates
@@ -61,14 +73,20 @@ fn load_state_v5() -> Option<WindowPlacementState> {
         settings_size: v4_state.settings_size,
     };
     // Persist migrated state as V5 so next load is fast.
-    save_state(&migrated);
+    save_state_in(&migrated, dir);
     Some(migrated)
 }
 
 fn save_state(state: &WindowPlacementState) {
-    if let Some(bf) = BinFile::new(WINDOW_MAGIC, WINDOW_VERSION_V5, "window.bin")
-        && !bf.save(state)
-    {
+    if let Some(dir) = Config::config_dir() {
+        save_state_in(state, &dir);
+    }
+}
+
+/// `save_state` と同じ永続化を `dir` 注入で行う（統合テスト用、issue #429）。
+fn save_state_in(state: &WindowPlacementState, dir: &Path) {
+    let bf = bin_file_in(dir, WINDOW_VERSION_V5);
+    if !bf.save(state) {
         eprintln!("[window] failed to save {}", bf.path().display());
     }
 }
@@ -78,6 +96,76 @@ fn save_state(state: &WindowPlacementState) {
 mod tests {
     use super::*;
     use crate::binfmt::{deserialize_with_header, serialize_with_header};
+
+    fn temp_dir(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("snotra_window_test_{}", tag));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    #[test]
+    fn save_state_in_then_load_state_v5_in_roundtrip() {
+        let dir = temp_dir("v5_roundtrip");
+        let state = WindowPlacementState {
+            search: Some(WindowPlacement { x: 10, y: 20 }),
+            settings: Some(WindowPlacement { x: 30, y: 40 }),
+            settings_size: Some(WindowSize {
+                width: 500,
+                height: 400,
+            }),
+        };
+
+        save_state_in(&state, &dir);
+        let loaded = load_state_v5_in(&dir).expect("load v5");
+        assert_eq!(loaded, state);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_state_v5_in_migrates_v4_discarding_search_and_persists_as_v5() {
+        // issue #429 の中核テスト: V4→V5 の実移行パス（絶対座標→モニター相対という
+        // セマンティクス変更）を、V4 フォーマットの実バイト書き込み→V5 ロード経路で検証する。
+        let dir = temp_dir("v4_to_v5_migration");
+
+        // V4 の実バイト形式で window.bin を書き込む（postcard + ヘッダ WNDW/v4）。
+        // search は V4 では絶対座標として記録されていた想定値。
+        let v4_state = WindowPlacementState {
+            search: Some(WindowPlacement { x: 2560, y: 300 }),
+            settings: Some(WindowPlacement { x: 100, y: 200 }),
+            settings_size: Some(WindowSize {
+                width: 800,
+                height: 600,
+            }),
+        };
+        let bytes = serialize_with_header(WINDOW_MAGIC, WINDOW_VERSION_V4, &v4_state)
+            .expect("serialize v4");
+        let path = dir.join("window.bin");
+        std::fs::write(&path, &bytes).expect("write v4 window.bin");
+
+        // V5 ロード経路（load_state_v5_in）で読む。
+        let migrated = load_state_v5_in(&dir).expect("load v4 via v5 path");
+
+        // (a) search（絶対座標）はモニター相対座標として無意味なため破棄され None になる。
+        assert_eq!(migrated.search, None, "V4 absolute search coords must be discarded");
+        // settings/settings_size は V4 でも絶対座標のまま意味を保つため引き継がれる。
+        assert_eq!(migrated.settings, v4_state.settings);
+        assert_eq!(migrated.settings_size, v4_state.settings_size);
+
+        // (b) load_state_v5_in の副作用（save_state_in 呼び出し）により、
+        // ディスク上のファイルは V5 として再保存されている。
+        let raw = std::fs::read(&path).expect("read persisted window.bin");
+        let reloaded_v5: WindowPlacementState =
+            deserialize_with_header(&raw, WINDOW_MAGIC, WINDOW_VERSION_V5)
+                .expect("persisted file should now deserialize as V5");
+        assert_eq!(reloaded_v5, migrated);
+        let as_v4: Option<WindowPlacementState> =
+            deserialize_with_header(&raw, WINDOW_MAGIC, WINDOW_VERSION_V4);
+        assert!(as_v4.is_none(), "persisted file should no longer be readable as V4");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn placement_state_roundtrip_header_v4() {


### PR DESCRIPTION
## 概要

`BinFile::new` が `Config::config_dir()`（実 `%APPDATA%`）固定でディレクトリ注入口が
無く、history / window_data / indexer の永続化ラウンドトリップが統合テスト不可能
だった（#429）。`config.rs` の `load_from_dir_reporting` / `save_to_dir` と同じ
設計思想で `BinFile::new_in(dir, ..)` を追加し、全永続モジュールを dir 注入可能に
した。公開 API の挙動は不変（純粋な additive + 内部委譲）。

## 設計判断

- **`BinFile::new_in(dir: &Path, magic, version, filename) -> Self`**（infallible）を
  追加。既存 `new(..) -> Option<Self>` は `Config::config_dir()` を解決してから
  これへ委譲する形にリファクタ（挙動不変）。config.rs の `save_to_dir(dir)` ←
  `save()` という「解決済み dir を受け取る内側関数 + config_dir を解決する外側
  関数」の非対称委譲パターンをそのまま踏襲した。
- **history.rs**: `HistoryStore::load_in(dir)` / `save_in(top_n, dir)` を追加。
  `load()` / `save()` はそれぞれ `Config::config_dir()` を解決してから委譲する。
  `load()` と `load_in()` はバージョン別マイグレーション適用ロジックを
  `from_loaded()` に共有し、二重実装を避けた。`save()` は config_dir 不在時でも
  従来どおり prune のみ実行する（挙動不変）。テストの `bin_file_in`（private
  フィールド直書きハック）は `HistoryStore::bin_file_in` 経由（新 API）に置き換えた。
- **window_data.rs**: 私有関数 `load_state_v5_in(dir)` / `save_state_in(state, dir)`
  を追加。公開 API（`load_search_placement` 等）と `load_state_v5()` /
  `save_state()` は config_dir を解決してから委譲する。V4→V5 の移行ロジック
  （絶対座標の破棄 + V5 としての再保存）自体は変更していない。
- **indexer.rs**: 私有関数 `save_cache_sorted_in(dir, entries, hash)` /
  `load_cache_in(dir, hash)` を追加。`save_cache_sorted()` / `load_cache()` は
  config_dir を解決してから委譲する。`INDEX_WRITE_LOCK` の契約（呼び出し側が
  ロックを保持する）は変更なし。
- `tempfile` クレートは追加していない（新規依存なし）。既存の
  `std::env::temp_dir() + ユニーク名 + 後始末`（indexer.rs/history.rs の既存
  `temp_dir()` ヘルパー）パターンをそのまま踏襲した。

## 追加/更新テスト

- `binfmt::tests::binfile_new_in_joins_dir_and_filename` — `new_in` が
  `dir.join(filename)` で path を組み立て、magic/version をそのまま保持すること。
- `history::tests::save_in_load_in_roundtrip_preserves_data` — `save_in` →
  `load_in` の実ファイル往復で global/query/folder_expansion の各カウントが
  保持されること。
- `history::tests::save_in_prunes_before_persisting_and_load_in_reflects_pruned_data`
  — `save_in` の prune がインメモリだけでなくディスク上のデータにも反映される
  こと（top_n=2 で低カウント entry がディスクからも消えること）。
- `window_data::tests::save_state_in_then_load_state_v5_in_roundtrip` —
  `save_state_in` → `load_state_v5_in` の V5 通常経路の往復保持。
- `window_data::tests::load_state_v5_in_migrates_v4_discarding_search_and_persists_as_v5`
  （**本 issue の中核**）— 一時ディレクトリに V4 フォーマットの実バイト列（postcard +
  ヘッダ `WNDW`/v4）を書き込み、V5 ロード経路（`load_state_v5_in`）で読み、
  (a) 絶対座標だった `search` が破棄され `None` になること、(b) `settings` /
  `settings_size` は引き継がれること、(c) `save_state` の副作用でディスク上の
  ファイルが V5 として再保存され、もはや V4 として読めなくなること、を検証した。
  **既存実装のまま Green（characterization test）— 実装バグは見つからなかった。**
- `indexer::tests::save_cache_sorted_in_then_load_cache_in_roundtrip` —
  `save_cache_sorted_in` → `load_cache_in` の実ファイル往復で entries と
  v4 キャッシュのマスク（`normalized_keys` 等）が復元されること、`config_hash` が
  異なると stale 扱いで `None` になること。

## 検証結果

- [x] `cargo check -p snotra-core -p snotra -p snotra-settings` — green
- [x] `cargo clippy -p snotra-core -p snotra -p snotra-settings --all-targets -- -D warnings` — warning なし
- [x] `cargo test -p snotra-core` — 461 passed; 0 failed; 9 ignored

## スコープ外（#437 へ）

- `try_*`（Result 化）への移行・deprecated 削除
- `binfmt.rs` の `#[must_use]` / eprintln（#428 で実装済み、本 PR では変更なし）

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)
