### PR TITLE
refactor(settings): dirty 判定・ModalState・正規化の二重管理を集約する

### DIFF
--- a/snotra-core/src/config.rs
+++ b/snotra-core/src/config.rs
@@ -978,6 +978,19 @@ impl Config {
         changed
     }
 
+    /// `Config::default()` に `apply_migrations()` を適用した「正規化済み既定値」を返す。
+    ///
+    /// `Config::default()` は一部フィールドを `None`（sentinel、明示未設定を表す）のまま返すため、
+    /// 読み込み経由（`load()` は必ず `apply_migrations()` を通す）で得た `Some(v)` な Config と
+    /// フィールド単位の `PartialEq` を比較すると、`None` を `Some` に解決する順序（DragValue の
+    /// `get_or_insert` 等）次第で結果が変わりうる。この関数は正規化を呼び忘れる余地を型レベルで
+    /// なくし、`Config::default()` の生値ではなく常にこちらを「比較可能な既定値」として使う。
+    pub fn normalized_default() -> Self {
+        let mut config = Self::default();
+        let _ = config.apply_migrations();
+        config
+    }
+
     pub fn load() -> Self {
         Self::load_reporting().0
     }
@@ -1514,6 +1527,40 @@ mod tests {
         assert_eq!(config.search.result_limit, Some(200));
         assert_eq!(config.search.recent_limit, Some(8));
         assert_eq!(config.appearance.visible_rows, Some(8));
+    }
+
+    #[test]
+    fn normalized_default_resolves_all_migration_sentinels() {
+        // #439: reset_to_default の apply_migrations() 手動呼び出し回避策をモデル層に閉じ込める。
+        // normalized_default() は常に Some(v) を返し、legacy 二層フィールドは take() 済みで None。
+        let config = Config::normalized_default();
+        assert!(config.appearance.visible_rows.is_some());
+        assert!(config.search.result_limit.is_some());
+        assert!(config.search.recent_limit.is_some());
+        assert_eq!(config.appearance.max_results, None);
+        assert_eq!(config.appearance.top_n_history, None);
+        assert_eq!(config.appearance.max_history_display, None);
+        assert_eq!(config.search.top_n_history, None);
+        assert_eq!(config.search.max_history_display, None);
+    }
+
+    #[test]
+    fn normalized_default_matches_default_plus_manual_migrations() {
+        let mut expected = Config::default();
+        expected.apply_migrations();
+        assert_eq!(Config::normalized_default(), expected);
+    }
+
+    #[test]
+    fn normalized_default_is_idempotent_under_reapplied_migrations() {
+        // モデル層で正規化済みなら、タブ遷移順序の違いを模した再適用（DragValue の
+        // get_or_insert 等）で値が変化しない。変化すれば draft/saved の PartialEq が
+        // 遷移順序に依存する既知のバグが再発している。
+        let mut config = Config::normalized_default();
+        let before = config.clone();
+        let changed = config.apply_migrations();
+        assert!(!changed, "normalized_default() should already be migration-stable");
+        assert_eq!(config, before);
     }
 
     #[test]

--- a/snotra-settings/CLAUDE.md
+++ b/snotra-settings/CLAUDE.md
@@ -18,6 +18,7 @@ egui ベースの設定・about バイナリ crate。本体（`src-tauri`）と�
 - `style.rs`: デザイントークン（色 / 余白 / フォントサイズ / 幅）と共有スタイルヘルパー（`tab_scroll_area` / `section_heading` / `hint` / `settings_grid` / `list_item` / `reorder_controls` / `modal_header` / `modal_buttons` / `danger_button` / `apply_type_ramp`）。全タブと app.rs がこれ経由で描画する。詳細は `SETTINGS-DESIGN.md`
 - `tabs/`: 7タブの UI 実装
   - `mod.rs`: サブモジュール宣言のみ
+  - `common.rs`: index / opener / instant 3タブ共通のモーダル状態（`ModalState<F, I>` / `ModalMode` / `save_entry` / `delete_entry`）と非同期ファイルピッカー（`PickerState::poll` / `launch`）。純ロジックのみ（egui 描画は各タブに残す）。ユニットテストあり
   - `general.rs`: 全般設定（起動時表示、トレイ、IME、ホットキー）
   - `search.rs`: 検索設定（検索モード、履歴、隠しファイル）
   - `index.rs`: インデックス設定（スキャンパス管理）
