### PR TITLE
ci(release): リリース前 smoke ゲートの追加とバージョン注入のスクリプト化

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,21 +48,7 @@ jobs:
       - name: Set version from tag
         run: |
           $ver = "${{ env.TAG_NAME }}".TrimStart('v')
-
-          # Cargo.toml (workspace)
-          (Get-Content Cargo.toml -Raw -Encoding utf8) `
-            -replace '(?m)^version = "[^"]+"', "version = `"$ver`"" |
-            Set-Content Cargo.toml -Encoding utf8 -NoNewline
-
-          # package.json
-          $pkg = Get-Content package.json -Raw -Encoding utf8 | ConvertFrom-Json
-          $pkg.version = $ver
-          $pkg | ConvertTo-Json -Depth 10 | Set-Content package.json -Encoding utf8
-
-          # tauri.conf.json
-          $conf = Get-Content src-tauri/tauri.conf.json -Raw -Encoding utf8 | ConvertFrom-Json
-          $conf.version = $ver
-          $conf | ConvertTo-Json -Depth 10 | Set-Content src-tauri/tauri.conf.json -Encoding utf8
+          ./scripts/inject-version.ps1 -Version $ver
 
       - name: Build snotra-settings (release)
         run: cargo build --release -p snotra-settings
@@ -90,6 +76,13 @@ jobs:
           $nsis = Get-Item "target/release/bundle/nsis/Snotra_*_x64-setup.exe" -ErrorAction SilentlyContinue
           if (!$nsis) { Write-Error "NSIS installer not found"; exit 1 }
           if (!(Test-Path "$($nsis.FullName).sig")) { Write-Error "NSIS .sig not found"; exit 1 }
+
+      # 成果物の存在検証だけでは実際の起動可否は保証されない。e2e.yml (L53-54) が
+      # release バイナリに対して行っている起動スモークと同じスクリプトを、ビルド済み
+      # exe（NSIS インストーラーではなく target/release/snotra.exe）に対して実行し、
+      # アップロード前に起動失敗を検知するゲートとする。
+      - name: Run startup smoke on release binary
+        run: pwsh -NoProfile -File scripts/smoke-startup.ps1 -ExePath target/release/snotra.exe
 
       - name: Package as ZIP (portable)
         run: |

