### PR TITLE
chore(core): deprecated 移行の完了と重複ヘルパーの集約

### DIFF
--- a/snotra-core/CLAUDE.md
+++ b/snotra-core/CLAUDE.md
@@ -60,6 +60,12 @@
 
 `query::char_bitmask()` が唯一の定義（bits 0-25 = a-z, bits 26-35 = 0-9）。`search.rs` と `indexer.rs` の両方がこの関数を import して使用する。ロジックを変更する場合は `query.rs` の1箇所のみ修正すればよい。
 
+**エントリ単位のマスク導出・file_name 導出も `query.rs` に集約済み**（issue #437）: 「ascii なら `char_bitmask`、非 ascii なら `u64::MAX`」は `query::name_char_mask()`、file_name 側の `None→0` を含む版は `query::file_char_mask()`、`target_path` から小文字 file_name を導出する処理は `query::lower_file_name()` に一元化。`search.rs`（Wave 2 / Wave 1）と `indexer.rs`（`save_cache_sorted_in` / `extend_cached_masks`）が共有する。検索ホットパスのため3関数とも `#[inline]`。
+
+### hidden/system 判定は `indexer::is_hidden_or_system` に一元化済み
+
+`indexer.rs` の `is_hidden_or_system(meta) -> bool`（true = hidden または system）が唯一の定義。`folder.rs::read_dir_entries` はこれを import して使う（旧 `folder.rs::is_hidden_or_system` は逆極性の別定義だったため削除・統合済み、issue #437）。
+
 ### `query.rs` の正規化と `Cow<str>` 遅延アロケーション
 
 `normalize_query()` は `Cow<str>` を返す。ASCII 小文字のみのクエリでは借用（ゼロアロケーション）、大文字・アクセント・連続空白がある場合のみ所有に切り替わる。正規化ロジックを変更するとき、この2パスの一貫性（チェック条件とビルド条件が同じ入力に対して同じ結果を生む）を壊さない。

--- a/snotra-core/src/binfmt.rs
+++ b/snotra-core/src/binfmt.rs
@@ -37,10 +37,9 @@ impl BinFile {
     }
 
     /// Load data from the file using the current version (postcard format).
-    #[allow(deprecated)]
     pub fn load<T: DeserializeOwned>(&self) -> Option<T> {
         let bytes = fs::read(&self.path).ok()?;
-        deserialize_with_header(&bytes, self.magic, self.version)
+        try_deserialize_with_header(&bytes, self.magic, self.version).ok()
     }
 
     /// Read raw file bytes. Useful when the caller needs custom deserialization