@@ -64,7 +65,8 @@ eframe は毎フレーム `App::ui()`（旧 `update()`。eframe 0.35 で `logic(
 - **saved**: `save()` 成功時のみ `draft` のクローンで更新。バリデーション失敗や I/O エラー時は更新されない
 - **has_changes()**: `draft != saved` で判定。Save/Discard ボタンの有効化に使用
 - **Discard**: `draft = saved.clone()` で全タブの編集を一括破棄
-- **Reset to default**: `draft = Config::default()` で既定値に戻す（saved は変更しない → has_changes() が true になり Save が必要）
+- **Reset to default**: `draft = Config::normalized_default()` で既定値に戻す（saved は変更しない → has_changes() が true になり Save が必要）。`normalized_default()` は `apply_migrations()` 適用済みの「正規化済み（Option フィールドが全 Some）」既定値を返すため、`saved` との `PartialEq` がタブ遷移順序（DragValue の `get_or_insert`）に依存しない
+- **タブ別ダーティ点（`•`）**: `app.rs` の `SECTION_TABLE`（Config セクション → TabId 対応表、SSOT）から導出。Config に新セクションを追加したら表を1箇所更新する（更新漏れは `section_table_covers_all_config_fields` テストの網羅 destructure がコンパイルエラー/テスト失敗で検出する）
 
 ### 保存フロー
 
@@ -81,21 +83,22 @@ Save クリック → draft.clone() → normalize_scan_paths() → normalize_ope
 
 | タブ | ステート | 特記 |
 |------|---------|------|
-| index | `IndexTabState` | `PickerState`（フォルダ選択）+ `ModalState`（Create/Edit） |
-| opener | `OpenerTabState` | `ExePickerState`（exe 選択）+ `ModalState`（ネストした rule/tool インデックス） |
-| instant | `InstantTabState` | `ModalState` のみ（シンプルなフラットリスト） |
+| index | `IndexTabState` | `common::PickerState`（フォルダ選択）+ `common::ModalState<ScanPathFields>` |
+| opener | `OpenerTabState` | `common::PickerState`（exe 選択）+ `common::ModalState<OpenerFields, (usize, usize)>`（ネストした rule/tool インデックス） |
+| instant | `InstantTabState` | `common::ModalState<InstantFields>` + exe 用 `common::PickerState` |
 
 ## モーダル Create/Edit パターン
 
-index / opener / instant の3タブが共通して使うモーダルの設計パターン:
+index / opener / instant の3タブが共通して使うモーダルの状態機械は `tabs/common.rs` の `ModalState<F, I = usize>`（`F` = タブ固有編集フィールド struct、`I` = 編集スナップショットの位置型）に集約されている:
 
-- `ModalMode::Create`: フィールド初期化 → モーダル表示 → Save で Vec に `push`
-- `ModalMode::Edit`: 既存値をフィールドにコピー → モーダル表示 → Save でインデックス指定で上書き。Delete ボタンも表示
-- **インデックス陳腐化ガード**: Edit モードで保持する `editing_index` はモーダルを開いた時点のスナップショット。モーダル表示中に外部で行が削除されるケース（このアプリでは発生しないが）に備え、Save/Delete 前に必ず `if idx < vec.len()` で境界チェックする
+- `ModalMode::Create`: `open_create()`（フィールドを `F::default()` に初期化）→ モーダル表示 → Save で `common::save_entry` が Vec に `push`。複製は `open_create_with(fields)`
+- `ModalMode::Edit`: `open_edit(index, fields)` で既存値をコピー → モーダル表示 → Save で `common::save_entry` がインデックス指定で上書き。Delete ボタンも表示（`common::delete_entry`）
+- **インデックス陳腐化ガード**: Edit モードで保持する `editing` はモーダルを開いた時点のスナップショット。モーダル表示中に外部で行が削除されるケース（このアプリでは発生しないが）に備え、`save_entry` / `delete_entry` が境界チェックを内蔵する（範囲外は no-op）。opener はネスト `(rule, tool)` のため Save/Delete の境界チェックのみ固有ロジック（`save_opener` / Delete ハンドラ）に残る
+- モーダルの egui 描画（`show_modal` の `ui.xxx()` 列）はタブごとに固有のまま各タブに残す。共通化するのは状態遷移・境界チェックだけ
 
 ## 非同期ファイルピッカーパターン
 
-`rfd::FileDialog` はブロッキング API のため、egui の UI スレッドで直接呼ぶとフリーズする。代わりにスレッド spawn + `Arc<Mutex<Option<Option<PathBuf>>>>` パターンを使う。
+`rfd::FileDialog` はブロッキング API のため、egui の UI スレッドで直接呼ぶとフリーズする。スレッド spawn + `Arc<Mutex<Option<Option<PathBuf>>>>` パターンを `tabs/common.rs` の `PickerState` に集約している。
 
 ```
 PickerState {
@@ -104,9 +107,9 @@ PickerState {
 }
 ```
 
-- スレッド内で `ctx.request_repaint()` を呼んで UI 更新をトリガーする
-- 毎フレーム `try_lock()`（非ブロッキング）で結果をポーリングし、取得後に `.take()` + `active = false`
-- **`active = false` の書き忘れはボタンが永久に無効化されるバグになる**
+- `launch(ctx, dialog)`: `active = true` にしてスレッド spawn。完了時に `ctx.request_repaint()` で UI 更新をトリガーする
+- `poll()`: 毎フレームの非ブロッキングポーリング（`try_lock` + `.take()`）。結果取得時（キャンセル含む）に `active = false` へ戻す
+- **`active = false` の戻し忘れはボタンが永久に無効化されるバグになる** — この責務は `poll()` 1箇所に集約されており、各タブで手書きしない
 
 ## opener のターゲットエンコーディング
 

--- a/snotra-settings/src/app.rs
+++ b/snotra-settings/src/app.rs
@@ -95,18 +95,33 @@ impl TabId {
         }
     }
 
+    /// タブ別ダーティ点（`•`）の判定を `SECTION_TABLE` から導出する。
+    /// 新セクション追加時は `SECTION_TABLE` の1箇所だけを更新すればよい
+    /// （`section_table_covers_all_config_fields` テストが更新漏れを検出する）。
     fn has_changes(self, draft: &Config, saved: &Config) -> bool {
-        match self {
-            TabId::General => draft.general != saved.general || draft.hotkey != saved.hotkey,
-            TabId::Search => draft.search != saved.search,
-            TabId::Index => draft.paths != saved.paths,
-            TabId::Visual => draft.visual != saved.visual || draft.appearance != saved.appearance,
-            TabId::Opener => draft.openers != saved.openers,
-            TabId::InstantCommand => draft.instant_commands != saved.instant_commands,
-            TabId::Backup => false,
-        }
+        SECTION_TABLE.iter().any(|(tab, diff)| *tab == self && diff(draft, saved))
     }
 }
+
+/// Config セクション → TabId の対応表（SSOT）。
+///
+/// タブ別ダーティ点（[`TabId::has_changes`]）はここから導出される。全体判定
+/// （[`SettingsApp::has_changes`]）は構造体全体の `PartialEq`（`draft != saved`）を使うため
+/// 新フィールド追加時も自動追従するが、この表を更新し忘れるとタブ点だけが無反応になりうる。
+/// `section_table_covers_all_config_fields` テストが、この表の合成が `draft != saved` と
+/// 一致すること（＝更新漏れがないこと）を Config の全フィールドについて検証する。
+type SectionDiff = fn(&Config, &Config) -> bool;
+
+const SECTION_TABLE: &[(TabId, SectionDiff)] = &[
+    (TabId::General, |d, s| d.hotkey != s.hotkey),
+    (TabId::General, |d, s| d.general != s.general),
+    (TabId::Search, |d, s| d.search != s.search),
+    (TabId::Index, |d, s| d.paths != s.paths),
+    (TabId::Visual, |d, s| d.visual != s.visual),
+    (TabId::Visual, |d, s| d.appearance != s.appearance),
+    (TabId::Opener, |d, s| d.openers != s.openers),
+    (TabId::InstantCommand, |d, s| d.instant_commands != s.instant_commands),
+];
 
 struct SettingsApp {
     draft: Config,
@@ -207,11 +222,9 @@ impl SettingsApp {
     }
 
     fn reset_to_default(&mut self) {
-        let mut draft = Config::default();
-        // apply_migrations() で None フィールドをデフォルト値（Some(v)）に解決する。
-        // これにより saved（常に Some(v)）との PartialEq が tab 遷移順序に依存しなくなる。
-        let _ = draft.apply_migrations();
-        self.draft = draft;
+        // Config::normalized_default() が正規化（apply_migrations 相当）済みの既定値を返すため、
+        // ここで呼び忘れても draft/saved の PartialEq が tab 遷移順序に依存する心配はない。
+        self.draft = Config::normalized_default();
         self.tr = Tr(self.draft.general.language);
         self.hotkey_state = Default::default();
         self.index_state = tabs::index::IndexTabState::default();
@@ -606,4 +619,110 @@ pub fn run(
             Ok(Box::new(SettingsApp::new(config, first_run, initial_tab, load_outcome)))
         }),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snotra_core::config::{InstantAction, InstantCommand, OpenerRule, OpenerTool, ScanPath};
+
+    /// Config の全トップレベルフィールドを1つずつ変更する mutation の一覧。
+    ///
+    /// 冒頭の `..` なし destructure が Config のフィールド網羅をコンパイル時に強制する:
+    /// Config に新フィールド（新セクション）を追加するとここがコンパイルエラーになり、
+    /// mutation と `SECTION_TABLE` の両方に対応を追加するまで検出が続く。
+    type FieldMutation = (&'static str, fn(&mut Config));
+
+    fn field_mutations() -> Vec<FieldMutation> {
+        // 網羅性ガード: 新フィールド追加でコンパイルエラーにする（`..` を使わないこと）。
+        let Config {
+            hotkey: _,
+            general: _,
+            appearance: _,
+            visual: _,
+            paths: _,
+            search: _,
+            openers: _,
+            instant_commands: _,
+        } = Config::normalized_default();
+        vec![
+            ("hotkey", |c: &mut Config| c.hotkey.key = "Z".to_string()),
+            ("general", |c: &mut Config| {
+                c.general.show_on_startup = !c.general.show_on_startup;
+            }),
+            ("appearance", |c: &mut Config| c.appearance.window_width += 10),
+            ("visual", |c: &mut Config| {
+                c.visual.background_color = "#123456".to_string();
+            }),
+            ("paths", |c: &mut Config| {
+                c.paths.scan.push(ScanPath {
+                    path: "C:/mutation".to_string(),
+                    extensions: vec![".txt".to_string()],
+                    include_folders: false,
+                });
+            }),
+            ("search", |c: &mut Config| {
+                c.search.show_hidden_system = !c.search.show_hidden_system;
+            }),
+            ("openers", |c: &mut Config| {
+                c.openers.push(OpenerRule {
+                    target: "folder".to_string(),
+                    tools: vec![OpenerTool {
+                        name: "t".to_string(),
+                        exe: "x.exe".to_string(),
+                        args: String::new(),
+                    }],
+                });
+            }),
+            ("instant_commands", |c: &mut Config| {
+                c.instant_commands.push(InstantCommand {
+                    name: "mutation".to_string(),
+                    description: String::new(),
+                    action: InstantAction::Url { url: "https://example.com".to_string() },
+                });
+            }),
+        ]
+    }
+
+    // 不変条件: SECTION_TABLE（全 TabId の対応の合成）は全体判定 `draft != saved` と一致する。
+    // Config のどのフィールドを変えても、少なくとも1つのタブ点が点灯しなければならない。
+    #[test]
+    fn section_table_covers_all_config_fields() {
+        let saved = Config::normalized_default();
+        for (name, mutate) in field_mutations() {
+            let mut draft = saved.clone();
+            mutate(&mut draft);
+            assert_ne!(draft, saved, "mutation `{name}` must actually change the config");
+            let any_tab_dirty = TabId::ALL.iter().any(|t| t.has_changes(&draft, &saved));
+            assert!(
+                any_tab_dirty,
+                "SECTION_TABLE lacks a mapping for config field `{name}`: \
+                 tab dot would stay off while overall draft != saved is true"
+            );
+        }
+    }
+
+    // 不変条件: draft == saved のとき、どのタブ点も点灯しない（偽陽性なし）。
+    #[test]
+    fn section_table_no_false_positive_when_unchanged() {
+        let saved = Config::normalized_default();
+        let draft = saved.clone();
+        for &tab in TabId::ALL {
+            assert!(!tab.has_changes(&draft, &saved), "{tab:?} must not light when unchanged");
+        }
+    }
+
+    // 不変条件: Backup タブは draft/saved に参加しないため、どの変更でも点灯しない。
+    #[test]
+    fn backup_tab_never_shows_dirty_dot() {
+        let saved = Config::normalized_default();
+        for (name, mutate) in field_mutations() {
+            let mut draft = saved.clone();
+            mutate(&mut draft);
+            assert!(
+                !TabId::Backup.has_changes(&draft, &saved),
+                "Backup tab must not light for `{name}`"
+            );
+        }
+    }
 }

--- a/snotra-settings/src/tabs/common.rs
+++ b/snotra-settings/src/tabs/common.rs
@@ -1,0 +1,275 @@
+//! index / opener / instant の3タブが共有するモーダル Create/Edit 状態と
+//! 非同期ファイルピッカーの共通実装（#439）。
+//!
+//! UI（egui の描画呼び出し列）はタブごとに固有のまま各タブに残し、ここには
+//! 状態遷移・境界チェック・ポーリングといった純ロジックだけを置く。
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use eframe::egui;
+
+/// モーダルの動作モード。
+///
+/// - `Create`: フィールド初期化 → Save で Vec に push
+/// - `Edit`: 既存値をコピー → Save でインデックス指定で上書き。Delete ボタンも表示
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
+pub enum ModalMode {
+    #[default]
+    Create,
+    Edit,
+}
+
+/// モーダル Create/Edit の共通状態。
+///
+/// - `F`: タブ固有の編集フィールド群（`Default` が Create 時の初期値）
+/// - `I`: 編集対象の位置（既定 `usize`。opener はネストした `(rule, tool)` を使う）
+///
+/// **インデックス陳腐化ガード**: `editing` はモーダルを開いた時点のスナップショット。
+/// モーダル表示中に外部で行が削除されるケース（このアプリでは発生しないが）に備え、
+/// Save/Delete は必ず境界チェックを通す（[`save_entry`] / [`delete_entry`]、
+/// opener は固有ロジック内でチェック）。
+#[derive(Default)]
+pub struct ModalState<F: Default, I = usize> {
+    pub open: bool,
+    pub mode: ModalMode,
+    pub editing: Option<I>,
+    pub fields: F,
+}
+
+impl<F: Default, I> ModalState<F, I> {
+    /// Create モードで開く（フィールドは `F::default()` に初期化）。
+    pub fn open_create(&mut self) {
+        self.open_create_with(F::default());
+    }
+
+    /// Create モードで開く（複製など、初期値を指定するケース）。
+    pub fn open_create_with(&mut self, fields: F) {
+        self.open = true;
+        self.mode = ModalMode::Create;
+        self.editing = None;
+        self.fields = fields;
+    }
+
+    /// Edit モードで開く（`index` は開いた時点のスナップショット）。
+    pub fn open_edit(&mut self, index: I, fields: F) {
+        self.open = true;
+        self.mode = ModalMode::Edit;
+        self.editing = Some(index);
+        self.fields = fields;
+    }
+
+    /// モーダルを閉じ、編集スナップショットを破棄する。
+    pub fn close(&mut self) {
+        self.open = false;
+        self.editing = None;
+    }
+
+    pub fn is_edit(&self) -> bool {
+        self.mode == ModalMode::Edit
+    }
+}
+
+/// モーダル Save の共通処理: Edit（`editing = Some`）なら境界チェック付きで上書き、
+/// Create（`None`）なら push。陳腐化したインデックス（範囲外）は黙って無視する
+/// （従来の各タブ実装と同じ挙動）。
+pub fn save_entry<T>(vec: &mut Vec<T>, editing: Option<usize>, entry: T) {
+    match editing {
+        Some(idx) if idx < vec.len() => vec[idx] = entry,
+        Some(_) => {}
+        None => vec.push(entry),
+    }
+}
+
+/// モーダル Delete の共通処理: 境界チェック付き remove。範囲外・Create モードは無視。
+pub fn delete_entry<T>(vec: &mut Vec<T>, editing: Option<usize>) {
+    if let Some(idx) = editing
+        && idx < vec.len()
+    {
+        vec.remove(idx);
+    }
+}
+
+/// 非同期ファイルピッカー状態（rfd + thread spawn パターン）。
+///
+/// `rfd::FileDialog` はブロッキング API のため UI スレッドで直接呼ばずスレッドに逃がす。
+/// `result` の意味: `None` = 実行中, `Some(None)` = キャンセル, `Some(Some(path))` = 選択。
+/// `active` が true の間は Browse ボタンを無効化する。
+#[derive(Clone, Default)]
+pub struct PickerState {
+    pub result: Arc<Mutex<Option<Option<PathBuf>>>>,
+    pub active: bool,
+}
+
+impl PickerState {
+    /// 毎フレームの非ブロッキングポーリング。ダイアログが完了していれば結果を取り出し
+    /// `active = false` に戻す（キャンセル時も必ず戻す＝ボタン永久無効化バグの防止を
+    /// 1箇所に集約）。返り値: `Some(Some(path))` = 選択, `Some(None)` = キャンセル,
+    /// `None` = 未完了または非アクティブ。
+    pub fn poll(&mut self) -> Option<Option<PathBuf>> {
+        if !self.active {
+            return None;
+        }
+        let taken = self.result.try_lock().ok().and_then(|mut guard| guard.take());
+        if taken.is_some() {
+            self.active = false;
+        }
+        taken
+    }
+
+    /// ダイアログをバックグラウンドスレッドで起動する。`active = true` にし（対になる
+    /// `false` は [`PickerState::poll`] が結果取得時に戻す）、完了時に `request_repaint`
+    /// で UI 更新をトリガーする。
+    pub fn launch(
+        &mut self,
+        ctx: &egui::Context,
+        dialog: impl FnOnce() -> Option<PathBuf> + Send + 'static,
+    ) {
+        self.active = true;
+        let result = Arc::clone(&self.result);
+        let repaint_ctx = ctx.clone();
+        std::thread::spawn(move || {
+            *result.lock().unwrap() = Some(dialog());
+            repaint_ctx.request_repaint();
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default, PartialEq, Debug)]
+    struct Fields {
+        text: String,
+    }
+
+    fn fields(s: &str) -> Fields {
+        Fields { text: s.to_string() }
+    }
+
+    // 不変条件: open_create はフィールドを Default に初期化し editing を消す
+    #[test]
+    fn modal_open_create_resets_fields_and_editing() {
+        let mut m: ModalState<Fields> = ModalState::default();
+        m.open_edit(3, fields("old"));
+        m.open_create();
+        assert!(m.open);
+        assert_eq!(m.mode, ModalMode::Create);
+        assert_eq!(m.editing, None);
+        assert_eq!(m.fields, Fields::default());
+    }
+
+    // 不変条件: open_create_with（複製）は Create モードのままフィールドだけ引き継ぐ
+    #[test]
+    fn modal_open_create_with_keeps_create_mode() {
+        let mut m: ModalState<Fields> = ModalState::default();
+        m.open_create_with(fields("dup"));
+        assert_eq!(m.mode, ModalMode::Create);
+        assert_eq!(m.editing, None);
+        assert_eq!(m.fields, fields("dup"));
+    }
+
+    // 不変条件: open_edit はスナップショット index とフィールドを保持する
+    #[test]
+    fn modal_open_edit_sets_snapshot() {
+        let mut m: ModalState<Fields> = ModalState::default();
+        m.open_edit(2, fields("row2"));
+        assert!(m.open && m.is_edit());
+        assert_eq!(m.editing, Some(2));
+        assert_eq!(m.fields, fields("row2"));
+    }
+
+    // 不変条件: close は editing スナップショットを必ず破棄する
+    #[test]
+    fn modal_close_clears_editing() {
+        let mut m: ModalState<Fields> = ModalState::default();
+        m.open_edit(1, fields("x"));
+        m.close();
+        assert!(!m.open);
+        assert_eq!(m.editing, None);
+    }
+
+    // 不変条件: ネスト index（opener の (rule, tool)）も同じ状態遷移で扱える
+    #[test]
+    fn modal_supports_nested_index() {
+        let mut m: ModalState<Fields, (usize, usize)> = ModalState::default();
+        m.open_edit((1, 2), fields("nested"));
+        assert_eq!(m.editing, Some((1, 2)));
+        m.close();
+        assert_eq!(m.editing, None);
+    }
+
+    // 不変条件: save_entry は Create で push、Edit（範囲内）で置換、範囲外で no-op（panic しない）
+    #[test]
+    fn save_entry_create_pushes() {
+        let mut v = vec![1, 2];
+        save_entry(&mut v, None, 3);
+        assert_eq!(v, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn save_entry_edit_replaces_in_bounds() {
+        let mut v = vec![1, 2, 3];
+        save_entry(&mut v, Some(1), 9);
+        assert_eq!(v, vec![1, 9, 3]);
+    }
+
+    #[test]
+    fn save_entry_stale_index_is_noop() {
+        let mut v = vec![1];
+        save_entry(&mut v, Some(5), 9);
+        assert_eq!(v, vec![1]);
+    }
+
+    // 不変条件: delete_entry は範囲内で remove、範囲外/Create で no-op（panic しない）
+    #[test]
+    fn delete_entry_in_bounds_removes() {
+        let mut v = vec![1, 2, 3];
+        delete_entry(&mut v, Some(1));
+        assert_eq!(v, vec![1, 3]);
+    }
+
+    #[test]
+    fn delete_entry_stale_or_create_is_noop() {
+        let mut v = vec![1];
+        delete_entry(&mut v, Some(5));
+        delete_entry(&mut v, None);
+        assert_eq!(v, vec![1]);
+    }
+
+    // 不変条件: poll は非アクティブ時 None、結果到着時に take + active=false（キャンセルでも戻す）
+    #[test]
+    fn picker_poll_inactive_returns_none() {
+        let mut p = PickerState::default();
+        assert_eq!(p.poll(), None);
+    }
+
+    fn active_picker() -> PickerState {
+        PickerState { active: true, ..Default::default() }
+    }
+
+    #[test]
+    fn picker_poll_pending_keeps_active() {
+        let mut p = active_picker();
+        assert_eq!(p.poll(), None);
+        assert!(p.active, "結果未着では active を維持する");
+    }
+
+    #[test]
+    fn picker_poll_takes_result_and_deactivates() {
+        let mut p = active_picker();
+        *p.result.lock().unwrap() = Some(Some(PathBuf::from("C:/x.exe")));
+        assert_eq!(p.poll(), Some(Some(PathBuf::from("C:/x.exe"))));
+        assert!(!p.active);
+        assert_eq!(p.poll(), None, "結果は take 済みで再取得されない");
+    }
+
+    #[test]
+    fn picker_poll_cancel_also_deactivates() {
+        let mut p = active_picker();
+        *p.result.lock().unwrap() = Some(None);
+        assert_eq!(p.poll(), Some(None));
+        assert!(!p.active, "キャンセルでも active を戻す（ボタン永久無効化の防止）");
+    }
+}

--- a/snotra-settings/src/tabs/index.rs
+++ b/snotra-settings/src/tabs/index.rs
@@ -1,64 +1,31 @@
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
-
 use eframe::egui;
 use snotra_core::config::{Config, ScanPath};
 
 use crate::i18n::Tr;
 use crate::style;
-
-/// Non-blocking file/folder picker state (rfd + thread spawn pattern)
-#[derive(Clone, Default)]
-pub struct PickerState {
-    pub result: Arc<Mutex<Option<Option<PathBuf>>>>,
-    pub active: bool,
-}
+use crate::tabs::common::{self, ModalState, PickerState};
 
 #[derive(Default)]
 pub struct IndexTabState {
     pub picker: PickerState,
-    modal: ModalState,
+    modal: ModalState<ScanPathFields>,
 }
 
+/// スキャンパスモーダルのタブ固有編集フィールド。
 #[derive(Default)]
-struct ModalState {
-    open: bool,
-    mode: ModalMode,
-    editing_index: Option<usize>,
-    edit_path: String,
-    edit_extensions: String,
-    edit_include_folders: bool,
+struct ScanPathFields {
+    path: String,
+    extensions: String,
+    include_folders: bool,
 }
 
-#[derive(Default, PartialEq)]
-enum ModalMode {
-    #[default]
-    Create,
-    Edit,
-}
-
-impl ModalState {
-    fn open_create(&mut self) {
-        self.open = true;
-        self.mode = ModalMode::Create;
-        self.editing_index = None;
-        self.edit_path.clear();
-        self.edit_extensions.clear();
-        self.edit_include_folders = false;
-    }
-
-    fn open_edit(&mut self, index: usize, scan: &ScanPath) {
-        self.open = true;
-        self.mode = ModalMode::Edit;
-        self.editing_index = Some(index);
-        self.edit_path = scan.path.clone();
-        self.edit_extensions = scan.extensions.join(", ");
-        self.edit_include_folders = scan.include_folders;
-    }
-
-    fn close(&mut self) {
-        self.open = false;
-        self.editing_index = None;
+impl ScanPathFields {
+    fn from_scan(scan: &ScanPath) -> Self {
+        Self {
+            path: scan.path.clone(),
+            extensions: scan.extensions.join(", "),
+            include_folders: scan.include_folders,
+        }
     }
 }
 
@@ -71,14 +38,8 @@ fn parse_extensions(raw: &str) -> Vec<String> {
 
 pub fn ui(ui: &mut egui::Ui, ctx: &egui::Context, config: &mut Config, state: &mut IndexTabState, tr: &Tr) {
     // Poll picker result
-    if state.picker.active
-        && let Ok(mut guard) = state.picker.result.try_lock()
-        && let Some(result) = guard.take()
-    {
-        state.picker.active = false;
-        if let Some(path) = result {
-            state.modal.edit_path = path.display().to_string();
-        }
+    if let Some(Some(path)) = state.picker.poll() {
+        state.modal.fields.path = path.display().to_string();
     }
 
     style::tab_scroll_area(ui, |ui| {
@@ -118,8 +79,8 @@ pub fn ui(ui: &mut egui::Ui, ctx: &egui::Context, config: &mut Config, state: &m
         match action {
             Some(ListAction::OpenCreate) => state.modal.open_create(),
             Some(ListAction::Edit(i)) => {
-                let scan = config.paths.scan[i].clone();
-                state.modal.open_edit(i, &scan);
+                let fields = ScanPathFields::from_scan(&config.paths.scan[i]);
+                state.modal.open_edit(i, fields);
             }
             None => {}
         }
@@ -137,7 +98,7 @@ enum ListAction {
 }
 
 fn show_modal(ctx: &egui::Context, config: &mut Config, state: &mut IndexTabState, tr: &Tr) {
-    let title = if state.modal.mode == ModalMode::Edit {
+    let title = if state.modal.is_edit() {
         tr.modal_edit_scan_path()
     } else {
         tr.modal_add_scan_path()
@@ -151,44 +112,32 @@ fn show_modal(ctx: &egui::Context, config: &mut Config, state: &mut IndexTabStat
         // Path input + browse button
         ui.label(tr.label_path());
         ui.horizontal(|ui| {
-            ui.text_edit_singleline(&mut state.modal.edit_path);
+            ui.text_edit_singleline(&mut state.modal.fields.path);
             if ui
                 .add_enabled(!state.picker.active, egui::Button::new(tr.btn_browse()))
                 .clicked()
             {
-                state.picker.active = true;
-                let result = Arc::clone(&state.picker.result);
-                let repaint_ctx = ctx.clone();
                 let dialog_title = tr.dialog_select_folder().to_string();
-                std::thread::spawn(move || {
-                    let path = rfd::FileDialog::new()
-                        .set_title(&dialog_title)
-                        .pick_folder();
-                    *result.lock().unwrap() = Some(path);
-                    repaint_ctx.request_repaint();
+                state.picker.launch(ctx, move || {
+                    rfd::FileDialog::new().set_title(&dialog_title).pick_folder()
                 });
             }
         });
 
         ui.add_space(style::SPACE_HINT);
         ui.label(tr.label_extensions());
-        ui.text_edit_singleline(&mut state.modal.edit_extensions);
+        ui.text_edit_singleline(&mut state.modal.fields.extensions);
 
         ui.add_space(style::SPACE_HINT);
-        ui.checkbox(&mut state.modal.edit_include_folders, tr.cb_include_folders());
+        ui.checkbox(&mut state.modal.fields.include_folders, tr.cb_include_folders());
 
         ui.add_space(style::SPACE_GROUP);
         ui.separator();
 
         ui.horizontal(|ui| {
             // Delete button (edit mode only)
-            if state.modal.mode == ModalMode::Edit && style::danger_button(ui, tr.btn_delete()).clicked()
-            {
-                if let Some(idx) = state.modal.editing_index
-                    && idx < config.paths.scan.len()
-                {
-                    config.paths.scan.remove(idx);
-                }
+            if state.modal.is_edit() && style::danger_button(ui, tr.btn_delete()).clicked() {
+                common::delete_entry(&mut config.paths.scan, state.modal.editing);
                 state.modal.close();
             }
 
@@ -208,22 +157,11 @@ fn show_modal(ctx: &egui::Context, config: &mut Config, state: &mut IndexTabStat
     }
 }
 
-fn save_scan_path(config: &mut Config, modal: &ModalState) {
-    let path = modal.edit_path.clone();
-    let extensions = parse_extensions(&modal.edit_extensions);
-    let include_folders = modal.edit_include_folders;
-
+fn save_scan_path(config: &mut Config, modal: &ModalState<ScanPathFields>) {
     let new_entry = ScanPath {
-        path,
-        extensions,
-        include_folders,
+        path: modal.fields.path.clone(),
+        extensions: parse_extensions(&modal.fields.extensions),
+        include_folders: modal.fields.include_folders,
     };
-
-    if let Some(idx) = modal.editing_index {
-        if idx < config.paths.scan.len() {
-            config.paths.scan[idx] = new_entry;
-        }
-    } else {
-        config.paths.scan.push(new_entry);
-    }
+    common::save_entry(&mut config.paths.scan, modal.editing, new_entry);
 }

--- a/snotra-settings/src/tabs/instant.rs
+++ b/snotra-settings/src/tabs/instant.rs
@@ -1,16 +1,14 @@
-use std::sync::Arc;
-
 use eframe::egui;
 use snotra_core::config::{Config, InstantAction, InstantCommand};
 
 use crate::i18n::Tr;
 use crate::style;
-use crate::tabs::opener::ExePickerState;
+use crate::tabs::common::{self, ModalState, PickerState};
 
 #[derive(Default)]
 pub struct InstantTabState {
-    modal: ModalState,
-    exe_picker: ExePickerState,
+    modal: ModalState<InstantFields>,
+    exe_picker: PickerState,
 }
 
 #[derive(Default, PartialEq, Clone, Copy)]
@@ -20,79 +18,40 @@ enum EditKind {
     Program,
 }
 
+/// インスタントコマンドモーダルのタブ固有編集フィールド。
 #[derive(Default)]
-struct ModalState {
-    open: bool,
-    mode: ModalMode,
-    editing_index: Option<usize>,
-    edit_name: String,
-    edit_description: String,
-    edit_kind: EditKind,
-    edit_url: String,
-    edit_exe: String,
-    edit_args: String,
+struct InstantFields {
+    name: String,
+    description: String,
+    kind: EditKind,
+    url: String,
+    exe: String,
+    args: String,
 }
 
-#[derive(Default, PartialEq)]
-enum ModalMode {
-    #[default]
-    Create,
-    Edit,
-}
-
-impl ModalState {
-    fn open_create(&mut self) {
-        self.open = true;
-        self.mode = ModalMode::Create;
-        self.editing_index = None;
-        self.edit_name.clear();
-        self.edit_description.clear();
-        self.edit_kind = EditKind::Url;
-        self.edit_url.clear();
-        self.edit_exe.clear();
-        self.edit_args.clear();
-    }
-
-    fn open_create_from(&mut self, cmd: &InstantCommand) {
-        self.open = true;
-        self.mode = ModalMode::Create;
-        self.editing_index = None;
-        self.load_action(cmd);
-    }
-
-    fn open_edit(&mut self, index: usize, cmd: &InstantCommand) {
-        self.open = true;
-        self.mode = ModalMode::Edit;
-        self.editing_index = Some(index);
-        self.load_action(cmd);
-    }
-
-    fn load_action(&mut self, cmd: &InstantCommand) {
-        self.edit_name = cmd.name.clone();
-        self.edit_description = cmd.description.clone();
-        self.edit_url.clear();
-        self.edit_exe.clear();
-        self.edit_args.clear();
+impl InstantFields {
+    fn from_command(cmd: &InstantCommand) -> Self {
+        let mut fields = Self {
+            name: cmd.name.clone(),
+            description: cmd.description.clone(),
+            ..Self::default()
+        };
         match &cmd.action {
             InstantAction::Url { url } => {
-                self.edit_kind = EditKind::Url;
-                self.edit_url = url.clone();
+                fields.kind = EditKind::Url;
+                fields.url = url.clone();
             }
             InstantAction::Exec { exe, args } => {
-                self.edit_kind = EditKind::Program;
-                self.edit_exe = exe.clone();
-                self.edit_args = args.clone();
+                fields.kind = EditKind::Program;
+                fields.exe = exe.clone();
+                fields.args = args.clone();
             }
             InstantAction::Legacy { command } => {
-                self.edit_kind = EditKind::Url;
-                self.edit_url = command.clone();
+                fields.kind = EditKind::Url;
+                fields.url = command.clone();
             }
         }
-    }
-
-    fn close(&mut self) {
-        self.open = false;
-        self.editing_index = None;
+        fields
     }
 }
 
@@ -104,14 +63,8 @@ pub fn ui(
     tr: &Tr,
 ) {
     // Poll exe picker result（opener タブと同型の非同期ピッカーパターン）
-    if state.exe_picker.active
-        && let Ok(mut guard) = state.exe_picker.result.try_lock()
-        && let Some(result) = guard.take()
-    {
-        state.exe_picker.active = false;
-        if let Some(path) = result {
-            state.modal.edit_exe = path.display().to_string();
-        }
+    if let Some(Some(path)) = state.exe_picker.poll() {
+        state.modal.fields.exe = path.display().to_string();
     }
 
     style::tab_scroll_area(ui, |ui| {
@@ -202,12 +155,12 @@ pub fn ui(
         match action {
             Some(RowAction::OpenCreate) => state.modal.open_create(),
             Some(RowAction::Edit(i)) => {
-                let cmd = &config.instant_commands[i];
-                state.modal.open_edit(i, cmd);
+                let fields = InstantFields::from_command(&config.instant_commands[i]);
+                state.modal.open_edit(i, fields);
             }
             Some(RowAction::Duplicate(i)) => {
-                let cmd = &config.instant_commands[i];
-                state.modal.open_create_from(cmd);
+                let fields = InstantFields::from_command(&config.instant_commands[i]);
+                state.modal.open_create_with(fields);
             }
             Some(RowAction::MoveUp(i)) if i > 0 => {
                 config.instant_commands.swap(i, i - 1);
@@ -240,7 +193,7 @@ fn show_modal(
     state: &mut InstantTabState,
     tr: &Tr,
 ) {
-    let title = if state.modal.mode == ModalMode::Edit {
+    let title = if state.modal.is_edit() {
         tr.modal_edit_instant()
     } else {
         tr.modal_add_instant()
@@ -253,14 +206,14 @@ fn show_modal(
 
         // Name
         ui.label(tr.label_instant_name());
-        ui.text_edit_singleline(&mut state.modal.edit_name);
+        ui.text_edit_singleline(&mut state.modal.fields.name);
         style::hint(ui, tr.hint_instant_name());
 
         ui.add_space(style::SPACE_HINT);
 
         // Description
         ui.label(tr.label_instant_description());
-        ui.text_edit_singleline(&mut state.modal.edit_description);
+        ui.text_edit_singleline(&mut state.modal.fields.description);
         style::hint(ui, tr.hint_instant_description());
 
         ui.add_space(style::SPACE_HINT);
@@ -268,23 +221,23 @@ fn show_modal(
         // Kind
         ui.label(tr.label_instant_kind());
         ui.horizontal(|ui| {
-            ui.radio_value(&mut state.modal.edit_kind, EditKind::Url, tr.radio_instant_url());
+            ui.radio_value(&mut state.modal.fields.kind, EditKind::Url, tr.radio_instant_url());
             ui.radio_value(
-                &mut state.modal.edit_kind,
+                &mut state.modal.fields.kind,
                 EditKind::Program,
                 tr.radio_instant_program(),
             );
         });
         ui.add_space(style::SPACE_HINT);
 
-        match state.modal.edit_kind {
+        match state.modal.fields.kind {
             EditKind::Url => {
                 ui.label(tr.label_instant_command());
-                ui.text_edit_singleline(&mut state.modal.edit_url);
+                ui.text_edit_singleline(&mut state.modal.fields.url);
                 style::hint(ui, tr.hint_instant_command());
-                if !state.modal.edit_url.is_empty() {
+                if !state.modal.fields.url.is_empty() {
                     let preview = snotra_core::instant::expand_instant_command(
-                        &state.modal.edit_url,
+                        &state.modal.fields.url,
                         "example",
                         "(clipboard)",
                     );
@@ -296,41 +249,36 @@ fn show_modal(
             EditKind::Program => {
                 ui.label(tr.label_instant_exe());
                 ui.horizontal(|ui| {
-                    ui.text_edit_singleline(&mut state.modal.edit_exe);
+                    ui.text_edit_singleline(&mut state.modal.fields.exe);
                     if ui
                         .add_enabled(!state.exe_picker.active, egui::Button::new(tr.btn_browse()))
                         .clicked()
                     {
-                        state.exe_picker.active = true;
-                        let result = Arc::clone(&state.exe_picker.result);
-                        let repaint_ctx = ctx.clone();
                         let dialog_title = tr.dialog_select_exe().to_string();
                         let exe_label = tr.filter_executables().to_string();
                         let all_label = tr.filter_all_files().to_string();
-                        std::thread::spawn(move || {
+                        state.exe_picker.launch(ctx, move || {
                             // exe を既定フィルタで誘導しつつ、全ファイル選択も許す（.com/拡張子なし/cmd.exe 等）。
                             // 最初の add_filter が既定フィルタになる（rfd 0.17 の set_default_extension）。
-                            let path = rfd::FileDialog::new()
+                            rfd::FileDialog::new()
                                 .set_title(&dialog_title)
                                 .add_filter(&exe_label, &["exe"])
                                 .add_filter(&all_label, &["*"])
-                                .pick_file();
-                            *result.lock().unwrap() = Some(path);
-                            repaint_ctx.request_repaint();
+                                .pick_file()
                         });
                     }
                 });
                 ui.label(tr.label_instant_args());
-                ui.text_edit_singleline(&mut state.modal.edit_args);
+                ui.text_edit_singleline(&mut state.modal.fields.args);
                 style::hint(ui, tr.hint_instant_program());
-                if !state.modal.edit_exe.is_empty() {
+                if !state.modal.fields.exe.is_empty() {
                     let tokens = snotra_core::instant::expand_exec_args(
-                        &state.modal.edit_args,
+                        &state.modal.fields.args,
                         "example",
                         "(clipboard)",
                         |s| s.to_string(),
                     );
-                    let preview = format!("{} {}", state.modal.edit_exe, tokens.join(" "));
+                    let preview = format!("{} {}", state.modal.fields.exe, tokens.join(" "));
                     ui.add_space(style::SPACE_HINT);
                     ui.label(tr.label_instant_preview());
                     style::hint(ui, preview.trim());
@@ -343,13 +291,8 @@ fn show_modal(
 
         ui.horizontal(|ui| {
             // Delete (edit mode only)
-            if state.modal.mode == ModalMode::Edit && style::danger_button(ui, tr.btn_delete()).clicked()
-            {
-                if let Some(idx) = state.modal.editing_index
-                    && idx < config.instant_commands.len()
-                {
-                    config.instant_commands.remove(idx);
-                }
+            if state.modal.is_edit() && style::danger_button(ui, tr.btn_delete()).clicked() {
+                common::delete_entry(&mut config.instant_commands, state.modal.editing);
                 state.modal.close();
             }
 
@@ -369,25 +312,18 @@ fn show_modal(
     }
 }
 
-fn save_instant_command(config: &mut Config, modal: &ModalState) {
-    let action = match modal.edit_kind {
-        EditKind::Url => InstantAction::Url { url: modal.edit_url.clone() },
+fn save_instant_command(config: &mut Config, modal: &ModalState<InstantFields>) {
+    let action = match modal.fields.kind {
+        EditKind::Url => InstantAction::Url { url: modal.fields.url.clone() },
         EditKind::Program => InstantAction::Exec {
-            exe: modal.edit_exe.clone(),
-            args: modal.edit_args.clone(),
+            exe: modal.fields.exe.clone(),
+            args: modal.fields.args.clone(),
         },
     };
     let cmd = InstantCommand {
-        name: modal.edit_name.clone(),
-        description: modal.edit_description.clone(),
+        name: modal.fields.name.clone(),
+        description: modal.fields.description.clone(),
         action,
     };
-
-    if let Some(idx) = modal.editing_index {
-        if idx < config.instant_commands.len() {
-            config.instant_commands[idx] = cmd;
-        }
-    } else {
-        config.instant_commands.push(cmd);
-    }
+    common::save_entry(&mut config.instant_commands, modal.editing, cmd);
 }

--- a/snotra-settings/src/tabs/mod.rs
+++ b/snotra-settings/src/tabs/mod.rs
@@ -1,4 +1,5 @@
 pub mod backup;
+pub mod common;
 pub mod general;
 pub mod index;
 pub mod instant;

--- a/snotra-settings/src/tabs/opener.rs
+++ b/snotra-settings/src/tabs/opener.rs
@@ -1,29 +1,22 @@
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
-
 use eframe::egui;
 use snotra_core::config::{self, extract_path_condition, opener_specificity_order, Config, OpenerRule, OpenerTool};
 
 use crate::i18n::Tr;
 use crate::style;
-
-/// Non-blocking file picker state for exe selection
-#[derive(Clone, Default)]
-pub struct ExePickerState {
-    pub result: Arc<Mutex<Option<Option<PathBuf>>>>,
-    pub active: bool,
-}
+use crate::tabs::common::{ModalState, PickerState};
 
 pub struct OpenerTabState {
-    pub exe_picker: ExePickerState,
-    modal: ModalState,
+    pub exe_picker: PickerState,
+    /// ネストした `(rule_idx, tool_idx)` を編集スナップショットに持つ（フラットリストの
+    /// index / instant と異なり、Save/Delete の境界チェックは opener 固有ロジックで行う）。
+    modal: ModalState<OpenerFields, (usize, usize)>,
     presets: Vec<config::OpenerPreset>,
 }
 
 impl OpenerTabState {
     pub fn new() -> Self {
         Self {
-            exe_picker: ExePickerState::default(),
+            exe_picker: PickerState::default(),
             modal: ModalState::default(),
             presets: config::detect_opener_presets(),
         }
@@ -37,79 +30,41 @@ enum TargetKind {
     Extension,
 }
 
+/// オープナーモーダルのタブ固有編集フィールド。
 #[derive(Default)]
-struct ModalState {
-    open: bool,
-    mode: ModalMode,
-    editing_rule: Option<usize>,
-    editing_tool: Option<usize>,
-    edit_target_kind: TargetKind,
-    edit_target_ext: String,
-    edit_target_path: String,
-    edit_tool_name: String,
-    edit_tool_exe: String,
-    edit_tool_args: String,
+struct OpenerFields {
+    target_kind: TargetKind,
+    target_ext: String,
+    target_path: String,
+    tool_name: String,
+    tool_exe: String,
+    tool_args: String,
 }
 
-#[derive(Default, PartialEq)]
-enum ModalMode {
-    #[default]
-    Create,
-    Edit,
-}
-
-impl ModalState {
-    fn open_create(&mut self) {
-        self.open = true;
-        self.mode = ModalMode::Create;
-        self.editing_rule = None;
-        self.editing_tool = None;
-        self.edit_target_kind = TargetKind::Folder;
-        self.edit_target_ext.clear();
-        self.edit_target_path.clear();
-        self.edit_tool_name.clear();
-        self.edit_tool_exe.clear();
-        self.edit_tool_args.clear();
-    }
-
-    fn open_edit(&mut self, rule_idx: usize, tool_idx: usize, rule: &OpenerRule, tool: &OpenerTool) {
-        self.open = true;
-        self.mode = ModalMode::Edit;
-        self.editing_rule = Some(rule_idx);
-        self.editing_tool = Some(tool_idx);
-        // パス条件の抽出
-        self.edit_target_path = extract_path_condition(&rule.target)
-            .unwrap_or("")
-            .to_string();
+impl OpenerFields {
+    fn from_rule_tool(rule: &OpenerRule, tool: &OpenerTool) -> Self {
+        let mut fields = Self {
+            // パス条件の抽出
+            target_path: extract_path_condition(&rule.target).unwrap_or("").to_string(),
+            tool_name: tool.name.clone(),
+            tool_exe: tool.exe.clone(),
+            tool_args: tool.args.clone(),
+            ..Self::default()
+        };
         if rule.target.starts_with("ext:") {
-            self.edit_target_kind = TargetKind::Extension;
-            self.edit_target_ext = config::extract_ext_part(&rule.target).to_string();
+            fields.target_kind = TargetKind::Extension;
+            fields.target_ext = config::extract_ext_part(&rule.target).to_string();
         } else {
-            self.edit_target_kind = TargetKind::Folder;
-            self.edit_target_ext.clear();
+            fields.target_kind = TargetKind::Folder;
         }
-        self.edit_tool_name = tool.name.clone();
-        self.edit_tool_exe = tool.exe.clone();
-        self.edit_tool_args = tool.args.clone();
-    }
-
-    fn close(&mut self) {
-        self.open = false;
-        self.editing_rule = None;
-        self.editing_tool = None;
+        fields
     }
 }
 
 pub fn ui(ui: &mut egui::Ui, ctx: &egui::Context, config: &mut Config, state: &mut OpenerTabState, tr: &Tr) {
     // Poll exe picker result
-    if state.exe_picker.active
-        && let Ok(mut guard) = state.exe_picker.result.try_lock()
-        && let Some(result) = guard.take()
-    {
-        state.exe_picker.active = false;
-        if let Some(path) = result {
-            state.modal.edit_tool_exe = path.display().to_string();
-        }
+    if let Some(Some(path)) = state.exe_picker.poll() {
+        state.modal.fields.tool_exe = path.display().to_string();
     }
 
     style::tab_scroll_area(ui, |ui| {
@@ -220,8 +175,8 @@ pub fn ui(ui: &mut egui::Ui, ctx: &egui::Context, config: &mut Config, state: &m
             Some(OpenerAction::OpenCreate) => state.modal.open_create(),
             Some(OpenerAction::Edit(ri, ti)) => {
                 let rule = &config.openers[ri];
-                let tool = &rule.tools[ti];
-                state.modal.open_edit(ri, ti, rule, tool);
+                let fields = OpenerFields::from_rule_tool(rule, &rule.tools[ti]);
+                state.modal.open_edit((ri, ti), fields);
             }
             Some(OpenerAction::MoveUp(ri, ti))
                 if ti > 0 && ri < config.openers.len() && ti < config.openers[ri].tools.len() =>
@@ -253,7 +208,7 @@ enum OpenerAction {
 }
 
 fn show_modal(ctx: &egui::Context, config: &mut Config, state: &mut OpenerTabState, tr: &Tr) {
-    let title = if state.modal.mode == ModalMode::Edit {
+    let title = if state.modal.is_edit() {
         tr.modal_edit_rule()
     } else {
         tr.modal_add_rule()
@@ -267,18 +222,18 @@ fn show_modal(ctx: &egui::Context, config: &mut Config, state: &mut OpenerTabSta
         // Target
         ui.label(tr.label_target());
         egui::ComboBox::from_id_salt("target_kind")
-            .selected_text(match state.modal.edit_target_kind {
+            .selected_text(match state.modal.fields.target_kind {
                 TargetKind::Folder => tr.target_kind_folder(),
                 TargetKind::Extension => tr.target_kind_extension(),
             })
             .show_ui(ui, |ui| {
-                ui.selectable_value(&mut state.modal.edit_target_kind, TargetKind::Folder, tr.target_kind_folder());
-                ui.selectable_value(&mut state.modal.edit_target_kind, TargetKind::Extension, tr.target_kind_extension());
+                ui.selectable_value(&mut state.modal.fields.target_kind, TargetKind::Folder, tr.target_kind_folder());
+                ui.selectable_value(&mut state.modal.fields.target_kind, TargetKind::Extension, tr.target_kind_extension());
             });
 
-        if state.modal.edit_target_kind == TargetKind::Extension {
+        if state.modal.fields.target_kind == TargetKind::Extension {
             ui.label(tr.label_extension());
-            ui.text_edit_singleline(&mut state.modal.edit_target_ext);
+            ui.text_edit_singleline(&mut state.modal.fields.target_ext);
             style::hint(ui, tr.hint_extension_format());
         }
 
@@ -286,37 +241,32 @@ fn show_modal(ctx: &egui::Context, config: &mut Config, state: &mut OpenerTabSta
 
         // Path condition (optional, applies to both folder and extension)
         ui.label(tr.label_path_condition());
-        ui.text_edit_singleline(&mut state.modal.edit_target_path);
+        ui.text_edit_singleline(&mut state.modal.fields.target_path);
         style::hint(ui, tr.hint_path_condition());
 
         ui.add_space(style::SPACE_HINT);
 
         // Tool name
         ui.label(tr.label_tool_name());
-        ui.text_edit_singleline(&mut state.modal.edit_tool_name);
+        ui.text_edit_singleline(&mut state.modal.fields.tool_name);
 
         ui.add_space(style::SPACE_HINT);
 
         // Tool exe + browse
         ui.label(tr.label_executable());
         ui.horizontal(|ui| {
-            ui.text_edit_singleline(&mut state.modal.edit_tool_exe);
+            ui.text_edit_singleline(&mut state.modal.fields.tool_exe);
             if ui
                 .add_enabled(!state.exe_picker.active, egui::Button::new(tr.btn_browse()))
                 .clicked()
             {
-                state.exe_picker.active = true;
-                let result = Arc::clone(&state.exe_picker.result);
-                let repaint_ctx = ctx.clone();
                 let dialog_title = tr.dialog_select_exe().to_string();
                 let filter_label = tr.filter_executables().to_string();
-                std::thread::spawn(move || {
-                    let path = rfd::FileDialog::new()
+                state.exe_picker.launch(ctx, move || {
+                    rfd::FileDialog::new()
                         .set_title(&dialog_title)
                         .add_filter(&filter_label, &["exe", "bat", "cmd"])
-                        .pick_file();
-                    *result.lock().unwrap() = Some(path);
-                    repaint_ctx.request_repaint();
+                        .pick_file()
                 });
             }
         });
@@ -325,7 +275,7 @@ fn show_modal(ctx: &egui::Context, config: &mut Config, state: &mut OpenerTabSta
 
         // Tool args
         ui.label(tr.label_arguments());
-        ui.text_edit_singleline(&mut state.modal.edit_tool_args);
+        ui.text_edit_singleline(&mut state.modal.fields.tool_args);
         style::hint(ui, tr.hint_path_placeholder());
 
         ui.add_space(style::SPACE_GROUP);
@@ -333,9 +283,8 @@ fn show_modal(ctx: &egui::Context, config: &mut Config, state: &mut OpenerTabSta
 
         ui.horizontal(|ui| {
             // Delete (edit mode only)
-            if state.modal.mode == ModalMode::Edit && style::danger_button(ui, tr.btn_delete()).clicked()
-            {
-                if let (Some(ri), Some(ti)) = (state.modal.editing_rule, state.modal.editing_tool)
+            if state.modal.is_edit() && style::danger_button(ui, tr.btn_delete()).clicked() {
+                if let Some((ri, ti)) = state.modal.editing
                     && ri < config.openers.len()
                     && ti < config.openers[ri].tools.len()
                 {
@@ -363,9 +312,9 @@ fn show_modal(ctx: &egui::Context, config: &mut Config, state: &mut OpenerTabSta
     }
 }
 
-fn save_opener(config: &mut Config, modal: &ModalState) {
-    let path_trimmed = modal.edit_target_path.trim();
-    let target = match modal.edit_target_kind {
+fn save_opener(config: &mut Config, modal: &ModalState<OpenerFields, (usize, usize)>) {
+    let path_trimmed = modal.fields.target_path.trim();
+    let target = match modal.fields.target_kind {
         TargetKind::Folder => {
             if path_trimmed.is_empty() {
                 "folder".to_string()
@@ -374,7 +323,7 @@ fn save_opener(config: &mut Config, modal: &ModalState) {
             }
         }
         TargetKind::Extension => {
-            let ext = modal.edit_target_ext.trim();
+            let ext = modal.fields.target_ext.trim();
             if path_trimmed.is_empty() {
                 format!("ext:{ext}")
             } else {
@@ -383,12 +332,12 @@ fn save_opener(config: &mut Config, modal: &ModalState) {
         }
     };
     let tool = OpenerTool {
-        name: modal.edit_tool_name.clone(),
-        exe: modal.edit_tool_exe.clone(),
-        args: modal.edit_tool_args.clone(),
+        name: modal.fields.tool_name.clone(),
+        exe: modal.fields.tool_exe.clone(),
+        args: modal.fields.tool_args.clone(),
     };
 
-    if let (Some(ri), Some(ti)) = (modal.editing_rule, modal.editing_tool) {
+    if let Some((ri, ti)) = modal.editing {
         // Edit existing
         if ri < config.openers.len() && ti < config.openers[ri].tools.len() {
             if config.openers[ri].target == target {


### PR DESCRIPTION
## 概要

snotra-settings の draft/saved モデル周辺に集積していた「手動列挙・二重管理・同型パターンの分散」を集約する（#439 の改善方向 1〜3）。

## 設計判断

### 1. Config セクション → TabId 対応の一元化（`app.rs`）

- `TabId::has_changes` の手書き match を `SECTION_TABLE`（`&[(TabId, fn(&Config, &Config) -> bool)]`、対応表 SSOT）からの導出に変更。General=hotkey+general、Visual=visual+appearance のような 1タブ:複数セクションは表の複数行で表現する
- Rust では「Config の全フィールドが表に載っている」ことを型だけでは強制できないため、issue の代替案どおりテストで担保:
  - `field_mutations()` が Config を **`..` なしで destructure** — 新フィールド追加はまずコンパイルエラーになり、mutation 一覧と表の更新を強制する
  - `section_table_covers_all_config_fields` — 全フィールドの mutation について「表の合成（いずれかのタブ点が点灯）⇔ 全体判定 `draft != saved`」の一致を検証

### 2. 正規化済み Config 不変条件（`snotra-core::Config::normalized_default()`）

- 「`Config::default()` + `apply_migrations()`」をモデル層の `normalized_default()` に封じ込め、`reset_to_default` の回避策コード + 警告コメントを削除。呼び忘れの余地が構造的に消える
- コンストラクタ（`Default::default()` 自体）での常時正規化は採用しない: `Option` sentinel（「TOML に明示されたか」の区別）は legacy キー移行の優先順位判定に必要で、`default()` を正規化すると `apply_migrations` の「新キー明示時は上書きしない」ロジックの前提が壊れるため、別名の関数として追加した

### 3. モーダル Create/Edit・非同期ピッカーのジェネリック化（`tabs/common.rs` 新設）

- `ModalState<F, I = usize>`（`F` = タブ固有フィールド struct、`I` = 編集スナップショット位置型）+ `ModalMode` + `open_create` / `open_create_with` / `open_edit` / `close` を共通化。opener はネストした `(usize, usize)` を `I` に指定
- `save_entry` / `delete_entry` が**インデックス陳腐化ガード（境界チェック）を内蔵** — 3タブに分散していた `if idx < vec.len()` が1箇所に集約
- `PickerState::poll()` / `launch()` が `try_lock → take → active=false` ポーリングとスレッド spawn + `request_repaint` を集約。**キャンセル時も `active=false` に戻す責務が `poll()` 1箇所になり**、既知の落とし穴（ボタン永久無効化）の再発余地が消えた。`index.rs` の `PickerState` と `opener.rs` の `ExePickerState`（同型定義の重複）も統合
- **egui の描画呼び出し列は不変**: 各タブの `show_modal` / リスト描画の `ui.xxx()` 構造は 1 行も並べ替えていない（diff は `state.modal.edit_xxx` → `state.modal.fields.xxx` の束縛パス変更のみ）

## 見送り項目

- **opener の Save/Delete 本体の共通化**: ネストした rule/tool 構造 + 「target 変更時は remove → add」のドメインロジックがフラットリスト用 `save_entry`/`delete_entry` と同型でないため、無理に抽象化せず opener 固有ロジックとして残した（境界チェック付きで従来どおり）
- **モーダル UI（描画部）の共通化**: 3タブのフィールド構成・プレビュー表示が異なり、抽出すると egui の描画順に影響しうるため issue の制約どおり見送り

## 検証結果

- `cargo check -p snotra-core -p snotra -p snotra-settings` — green
- `cargo clippy -p snotra-core -p snotra -p snotra-settings --all-targets -- -D warnings` — green
- `cargo test -p snotra-settings` — 28 passed（既存 backup 6件・font 5件を維持 + 新規 17件）
- `cargo test -p snotra-core` — 464 passed（新規 3件含む）

追加テスト名と検証した不変条件はコミットメッセージ参照（dirty 判定の網羅・正規化の冪等性・モーダル遷移と境界チェック・ピッカー active リセットの全パス）。

> **注記**: egui UI 構造には触れていないが、マージ後リリース前に視覚スモーク（`cargo run -p snotra-settings` で全タブ目視）を推奨。egui の欠陥は型チェック・clippy・ユニットテストを素通りし視覚スモークでのみ顕在化する（snotra-settings/CLAUDE.md）。

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)