--- a/scripts/inject-version.ps1
+++ b/scripts/inject-version.ps1
@@ -1,0 +1,108 @@
+<#
+.SYNOPSIS
+  リリースタグから抽出したバージョンを Cargo.toml / package.json / src-tauri/tauri.conf.json
+  の 3 ファイルへ注入する。
+
+.DESCRIPTION
+  .github/workflows/release.yml の "Set version from tag" ステップに埋め込まれていた
+  インライン PowerShell を切り出したスクリプト。3 ファイルへの書き換え方式は元のインライン
+  処理と同一（Cargo.toml は正規表現置換、package.json / tauri.conf.json は
+  ConvertFrom-Json → プロパティ代入 → ConvertTo-Json）。
+
+  Cargo.lock は対象外（元のインライン処理と同じ。workspace.package.version を
+  参照する Cargo.lock 内エントリの追従は cargo 側の責務とし、このスクリプトは
+  バージョン文字列が定義された 3 ファイルのみを扱う）。
+
+.PARAMETER Version
+  設定する semver 文字列（例: "0.12.0", "0.12.0-alpha7"）。先頭の "v" は含めない。
+
+.PARAMETER RepoRoot
+  リポジトリルートのパス。省略時はカレントディレクトリ。
+
+.PARAMETER WhatIf
+  実際には書き換えず、対象ファイルと設定予定のバージョンを表示して終了する。
+
+.EXAMPLE
+  pwsh -File scripts/inject-version.ps1 -Version 0.12.0-alpha7
+
+.EXAMPLE
+  pwsh -File scripts/inject-version.ps1 -Version 0.12.0 -WhatIf
+#>
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$Version,
+
+  [string]$RepoRoot = (Get-Location).Path,
+
+  [switch]$WhatIf
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if ($Version -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$') {
+  throw "Invalid version format: $Version"
+}
+
+$cargoTomlPath   = Join-Path $RepoRoot "Cargo.toml"
+$packageJsonPath = Join-Path $RepoRoot "package.json"
+$tauriConfPath   = Join-Path $RepoRoot "src-tauri/tauri.conf.json"
+
+foreach ($p in @($cargoTomlPath, $packageJsonPath, $tauriConfPath)) {
+  if (-not (Test-Path $p)) {
+    throw "File not found: $p"
+  }
+}
+
+if ($WhatIf) {
+  Write-Host "[WhatIf] Would set version to '$Version' in:"
+  Write-Host "  - $cargoTomlPath"
+  Write-Host "  - $packageJsonPath"
+  Write-Host "  - $tauriConfPath"
+  Write-Host "[WhatIf] Cargo.lock is intentionally left untouched (matches current release.yml behavior)."
+  exit 0
+}
+
+# Cargo.toml (workspace) — [workspace.package] version 行を正規表現置換
+$cargoContent = Get-Content $cargoTomlPath -Raw -Encoding utf8
+$newCargoContent = $cargoContent -replace '(?m)^version = "[^"]+"', "version = `"$Version`""
+Set-Content $cargoTomlPath -Value $newCargoContent -Encoding utf8 -NoNewline
+
+# package.json
+$pkg = Get-Content $packageJsonPath -Raw -Encoding utf8 | ConvertFrom-Json
+$pkg.version = $Version
+$pkg | ConvertTo-Json -Depth 10 | Set-Content $packageJsonPath -Encoding utf8
+
+# tauri.conf.json
+$conf = Get-Content $tauriConfPath -Raw -Encoding utf8 | ConvertFrom-Json
+$conf.version = $Version
+$conf | ConvertTo-Json -Depth 10 | Set-Content $tauriConfPath -Encoding utf8
+
+# 書き換え後の検証: 3ファイルから読み戻して Version と一致するか確認する
+$verifyErrors = @()
+
+$cargoCheck = Get-Content $cargoTomlPath -Raw -Encoding utf8
+$escapedVersion = [regex]::Escape($Version)
+if ($cargoCheck -notmatch "(?m)^version = `"$escapedVersion`"") {
+  $verifyErrors += "Cargo.toml: version '$Version' not found after write"
+}
+
+$pkgCheck = Get-Content $packageJsonPath -Raw -Encoding utf8 | ConvertFrom-Json
+if ($pkgCheck.version -ne $Version) {
+  $verifyErrors += "package.json: expected version '$Version', got '$($pkgCheck.version)'"
+}
+
+$confCheck = Get-Content $tauriConfPath -Raw -Encoding utf8 | ConvertFrom-Json
+if ($confCheck.version -ne $Version) {
+  $verifyErrors += "src-tauri/tauri.conf.json: expected version '$Version', got '$($confCheck.version)'"
+}
+
+if ($verifyErrors.Count -gt 0) {
+  Write-Host "Version injection verification failed:" -ForegroundColor Red
+  foreach ($e in $verifyErrors) {
+    Write-Host " - $e" -ForegroundColor Red
+  }
+  exit 1
+}
+
+Write-Host "Version set to '$Version' in Cargo.toml, package.json, src-tauri/tauri.conf.json (verified)." -ForegroundColor Green


### PR DESCRIPTION
## 背景

#441 の指摘に対応する。

- リリースパイプラインは成果物の存在 + 署名検証までは自動だが、機能テスト（smoke/E2E）を通過ゲートにしておらず、動作保証が「draft を人が確認」に依存していた
- バージョンが 3 ファイル（`Cargo.toml` / `package.json` / `src-tauri/tauri.conf.json`）に分散し、`release.yml` 内のインライン PowerShell で個別置換していた（`release.yml:48-65` 付近）

## 変更内容

### 1. バージョン注入のスクリプト化

`release.yml` の "Set version from tag" ステップに埋め込まれていたインライン PowerShell を `scripts/inject-version.ps1` に切り出した。

- `-Version <semver>` パラメータを受け、`Cargo.toml`（正規表現置換）/ `package.json` / `src-tauri/tauri.conf.json`（`ConvertFrom-Json` → プロパティ代入 → `ConvertTo-Json`）の3ファイルを書き換える方式は元のインライン処理と同一
- `-WhatIf` スイッチで実際の書き換えなしに対象ファイル・設定予定バージョンを表示できる
- 書き換え後、3ファイルから読み戻して `Version` と一致するか検証し、不一致なら `exit 1`
- `Cargo.lock` は対象外（元のインライン処理と同じ挙動を維持）
- `release.yml` は `./scripts/inject-version.ps1 -Version $ver` の呼び出しに置き換え

### 2. リリース前 smoke ゲート

`build-and-release` ジョブの "Verify release artifacts"（成果物存在確認）の直後に、ビルド済み `target/release/snotra.exe` への起動スモークを追加した。

```yaml
- name: Run startup smoke on release binary
  run: pwsh -NoProfile -File scripts/smoke-startup.ps1 -ExePath target/release/snotra.exe
```