@@ -55,7 +54,6 @@ impl BinFile {
     ///
     /// Returns `Some((data, version))` where `version` is the version that
     /// succeeded, so the caller can apply version-specific migrations.
-    #[allow(deprecated)]
     pub fn load_with_fallback<T: DeserializeOwned>(
         &self,
         fallbacks: &[u32],
@@ -63,13 +61,13 @@ impl BinFile {
         let bytes = fs::read(&self.path).ok()?;
 
         // Try current version (always postcard)
-        if let Some(data) = deserialize_with_header(&bytes, self.magic, self.version) {
+        if let Ok(data) = try_deserialize_with_header(&bytes, self.magic, self.version) {
             return Some((data, self.version));
         }
 
         // Try each fallback
         for &ver in fallbacks {
-            if let Some(data) = deserialize_with_header(&bytes, self.magic, ver) {
+            if let Ok(data) = try_deserialize_with_header(&bytes, self.magic, ver) {
                 return Some((data, ver));
             }
         }
@@ -80,13 +78,12 @@ impl BinFile {
     /// Atomically save data: write to `.tmp`, remove old file, rename `.tmp`.
     /// Returns `true` on success. `#[must_use]`: callers must check for failure and
     /// surface it (log/eprintln) rather than silently discard it (issue #428).
-    #[allow(deprecated)]
     #[must_use]
     pub fn save<T: Serialize>(&self, data: &T) -> bool {
         if let Some(dir) = self.path.parent() {
             let _ = fs::create_dir_all(dir);
         }
-        let Some(bytes) = serialize_with_header(self.magic, self.version, data) else {
+        let Ok(bytes) = try_serialize_with_header(self.magic, self.version, data) else {
             return false;
         };
         let tmp = self.path.with_extension("bin.tmp");
@@ -108,16 +105,7 @@ impl BinFile {
     }
 }
 
-#[deprecated(note = "use try_serialize_with_header for Result-based error handling")]
-pub fn serialize_with_header<T: Serialize>(
-    magic: [u8; 4],
-    version: u32,
-    payload: &T,
-) -> Option<Vec<u8>> {
-    try_serialize_with_header(magic, version, payload).ok()
-}
-
-/// Result-based serialization (preferred over Option-based `serialize_with_header`).
+/// Result-based serialization.
 pub fn try_serialize_with_header<T: Serialize>(
     magic: [u8; 4],
     version: u32,
@@ -132,27 +120,7 @@ pub fn try_serialize_with_header<T: Serialize>(
     postcard::to_extend(payload, buf).map_err(|_| BinError::SerializeFailed)
 }
 
-#[deprecated(note = "use try_deserialize_with_header for Result-based error handling")]
-pub fn deserialize_with_header<T: DeserializeOwned>(
-    bytes: &[u8],
-    magic: [u8; 4],
-    version: u32,
-) -> Option<T> {
-    if bytes.len() < HEADER_LEN {
-        return None;
-    }
-    if bytes[0..4] != magic {
-        return None;
-    }
-    let mut ver = [0u8; 4];
-    ver.copy_from_slice(&bytes[4..8]);
-    if u32::from_le_bytes(ver) != version {
-        return None;
-    }
-    postcard::from_bytes(&bytes[HEADER_LEN..]).ok()
-}
-
-/// Result-based deserialization (preferred over Option-based `deserialize_with_header`).
+/// Result-based deserialization.
 pub fn try_deserialize_with_header<T: DeserializeOwned>(
     bytes: &[u8],
     magic: [u8; 4],
@@ -179,7 +147,6 @@ pub fn try_deserialize_with_header<T: DeserializeOwned>(
 }
 
 #[cfg(test)]
-#[allow(deprecated)]
 mod tests {
     use super::*;
     use serde::{Deserialize, Serialize};
@@ -189,31 +156,10 @@ mod tests {
         value: u32,
     }
 
-    #[test]
-    fn roundtrip_with_header() {
-        let input = Dummy { value: 42 };
-        let bytes = serialize_with_header(*b"TEST", 1, &input).expect("serialize");
-        let output: Dummy = deserialize_with_header(&bytes, *b"TEST", 1).expect("deserialize");
-        assert_eq!(input, output);
-    }
-
-    #[test]
-    fn deserialize_fails_on_magic_mismatch() {
-        let input = Dummy { value: 1 };
-        let bytes = serialize_with_header(*b"GOOD", 1, &input).expect("serialize");
-        let output: Option<Dummy> = deserialize_with_header(&bytes, *b"BAD!", 1);
-        assert!(output.is_none());
-    }
-
-    #[test]
-    fn deserialize_fails_on_version_mismatch() {
-        let input = Dummy { value: 1 };
-        let bytes = serialize_with_header(*b"TEST", 1, &input).expect("serialize");
-        let output: Option<Dummy> = deserialize_with_header(&bytes, *b"TEST", 2);
-        assert!(output.is_none());
-    }
-
     // --- BinFile tests ---
+    // NOTE: header roundtrip / magic mismatch / version mismatch coverage lives in
+    // the `try_roundtrip_with_header` / `try_deserialize_magic_mismatch` /
+    // `try_deserialize_version_mismatch` tests below (Result-based API).
 
     fn temp_dir(tag: &str) -> std::path::PathBuf {
         let dir = std::env::temp_dir().join(format!("snotra_binfmt_test_{}", tag));
@@ -335,7 +281,7 @@ mod tests {
         let dir = temp_dir("binfile_fb_postcard");
         // Write a v2 postcard file
         let path = dir.join("data.bin");
-        let bytes = serialize_with_header(*b"TEST", 2, &Dummy { value: 55 }).unwrap();
+        let bytes = try_serialize_with_header(*b"TEST", 2, &Dummy { value: 55 }).unwrap();
         std::fs::write(&path, &bytes).unwrap();
 
         // Create a BinFile expecting v3 as current
@@ -353,7 +299,7 @@ mod tests {
         let dir = temp_dir("binfile_fb_nomatch");
         // Write a file with a different magic
         let path = dir.join("data.bin");
-        let bytes = serialize_with_header(*b"NOPE", 1, &Dummy { value: 1 }).unwrap();
+        let bytes = try_serialize_with_header(*b"NOPE", 1, &Dummy { value: 1 }).unwrap();
         std::fs::write(&path, &bytes).unwrap();
 
         let bf = bin_file_in(&dir, *b"TEST", 3, "data.bin");
@@ -374,7 +320,7 @@ mod tests {
         let raw = bf.load_bytes().expect("load_bytes");
         // Verify the raw bytes can be deserialized manually
         let output: Dummy =
-            deserialize_with_header(&raw, *b"TEST", 1).expect("manual deserialize");
+            try_deserialize_with_header(&raw, *b"TEST", 1).expect("manual deserialize");
         assert_eq!(input, output);
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/snotra-core/src/config.rs
+++ b/snotra-core/src/config.rs
@@ -404,18 +404,6 @@ impl SearchConfig {
     pub fn effective_recent_limit(&self) -> usize {
         self.recent_limit.unwrap_or_else(default_recent_limit)
     }
-
-    #[deprecated(note = "use Config::validate() to detect issues instead")]
-    pub fn sanitize(&mut self) -> bool {
-        if self.fuzzy_history_cap_ratio.is_finite()
-            && (0.0..=1.0).contains(&self.fuzzy_history_cap_ratio)
-        {
-            return false;
-        }
-
-        self.fuzzy_history_cap_ratio = default_fuzzy_history_cap_ratio();
-        true
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -944,8 +932,12 @@ impl Config {
         let _ = self.appearance.visible_rows.get_or_insert_with(default_visible_rows);
         let _ = self.search.result_limit.get_or_insert_with(default_result_limit);
         let _ = self.search.recent_limit.get_or_insert_with(default_recent_limit);
-        #[allow(deprecated)]
-        if self.search.sanitize() {
+        // fuzzy_history_cap_ratio が不正（非有限 or [0.0, 1.0] 範囲外）なら既定値へ補正する。
+        // `Config::validate()` は同条件で問題を検出するが補正はしない（検出=validate / 補正=migration
+        // の責務分離。旧 `SearchConfig::sanitize()` の直接処理をここへ移設、issue #437）。
+        let ratio = self.search.fuzzy_history_cap_ratio;
+        if !ratio.is_finite() || !(0.0..=1.0).contains(&ratio) {
+            self.search.fuzzy_history_cap_ratio = default_fuzzy_history_cap_ratio();
             changed = true;
         }
         if self.paths.normalize_scan_paths() {
@@ -1987,20 +1979,52 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated)]
-    fn sanitize_invalid_fuzzy_history_cap_ratio() {
-        let mut config = SearchConfig {
-            normal_mode: SearchModeConfig::Fuzzy,
-            folder_mode: SearchModeConfig::Fuzzy,
-            show_hidden_system: false,
-            history_normalization: SearchHistoryNormalizationConfig::FuzzyRelativeCap,
-            fuzzy_history_cap_ratio: 1.5,
-            instant_command_prefix: "@".to_string(),
-            ..SearchConfig::default()
-        };
+    fn apply_migrations_sanitizes_invalid_fuzzy_history_cap_ratio() {
+        // 旧 `SearchConfig::sanitize()` の直接処理を `apply_migrations()` へ移設した
+        // 補正ロジックを検証する（issue #437）。範囲外（> 1.0）の値は既定値へ補正される。
+        let toml_str = r#"
+            [hotkey]
+            modifier = "Alt"
+            key = "Q"
 
-        assert!(config.sanitize());
-        assert!((config.fuzzy_history_cap_ratio - 0.30).abs() < f64::EPSILON);
+            [appearance]
+            window_width = 600
+
+            [search]
+            fuzzy_history_cap_ratio = 1.5
+
+            [paths]
+            additional = []
+        "#;
+        let mut config: Config = toml::from_str(toml_str).expect("parse");
+        assert!(config.apply_migrations());
+        assert!((config.search.fuzzy_history_cap_ratio - 0.30).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn apply_migrations_leaves_valid_fuzzy_history_cap_ratio_unchanged() {
+        // 有効範囲内の値は補正されず、apply_migrations() の changed フラグにも寄与しない
+        // （他の移行項目が無い最小 TOML では false を返す）ことを確認する。
+        let toml_str = r#"
+            [hotkey]
+            modifier = "Alt"
+            key = "Q"
+
+            [appearance]
+            window_width = 600
+            visible_rows = 10
+
+            [search]
+            fuzzy_history_cap_ratio = 0.5
+            result_limit = 200
+            recent_limit = 10
+
+            [paths]
+            additional = []
+        "#;
+        let mut config: Config = toml::from_str(toml_str).expect("parse");
+        assert!(!config.apply_migrations());
+        assert!((config.search.fuzzy_history_cap_ratio - 0.5).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/snotra-core/src/error.rs
+++ b/snotra-core/src/error.rs
@@ -13,7 +13,6 @@ pub enum BinError {
     },
     DeserializeFailed,
     SerializeFailed,
-    IoError(std::io::Error),
     BufferTooShort,
 }
 
@@ -37,26 +36,12 @@ impl fmt::Display for BinError {
             }
             Self::DeserializeFailed => write!(f, "deserialization failed"),
             Self::SerializeFailed => write!(f, "serialization failed"),
-            Self::IoError(e) => write!(f, "I/O error: {}", e),
             Self::BufferTooShort => write!(f, "buffer too short for header"),
         }
     }
 }
 
-impl std::error::Error for BinError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::IoError(e) => Some(e),
-            _ => None,
-        }
-    }
-}
-
-impl From<std::io::Error> for BinError {
-    fn from(e: std::io::Error) -> Self {
-        Self::IoError(e)
-    }
-}
+impl std::error::Error for BinError {}
 
 /// Errors from config validation.
 #[derive(Debug, Clone, PartialEq)]
@@ -116,31 +101,13 @@ mod tests {
     }
 
     #[test]
-    fn bin_error_display_io_error() {
-        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
-        let err = BinError::IoError(io_err);
-        let msg = format!("{}", err);
-        assert!(msg.contains("I/O error"));
-        assert!(msg.contains("file not found"));
-    }
-
-    #[test]
     fn bin_error_display_buffer_too_short() {
         let err = BinError::BufferTooShort;
         assert_eq!(format!("{}", err), "buffer too short for header");
     }
 
     #[test]
-    fn bin_error_source_io_error() {
-        use std::error::Error;
-        let io_err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "access denied");
-        let err = BinError::IoError(io_err);
-        let source = err.source().expect("IoError should have a source");
-        assert!(source.to_string().contains("access denied"));
-    }
-
-    #[test]
-    fn bin_error_source_non_io_variants_return_none() {
+    fn bin_error_source_all_variants_return_none() {
         use std::error::Error;
         let variants: Vec<BinError> = vec![
             BinError::MagicMismatch {
@@ -162,12 +129,5 @@ mod tests {
                 variant
             );
         }
-    }
-
-    #[test]
-    fn bin_error_from_io_error() {
-        let io_err = std::io::Error::new(std::io::ErrorKind::BrokenPipe, "broken");
-        let bin_err: BinError = io_err.into();
-        assert!(matches!(bin_err, BinError::IoError(_)));
     }
 }

--- a/snotra-core/src/folder.rs
+++ b/snotra-core/src/folder.rs
@@ -1,9 +1,8 @@
 use nucleo_matcher::{Config as MatcherConfig, Matcher, Utf32Str};
-use std::os::windows::fs::MetadataExt;
 use std::path::Path;
-use windows::Win32::Storage::FileSystem::{FILE_ATTRIBUTE_HIDDEN, FILE_ATTRIBUTE_SYSTEM};
 
 use crate::history::HistoryStore;
+use crate::indexer::is_hidden_or_system;
 use crate::query::to_lower_folded;
 use crate::search::SearchMode;
 use crate::ui_types::SearchResult;
@@ -181,13 +180,6 @@ fn matches_filter(name: &str, filter_lower: &str, mode: SearchMode, matcher: &mu
             matcher.fuzzy_match(haystack, needle).is_some()
         }
     }
-}
-
-fn is_hidden_or_system(meta: &std::fs::Metadata) -> bool {
-    let attrs = meta.file_attributes();
-    let hidden = (attrs & FILE_ATTRIBUTE_HIDDEN.0) != 0;
-    let system = (attrs & FILE_ATTRIBUTE_SYSTEM.0) != 0;
-    hidden || system
 }
 
 #[cfg(test)]

--- a/snotra-core/src/history.rs
+++ b/snotra-core/src/history.rs
@@ -295,10 +295,9 @@ fn migrate_normalize_keys(data: HistoryData) -> HistoryData {
 }
 
 #[cfg(test)]
-#[allow(deprecated)]
 mod tests {
     use super::*;
-    use crate::binfmt::{deserialize_with_header, serialize_with_header};
+    use crate::binfmt::{try_deserialize_with_header, try_serialize_with_header};
     use crate::query::normalize_query;
 
     fn temp_dir(tag: &str) -> std::path::PathBuf {
@@ -508,7 +507,7 @@ mod tests {
                 last_launched: 1_700_000_000,
             },
         );
-        let bytes = serialize_with_header(HISTORY_MAGIC, HISTORY_VERSION_POSTCARD_V2, &data)
+        let bytes = try_serialize_with_header(HISTORY_MAGIC, HISTORY_VERSION_POSTCARD_V2, &data)
             .expect("serialize v2 postcard");
         let bf = HistoryStore::bin_file_in(&dir);
         std::fs::write(bf.path(), &bytes).unwrap();
@@ -566,9 +565,9 @@ mod tests {
         data.folder_expansion.insert("C:\\Projects".to_string(), 2);
 
         let bytes =
-            serialize_with_header(HISTORY_MAGIC, HISTORY_VERSION, &data).expect("serialize");
-        let roundtripped: HistoryData =
-            deserialize_with_header(&bytes, HISTORY_MAGIC, HISTORY_VERSION).expect("deserialize");
+            try_serialize_with_header(HISTORY_MAGIC, HISTORY_VERSION, &data).expect("serialize");
+        let roundtripped: HistoryData = try_deserialize_with_header(&bytes, HISTORY_MAGIC, HISTORY_VERSION)
+            .expect("deserialize");
 
         assert_eq!(roundtripped.global["C:\\app.lnk"].launch_count, 5);
         assert_eq!(roundtripped.query["notepad"]["C:\\app.lnk"], 3);

--- a/snotra-core/src/indexer.rs
+++ b/snotra-core/src/indexer.rs
@@ -15,7 +15,7 @@ use windows::Win32::System::Threading::{
 
 use crate::binfmt::{BinFile, try_deserialize_with_header};
 use crate::config::{Config, ScanPath};
-use crate::query::{char_bitmask, to_lower_folded};
+use crate::query::{file_char_mask, lower_file_name, name_char_mask, to_lower_folded};
 
 const INDEX_MAGIC: [u8; 4] = *b"INDX";
 const INDEX_CACHE_VERSION: u32 = 4;
@@ -81,7 +81,7 @@ fn scan_directory_with_extensions(
             continue;
         };
 
-        if !show_hidden_system && !is_visible_metadata(&meta) {
+        if !show_hidden_system && is_hidden_or_system(&meta) {
             continue;
         }
 
@@ -135,11 +135,14 @@ fn scan_directory_with_extensions(
     }
 }
 
-fn is_visible_metadata(meta: &Metadata) -> bool {
+/// エントリが hidden または system 属性を持つか判定する。
+/// `folder.rs` の同名判定と逆極性の2重定義があったため、単一定義に統一（issue #437）。
+/// `folder.rs::read_dir_entries` はこの関数をそのまま import して使う。
+pub(crate) fn is_hidden_or_system(meta: &Metadata) -> bool {
     let attrs = meta.file_attributes();
     let hidden = (attrs & FILE_ATTRIBUTE_HIDDEN.0) != 0;
     let system = (attrs & FILE_ATTRIBUTE_SYSTEM.0) != 0;
-    !hidden && !system
+    hidden || system
 }
 
 pub fn normalize_entry_key(path: &str) -> String {
@@ -406,23 +409,12 @@ fn save_cache_sorted_in(dir: &Path, entries: &[AppEntry], config_hash: u64) {
     let lower_names: Vec<String> = entries.iter().map(|e| to_lower_folded(&e.name)).collect();
     let lower_file_names: Vec<Option<String>> = entries
         .iter()
-        .map(|e| {
-            std::path::Path::new(&e.target_path)
-                .file_name()
-                .and_then(|f| f.to_str())
-                .map(to_lower_folded)
-        })
+        .map(|e| lower_file_name(&e.target_path))
         .collect();
-    let char_masks: Vec<u64> = lower_names
-        .iter()
-        .map(|n| if n.is_ascii() { char_bitmask(n) } else { u64::MAX })
-        .collect();
+    let char_masks: Vec<u64> = lower_names.iter().map(|n| name_char_mask(n)).collect();
     let file_name_char_masks: Vec<u64> = lower_file_names
         .iter()
-        .map(|n| {
-            n.as_deref()
-                .map_or(0, |s| if s.is_ascii() { char_bitmask(s) } else { u64::MAX })
-        })
+        .map(|n| file_char_mask(n.as_deref()))
         .collect();
     // A-3: normalized_keys もキャッシュに含める。起動時の Wave 1 計算を完全スキップするため。
     let normalized_keys: Vec<String> =
@@ -761,7 +753,7 @@ fn scan_path_dirs(
             let Ok(meta) = entry.metadata() else {
                 continue;
             };
-            if !show_hidden_system && !is_visible_metadata(&meta) {
+            if !show_hidden_system && is_hidden_or_system(&meta) {
                 continue;
             }
             let ext = path
@@ -820,23 +812,10 @@ pub fn scan_path_env(existing_entries: &[AppEntry], show_hidden_system: bool) ->
 pub fn extend_cached_masks(masks: &mut CachedMasks, new_entries: &[AppEntry]) {
     for entry in new_entries {
         let lower = to_lower_folded(&entry.name);
-        let lower_file = std::path::Path::new(&entry.target_path)
-            .file_name()
-            .and_then(|f| f.to_str())
-            .map(to_lower_folded);
+        let lower_file = lower_file_name(&entry.target_path);
 
-        let mask = if lower.is_ascii() {
-            char_bitmask(&lower)
-        } else {
-            u64::MAX
-        };
-        let file_mask = lower_file.as_deref().map_or(0, |s| {
-            if s.is_ascii() {
-                char_bitmask(s)
-            } else {
-                u64::MAX
-            }
-        });
+        let mask = name_char_mask(&lower);
+        let file_mask = file_char_mask(lower_file.as_deref());
 
         masks.char_masks.push(mask);
         masks.file_name_char_masks.push(file_mask);
@@ -854,10 +833,9 @@ pub fn extend_cached_masks(masks: &mut CachedMasks, new_entries: &[AppEntry]) {
 }
 
 #[cfg(test)]
-#[allow(deprecated)]
 mod tests {
     use super::*;
-    use crate::binfmt::{deserialize_with_header, serialize_with_header, try_deserialize_with_header};
+    use crate::binfmt::{try_deserialize_with_header, try_serialize_with_header};
     use std::fs;
 
     /// `INDEX_WRITE_LOCK` に触れるテストを直列化するガード。
@@ -1000,10 +978,10 @@ mod tests {
             ],
         };
 
-        let bytes =
-            serialize_with_header(INDEX_MAGIC, INDEX_CACHE_VERSION, &cache).expect("serialize");
+        let bytes = try_serialize_with_header(INDEX_MAGIC, INDEX_CACHE_VERSION, &cache)
+            .expect("serialize");
         let restored: IndexCache =
-            deserialize_with_header(&bytes, INDEX_MAGIC, INDEX_CACHE_VERSION).expect("deserialize");
+            try_deserialize_with_header(&bytes, INDEX_MAGIC, INDEX_CACHE_VERSION).expect("deserialize");
 
         assert_eq!(restored.built_at, 1700000000);
         assert_eq!(restored.entries.len(), 2);
@@ -1072,9 +1050,9 @@ mod tests {
         };
 
         let owned_bytes =
-            serialize_with_header(INDEX_MAGIC, INDEX_CACHE_VERSION, &owned).expect("owned");
+            try_serialize_with_header(INDEX_MAGIC, INDEX_CACHE_VERSION, &owned).expect("owned");
         let ref_bytes =
-            serialize_with_header(INDEX_MAGIC, INDEX_CACHE_VERSION, &borrowed).expect("borrowed");
+            try_serialize_with_header(INDEX_MAGIC, INDEX_CACHE_VERSION, &borrowed).expect("borrowed");
         assert_eq!(
             owned_bytes, ref_bytes,
             "IndexCacheRef must serialize byte-identically to owned IndexCache"
@@ -1082,7 +1060,7 @@ mod tests {
 
         // 借用版で書いたバイト列を所有版として読み戻せること（read 経路の不変性）も確認する。
         let restored: IndexCache =
-            deserialize_with_header(&ref_bytes, INDEX_MAGIC, INDEX_CACHE_VERSION)
+            try_deserialize_with_header(&ref_bytes, INDEX_MAGIC, INDEX_CACHE_VERSION)
                 .expect("roundtrip");
         assert_eq!(restored.entries.len(), 2);
         assert_eq!(restored.normalized_keys, normalized_keys);
@@ -1145,11 +1123,11 @@ mod tests {
             config_hash,
         };
         let bytes =
-            serialize_with_header(INDEX_MAGIC, 2, &cache_v2).expect("serialize v2");
+            try_serialize_with_header(INDEX_MAGIC, 2, &cache_v2).expect("serialize v2");
 
         // try_deserialize_with_header で v2 として読める
         let restored: IndexCacheV2 =
-            deserialize_with_header(&bytes, INDEX_MAGIC, 2).expect("deserialize v2");
+            try_deserialize_with_header(&bytes, INDEX_MAGIC, 2).expect("deserialize v2");
         assert_eq!(restored.entries[0].name, "Firefox");
         assert_eq!(restored.config_hash, config_hash);
 
@@ -1176,10 +1154,10 @@ mod tests {
             char_masks: vec![0xAB],
             file_name_char_masks: vec![0xCD],
         };
-        let bytes = serialize_with_header(INDEX_MAGIC, 3, &cache_v3).expect("serialize v3");
+        let bytes = try_serialize_with_header(INDEX_MAGIC, 3, &cache_v3).expect("serialize v3");
 
         let restored: IndexCacheV3 =
-            deserialize_with_header(&bytes, INDEX_MAGIC, 3).expect("deserialize v3");
+            try_deserialize_with_header(&bytes, INDEX_MAGIC, 3).expect("deserialize v3");
         assert_eq!(restored.char_masks, vec![0xAB]);
 
         // v4 として読もうとすると失敗する（lower_names フィールドがない）

--- a/snotra-core/src/query.rs
+++ b/snotra-core/src/query.rs
@@ -48,6 +48,43 @@ pub fn char_bitmask(lower: &str) -> u64 {
     mask
 }
 
+/// Character-presence bitmask for a single lowercase entry name (or file name).
+/// ASCII strings get the bit-exact mask from [`char_bitmask`]; non-ASCII strings
+/// (typically CJK, Arabic, etc. — `to_lower_folded` already folds Latin accents to
+/// ASCII) get `u64::MAX` so `(query_mask & u64::MAX) == query_mask` always holds and
+/// the entry is never excluded by the bitmask pre-filter.
+///
+/// Single definition shared by `search.rs` (Wave 2) and `indexer.rs` (cache build /
+/// incremental extend) — previously duplicated in 3 call sites (issue #437).
+#[inline]
+pub fn name_char_mask(lower: &str) -> u64 {
+    if lower.is_ascii() {
+        char_bitmask(lower)
+    } else {
+        u64::MAX
+    }
+}
+
+/// Character-presence bitmask for an optional lowercase file name. `None` (entry has no
+/// file_name component) yields `0` — such entries cannot match via the file_name path,
+/// so failing the bitmask pre-filter is correct. `Some` defers to [`name_char_mask`].
+#[inline]
+pub fn file_char_mask(lower_file_name: Option<&str>) -> u64 {
+    lower_file_name.map_or(0, name_char_mask)
+}
+
+/// Derive the lowercase, accent-folded file name from an entry's `target_path`, or
+/// `None` if the path has no file name component. Single definition shared by
+/// `search.rs` (Wave 1) and `indexer.rs` (cache build / incremental extend) —
+/// previously duplicated in 3 call sites (issue #437).
+#[inline]
+pub fn lower_file_name(target_path: &str) -> Option<String> {
+    std::path::Path::new(target_path)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .map(to_lower_folded)
+}
+
 pub fn normalize_query(query: &str) -> Cow<'_, str> {
     let trimmed = query.trim();
     if trimmed.is_empty() {

--- a/snotra-core/src/search.rs
+++ b/snotra-core/src/search.rs
@@ -8,7 +8,10 @@ use rayon::prelude::*;
 use crate::config::{SearchConfig, SearchHistoryNormalizationConfig};
 use crate::history::HistoryStore;
 use crate::indexer::{AppEntry, normalize_entry_key};
-use crate::query::{char_bitmask, normalize_history_query_key, normalize_query, to_kana, to_lower_folded};
+use crate::query::{
+    char_bitmask, file_char_mask, lower_file_name, name_char_mask, normalize_history_query_key,
+    normalize_query, to_kana, to_lower_folded,
+};
 use crate::ui_types::SearchResult;
 
 const GLOBAL_WEIGHT: i64 = 5;
@@ -162,12 +165,7 @@ fn compute_wave1(entries: &[AppEntry], migemo_enabled: bool) -> Wave1Strings {
                 || {
                     entries
                         .iter()
-                        .map(|e| {
-                            std::path::Path::new(&e.target_path)
-                                .file_name()
-                                .and_then(|f| f.to_str())
-                                .map(|s| to_lower_folded(s).into_boxed_str())
-                        })
+                        .map(|e| lower_file_name(&e.target_path).map(String::into_boxed_str))
                         .collect::<Vec<_>>()
                 },
             )
@@ -207,21 +205,13 @@ fn compute_wave2(
     lower_file_names: &[Option<Box<str>>],
 ) -> (Vec<u64>, Vec<u64>) {
     rayon::join(
-        || {
-            lower_names
-                .iter()
-                .map(|n| if n.is_ascii() { char_bitmask(n) } else { u64::MAX })
-                .collect::<Vec<_>>()
-        },
+        || lower_names.iter().map(|n| name_char_mask(n)).collect::<Vec<_>>(),
         || {
             // None → 0: entries without a file_name cannot match via the file_name path,
             // so failing the bitmask check (and being skipped when the name also fails) is correct.
             lower_file_names
                 .iter()
-                .map(|n| {
-                    n.as_deref()
-                        .map_or(0, |s| if s.is_ascii() { char_bitmask(s) } else { u64::MAX })
-                })
+                .map(|n| file_char_mask(n.as_deref()))
                 .collect::<Vec<_>>()
         },
     )

--- a/snotra-core/src/window_data.rs
+++ b/snotra-core/src/window_data.rs
@@ -92,10 +92,9 @@ fn save_state_in(state: &WindowPlacementState, dir: &Path) {
 }
 
 #[cfg(test)]
-#[allow(deprecated)]
 mod tests {
     use super::*;
-    use crate::binfmt::{deserialize_with_header, serialize_with_header};
+    use crate::binfmt::{try_deserialize_with_header, try_serialize_with_header};
 
     fn temp_dir(tag: &str) -> std::path::PathBuf {
         let dir = std::env::temp_dir().join(format!("snotra_window_test_{}", tag));
@@ -139,7 +138,7 @@ mod tests {
                 height: 600,
             }),
         };
-        let bytes = serialize_with_header(WINDOW_MAGIC, WINDOW_VERSION_V4, &v4_state)
+        let bytes = try_serialize_with_header(WINDOW_MAGIC, WINDOW_VERSION_V4, &v4_state)
             .expect("serialize v4");
         let path = dir.join("window.bin");
         std::fs::write(&path, &bytes).expect("write v4 window.bin");
@@ -157,12 +156,12 @@ mod tests {
         // ディスク上のファイルは V5 として再保存されている。
         let raw = std::fs::read(&path).expect("read persisted window.bin");
         let reloaded_v5: WindowPlacementState =
-            deserialize_with_header(&raw, WINDOW_MAGIC, WINDOW_VERSION_V5)
+            try_deserialize_with_header(&raw, WINDOW_MAGIC, WINDOW_VERSION_V5)
                 .expect("persisted file should now deserialize as V5");
         assert_eq!(reloaded_v5, migrated);
-        let as_v4: Option<WindowPlacementState> =
-            deserialize_with_header(&raw, WINDOW_MAGIC, WINDOW_VERSION_V4);
-        assert!(as_v4.is_none(), "persisted file should no longer be readable as V4");
+        let as_v4: Result<WindowPlacementState, _> =
+            try_deserialize_with_header(&raw, WINDOW_MAGIC, WINDOW_VERSION_V4);
+        assert!(as_v4.is_err(), "persisted file should no longer be readable as V4");
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -178,9 +177,9 @@ mod tests {
             }),
         };
         let bytes =
-            serialize_with_header(WINDOW_MAGIC, WINDOW_VERSION_V4, &state).expect("serialize");
+            try_serialize_with_header(WINDOW_MAGIC, WINDOW_VERSION_V4, &state).expect("serialize");
         let restored: WindowPlacementState =
-            deserialize_with_header(&bytes, WINDOW_MAGIC, WINDOW_VERSION_V4).expect("deserialize");
+            try_deserialize_with_header(&bytes, WINDOW_MAGIC, WINDOW_VERSION_V4).expect("deserialize");
         assert_eq!(state, restored);
     }
 
@@ -195,9 +194,9 @@ mod tests {
             }),
         };
         let bytes =
-            serialize_with_header(WINDOW_MAGIC, WINDOW_VERSION_V5, &state).expect("serialize");
+            try_serialize_with_header(WINDOW_MAGIC, WINDOW_VERSION_V5, &state).expect("serialize");
         let restored: WindowPlacementState =
-            deserialize_with_header(&bytes, WINDOW_MAGIC, WINDOW_VERSION_V5).expect("deserialize");
+            try_deserialize_with_header(&bytes, WINDOW_MAGIC, WINDOW_VERSION_V5).expect("deserialize");
         assert_eq!(state, restored);
     }
 
@@ -211,9 +210,9 @@ mod tests {
             settings_size: None,
         };
         let bytes =
-            serialize_with_header(WINDOW_MAGIC, WINDOW_VERSION_V4, &state).expect("serialize");
-        let result: Option<WindowPlacementState> =
-            deserialize_with_header(&bytes, WINDOW_MAGIC, WINDOW_VERSION_V5);
-        assert!(result.is_none(), "V4 data should not load as V5");
+            try_serialize_with_header(WINDOW_MAGIC, WINDOW_VERSION_V4, &state).expect("serialize");
+        let result: Result<WindowPlacementState, _> =
+            try_deserialize_with_header(&bytes, WINDOW_MAGIC, WINDOW_VERSION_V5);
+        assert!(result.is_err(), "V4 data should not load as V5");
     }
 }


### PR DESCRIPTION
## 背景

#437: snotra-core に `#[deprecated]` のまま主経路として実動作を担うコード（binfmt.rs の移行未完・config.rs の sanitize）と、同一ロジックの多重実装（マスク導出・lower_file_name 導出・hidden/system 判定）が残っていた。前提: #428（must_use + eprintln）・#429（BinFile::new_in / *_in 系 API）はマージ済み。

## A. binfmt.rs: deprecated 移行の完了

`BinFile::load` / `save` / `load_with_fallback` の内部実装を Result 版 `try_serialize_with_header` / `try_deserialize_with_header` ベースに切替え、`#[allow(deprecated)]` を除去。

`serialize_with_header` / `deserialize_with_header`（deprecated）の呼び出し元をシンボル単位で `git grep` 列挙:
- `binfmt.rs`: `BinFile::load` / `load_with_fallback` / `save`（本体）+ 自テストモジュール
- `history.rs` / `window_data.rs` / `indexer.rs`: いずれも `#[cfg(test)] mod tests` 配下（`#[allow(deprecated)]` 付き）

全て `try_*` へ移行してから deprecated 関数本体を削除。公開 API（`load`/`save`/`load_with_fallback` のシグネチャ・戻り値・挙動）は不変。

## B. config.rs: `SearchConfig::sanitize` の削除

`apply_migrations()` 内の `sanitize()` 呼び出しを、fuzzy_history_cap_ratio の範囲外補正を直接 inline したコードへ置き換えて削除。`Config::validate()` は問題を**検出**するのみで補正はしない（責務分離のため重複なし）。

## C. `BinError::IoError` の死蔵確認と削除

crate 全体（テスト含む）を `git grep` で確認した結果、生成経路（`?` 変換 / `.into()`）は error.rs 自身のテスト以外に存在せず、死蔵と判断して削除。cargo check/clippy を死蔵検出器として使用（残存参照があればビルドが落ちる）。

## D. 重複ヘルパーの集約

`query.rs` に以下を追加し、`search.rs` / `indexer.rs` の手書き重複（各3箇所）を機械的抽出で置換（ロジック無変更・`#[inline]`）:
- `name_char_mask(lower: &str) -> u64`（マスク導出の3重複を集約）
- `file_char_mask(Option<&str>) -> u64`（file_name 側マスク、None→0 含む）
- `lower_file_name(target_path: &str) -> Option<String>`（lower_file_name 導出の3重複を集約）

hidden/system 判定の逆極性2重定義（`indexer.rs::is_visible_metadata` / `folder.rs::is_hidden_or_system`）を `indexer::is_hidden_or_system`（true = hidden or system）に統一。`folder.rs` はこれを import し、ローカル定義と now-unused の `MetadataExt` / `FILE_ATTRIBUTE_*` import を削除。

## 見送り項目

なし。issue の A〜D 全項目を実施した。

## 追加/更新テスト

- 削除（deprecated API 直接テスト・重複カバレッジ）: `binfmt.rs::roundtrip_with_header` / `deserialize_fails_on_magic_mismatch` / `deserialize_fails_on_version_mismatch`（`try_*` 版で既にカバー）、`error.rs::bin_error_display_io_error` / `bin_error_source_io_error` / `bin_error_from_io_error`、`config.rs::sanitize_invalid_fuzzy_history_cap_ratio`
- 改名: `error.rs::bin_error_source_non_io_variants_return_none` → `bin_error_source_all_variants_return_none`（IoError 削除により全 variant が対象に）
- 追加: `config.rs::apply_migrations_sanitizes_invalid_fuzzy_history_cap_ratio`（範囲外値が migration 経由で既定値へ補正されることを検証）、`config.rs::apply_migrations_leaves_valid_fuzzy_history_cap_ratio_unchanged`（有効範囲内の値は不変・changed フラグも立たないことを検証）

## 検証結果

- `cargo check -p snotra-core -p snotra -p snotra-settings` green
- `cargo clippy -p snotra-core -p snotra -p snotra-settings --all-targets -- -D warnings` green
- `cargo test -p snotra-core` 456 passed / 0 failed / 9 ignored（config モジュールのみ 157 passed、既存156本+追加分）

Closes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)