- `e2e.yml:53-54` が release バイナリに対して行っている起動スモークと同じスクリプト・同じ呼び出し方
- NSIS インストーラーではなくビルド済み exe に対して実行（`smoke-startup.ps1` は `-ExePath` で任意の exe を指定可能）
- 既存の成果物検証（`.sig` 含む）・ZIP パッケージング・`latest.json` 生成・アップロードの順序・draft 維持の挙動は変更していない（挿入のみ、既存ステップの削除・並び替えなし）
- 別ジョブ化はせず、`build-and-release` ジョブ内のステップとして追加（最小変更を優先。issue の「改善の方向性 1」= `build-release` を smoke/E2E に `needs` 依存させる、という別ジョブ構成は本 PR では採用していない。理由は次項）

### 3. フル E2E のゲート化は見送り

E2E（`npm run e2e:tauri`）を release ワークフローに組み込むことは見送った。

- `e2e.yml` の E2E ジョブは `npm run e2e:tauri:setup`（フロントエンドビルド + Tauri セットアップ）を含み、`build-and-release` とはビルド前提が異なる（release は署名付き NSIS バンドルを含む本番相当ビルド、e2e は debug/setup 用ビルド）。同一ジョブに混在させるとビルド成果物の二重生成やステップ順序の複雑化を招く
- release ワークフローは `windows-latest` 上で NSIS ビルド + 署名を含みただでさえ時間がかかる。フル E2E（`timeout-minutes: 30`）を直列に足すとリリース所要時間が大きく伸びる
- 設計案: `build-release` を独立ジョブとして残しつつ、成果物（`target/release/snotra.exe` 等）を `actions/upload-artifact` で共有し、後続の `e2e-gate` ジョブで smoke に加えて縮小版 E2E（起動・検索・起動の基本シナリオのみ）を走らせ、`softprops/action-gh-release` ステップを `needs: [build-release, e2e-gate]` に依存させる。これは release.yml のジョブ分割を伴う中〜大規模な変更になるため、issue に記載の通り本 PR ではスコープ外とし、必要であれば別 issue で設計する

## スクリプト検証

`scripts/inject-version.ps1` を一時ディレクトリ（`$env:TEMP/inject-version-verify/`）に配置した3ファイルの実物コピーに対して実行し、現行インライン処理と同一の出力になることを確認した。

手順:
1. `Cargo.toml` / `package.json` / `src-tauri/tauri.conf.json` を `inline/` と `script/` の2ディレクトリへコピー
2. `inline/` には元のインライン PowerShell をそのまま実行（バージョン `0.99.9-verify1`）
3. `script/` には `pwsh -File scripts/inject-version.ps1 -Version 0.99.9-verify1 -RepoRoot script/` を実行
4. 3ファイルをそれぞれ `Get-Content -Raw` で読み込み比較

結果:
```
MATCH: Cargo.toml
MATCH: package.json
MATCH: src-tauri/tauri.conf.json
---
All match: True
Cargo.lock exists in inline copy: False
Cargo.lock exists in script copy: False
```

追加で以下も確認済み:
- `-WhatIf` 指定時はファイルを一切書き換えない（対象ファイル一覧を表示して `exit 0`）
- 不正なバージョン文字列（例: `not-a-version`）は semver 正規表現チェックで `throw` し `exit 1`
- 対象ファイルが存在しないリポジトリルートを指定すると `File not found` で `exit 1`

## YAML 構文チェック

`gh api` 等でのワークフロー実行はできないため、Python `yaml.safe_load` でパース確認した。

```
release.yml OK
create-release.yml OK
e2e.yml OK (unmodified, sanity check)
```

## 制約・変更しなかったこと

- release.yml の既存ステップ順・成果物検証・draft 維持の挙動は変更していない（追加のみ）
- 第三者 Action のバージョン更新は行っていない（#384 のスコープ）
- `.claude/` / `AGENTS.md` は変更していない

## タグ実行の検証について（本 PR では不可）

リリースフロー全体（`create-release.yml` → `release.yml`）はタグ push でしか実行できないため、本 PR ではタグ実行そのものの検証はできていない。次回リリース時に以下を確認する:

- [ ] `scripts/inject-version.ps1` 呼び出しが CI 上で正常終了し、3ファイルのバージョンが期待通り更新されている
- [ ] "Run startup smoke on release binary" ステップが release ビルドの `target/release/snotra.exe` に対して成功する
- [ ] スモーク失敗時にジョブが実際に赤くなり、後続の ZIP パッケージング・アップロードへ進まないことを確認する（意図的に失敗させるテストは本 PR には含まれない）
- [ ] draft リリースの内容（NSIS installer / ZIP / `latest.json`）が従来通り生成されていることを確認する

## 関連

- Closes #441
- #145（E2E の CI 常設組み込み）— 本 PR では見送ったフル E2E ゲートの関連 issue
- #384（第三者 Action の更新）— 本 PR ではスコープ外として変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
