### PR TITLE
test(ui): ResultsSection / MainApp / invoke.ts のテスト追加（Blob URL ライフサイクル等の回帰検知）

### DIFF
--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -78,6 +78,9 @@ vi.mock("../stores/search", () => ({ fn1: mockFn1, fn2: mockFn2 }));
 
 - `SearchWindow.test.tsx` が基盤実装。新しいコンポーネントテストはこのパターンを踏襲する
 - Tauri API（`@tauri-apps/api/window`, `@tauri-apps/api/event`）は空モックで無害化
+- **自動 cleanup は登録されない（vitest globals 無効のため）**: `@solidjs/testing-library` の auto-cleanup はグローバル `afterEach` に依存する。明示的に `afterEach(() => cleanup())` を書かないと、前のテストのコンポーネントがシグナル購読を持ったまま残り、後続テストのシグナル更新に反応してモック呼び出し回数を汚染する（`ResultsSection.test.tsx` で実証済み）
+- **effect の再実行を検証するテストではストアモックに実シグナルを使う**: `vi.fn(() => value)` の静的モックでは購読が発生せず effect が再実行されない。`vi.mock` の async ファクトリ内で `createSignal` を作り、setter を `__setResults` 等の名前で一緒に export してテストから駆動する（`ResultsSection.test.tsx` が基盤実装）
+- **コンポーネント境界の配線テストは子コンポーネントを props 捕捉モックにする**: 親（`MainApp` 等）のハンドラ配線・props 導出を検証するとき、子を `(props) => { captured = props; return null; }` でモックすると、jsdom 描画に依存せず「どの props / コールバックが渡ったか」を直接アサートできる（`MainApp.test.tsx` が基盤実装。Solid の props は getter なので捕捉後も live 値を返す）
 - **導出アクセサ（`viewKind`/`interpKind` 等）のモックは下位シグナルモックから導出させる**: ストアが既存シグナルから導出する派生アクセサを追加したとき、そのモックを下位シグナルモック（`mockToolSelectionState` 等）を読む実装（`vi.fn(() => mockToolSelectionState() ? ... : ...)`）にすると、既存テストが下位シグナルを set するだけで派生も追従し、テスト本体を書き換えずに緑を維持できる。`vi.clearAllMocks()` は `vi.fn(impl)` の実装を保持するため、`beforeEach` で下位モックを再設定すれば導出モックも最新値を反映する
 
 ## 実装パターン

--- a/ui/src/MainApp.test.tsx
+++ b/ui/src/MainApp.test.tsx
@@ -1,0 +1,208 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@solidjs/testing-library";
+import type { ResultsSectionProps } from "./components/ResultsSection";
+
+// ── ブラウザ API スタブ + モック関数宣言（vi.hoisted でモジュールロード前に実行） ──
+const {
+  mockActivateSelectedByIndex, mockSetSelected, mockResetForShow,
+  mockInitIndexingState, mockSetHotkeyFailureNotice, mockShouldShowResults,
+  mockInterpKind, mockSetInstantCommandPrefix, mockHideMainWindow,
+  mockGetBootstrapPayload, mockSetSize,
+} = vi.hoisted(() => {
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    cb(0);
+    return 0;
+  }) as typeof requestAnimationFrame;
+  globalThis.cancelAnimationFrame = (() => {}) as typeof cancelAnimationFrame;
+
+  return {
+    mockActivateSelectedByIndex: vi.fn(async (_i: number) => true),
+    mockSetSelected: vi.fn(),
+    mockResetForShow: vi.fn(),
+    mockInitIndexingState: vi.fn(async () => () => {}),
+    mockSetHotkeyFailureNotice: vi.fn(),
+    mockShouldShowResults: vi.fn(() => true),
+    mockInterpKind: vi.fn((): "plain" | "command" | "instant" => "plain"),
+    mockSetInstantCommandPrefix: vi.fn(),
+    mockHideMainWindow: vi.fn(async () => {}),
+    mockGetBootstrapPayload: vi.fn(),
+    mockSetSize: vi.fn(async () => {}),
+  };
+});
+
+// ── 子コンポーネントモック ──
+// ResultsSection の props を捕捉し、MainApp が配線する onClickResult /
+// onDoubleClickResult / visible を「コンポーネント境界の契約」としてテストする。
+let capturedProps: ResultsSectionProps | undefined;
+vi.mock("./components/ResultsSection", () => ({
+  default: (props: ResultsSectionProps) => {
+    capturedProps = props;
+    return null;
+  },
+}));
+vi.mock("./components/SearchWindow", () => ({ default: () => null }));
+vi.mock("./components/UpdateToast", () => ({ default: () => null }));
+
+// ── stores/search モック ──
+vi.mock("./stores/search", () => ({
+  resetForShow: mockResetForShow,
+  setSelected: mockSetSelected,
+  activateSelectedByIndex: mockActivateSelectedByIndex,
+  initIndexingState: mockInitIndexingState,
+  setHotkeyFailureNotice: mockSetHotkeyFailureNotice,
+  shouldShowResults: mockShouldShowResults,
+  interpKind: mockInterpKind,
+  setInstantCommandPrefix: mockSetInstantCommandPrefix,
+}));
+
+// ── 外部依存モック ──
+vi.mock("./lib/commands", () => ({ hideMainWindow: mockHideMainWindow }));
+vi.mock("./lib/theme", () => ({ applyTheme: vi.fn() }));
+vi.mock("./lib/i18n", () => ({
+  t: (key: string) => key,
+  setLanguage: vi.fn(),
+}));
+vi.mock("./lib/invoke", () => ({
+  getBootstrapPayload: mockGetBootstrapPayload,
+  notifyMainShown: vi.fn(async () => {}),
+  saveSearchPlacement: vi.fn(async () => {}),
+  quitApp: vi.fn(async () => {}),
+}));
+vi.mock("./lib/trace", () => ({ trace: vi.fn() }));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    isVisible: async () => true,
+    scaleFactor: async () => 1,
+    innerSize: async () => ({ toLogical: () => ({ width: 600, height: 52 }) }),
+    onResized: async () => () => {},
+    onMoved: async () => () => {},
+    onFocusChanged: async () => () => {},
+    setSize: mockSetSize,
+    show: vi.fn(async () => {}),
+  }),
+}));
+vi.mock("@tauri-apps/api/dpi", () => ({
+  LogicalSize: class {
+    constructor(public width: number, public height: number) {}
+  },
+}));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async () => () => {}),
+}));
+
+// ── モック確立後にインポート ──
+import MainApp from "./MainApp";
+import type { BootstrapPayload } from "./lib/types";
+
+// auto_update: "disabled" で plugin-updater の動的 import を回避する
+const BOOTSTRAP: BootstrapPayload = {
+  visual: {
+    preset: "dark",
+    background_color: "#000",
+    input_background_color: "#111",
+    text_color: "#fff",
+    selected_row_color: "#333",
+    hint_text_color: "#888",
+    font_family: "Segoe UI",
+    font_size: 15,
+  },
+  general: { auto_hide_on_focus_lost: false, auto_update: "disabled" },
+  appearance: { show_icons: true, visible_rows: 8 },
+  language: "ja",
+  indexing: false,
+  instant_command_prefix: "@",
+  result_limit: 200,
+};
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function renderMainApp() {
+  const rendered = render(() => <MainApp />);
+  // onMount の直列 await（listen 登録 → isVisible → bootstrap）を流し切る
+  await tick();
+  await tick();
+  return rendered;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  capturedProps = undefined;
+  mockGetBootstrapPayload.mockResolvedValue(BOOTSTRAP);
+  mockActivateSelectedByIndex.mockResolvedValue(true);
+  mockShouldShowResults.mockReturnValue(true);
+  mockInterpKind.mockReturnValue("plain");
+});
+
+afterEach(() => {
+  // vitest globals が無効のため testing-library の自動 cleanup は登録されない（明示 unmount）
+  cleanup();
+});
+
+describe("MainApp handleClickResult（launched 分岐）", () => {
+  it("起動成功: activateSelectedByIndex(index) → hideMainWindow + visible が false になる", async () => {
+    await renderMainApp();
+    expect(capturedProps).toBeDefined();
+    // 初期状態: isVisible=true + shouldShowResults=true → visible
+    expect(capturedProps!.visible).toBe(true);
+
+    capturedProps!.onClickResult(2);
+    await tick();
+
+    expect(mockActivateSelectedByIndex).toHaveBeenCalledWith(2);
+    expect(mockHideMainWindow).toHaveBeenCalledTimes(1);
+    // mainVisible=false へ即時リセット（Blob URL の hide 前解放経路）
+    expect(capturedProps!.visible).toBe(false);
+  });
+
+  it("起動失敗: hideMainWindow は呼ばれず visible は維持、warn を出す", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockActivateSelectedByIndex.mockResolvedValue(false);
+    await renderMainApp();
+
+    capturedProps!.onClickResult(0);
+    await tick();
+
+    expect(mockActivateSelectedByIndex).toHaveBeenCalledWith(0);
+    expect(mockHideMainWindow).not.toHaveBeenCalled();
+    expect(capturedProps!.visible).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith("Failed to launch clicked result", { index: 0 });
+    warnSpy.mockRestore();
+  });
+
+  it("ダブルクリック: setSelected(index) のみ（起動しない）", async () => {
+    await renderMainApp();
+
+    capturedProps!.onDoubleClickResult(3);
+    await tick();
+
+    expect(mockSetSelected).toHaveBeenCalledWith(3);
+    expect(mockActivateSelectedByIndex).not.toHaveBeenCalled();
+    expect(mockHideMainWindow).not.toHaveBeenCalled();
+  });
+});
+
+describe("MainApp → ResultsSection props 配線", () => {
+  it("bootstrap の値が maxResults / iconCacheSize / showIcons に反映される", async () => {
+    mockGetBootstrapPayload.mockResolvedValue({
+      ...BOOTSTRAP,
+      appearance: { show_icons: false, visible_rows: 5 },
+      result_limit: 77,
+    });
+    await renderMainApp();
+
+    expect(capturedProps!.maxResults).toBe(5);
+    expect(capturedProps!.iconCacheSize).toBe(77);
+    expect(capturedProps!.showIcons).toBe(false);
+  });
+
+  it("interpKind=instant のとき skipIcons=true（IC モード中の取得抑制）", async () => {
+    mockInterpKind.mockReturnValue("instant");
+    await renderMainApp();
+
+    expect(capturedProps!.skipIcons).toBe(true);
+  });
+});

--- a/ui/src/components/ResultsSection.test.tsx
+++ b/ui/src/components/ResultsSection.test.tsx
@@ -1,0 +1,289 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+
+// ── ブラウザ API スタブ + モック関数宣言（vi.hoisted でモジュールロード前に実行） ──
+// requestAnimationFrame は同期実行スタブ: アイコン取得 effect の RAF スケジュールを
+// テスト内で決定的に進めるため（実行は fetchIcons 内の await で必ず一時停止する）。
+const { mockGetIconsBatch, mockParseBinaryBatch, createdUrls, revokedUrls } = vi.hoisted(() => {
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    cb(0);
+    return 0;
+  }) as typeof requestAnimationFrame;
+  globalThis.cancelAnimationFrame = (() => {}) as typeof cancelAnimationFrame;
+
+  const createdUrls: string[] = [];
+  const revokedUrls: string[] = [];
+  return {
+    mockGetIconsBatch: vi.fn<(paths: string[]) => Promise<ArrayBuffer>>(),
+    // 実 parseBinaryBatch と同じ契約: 要求パスごとに URL.createObjectURL で Blob URL を生成
+    mockParseBinaryBatch: vi.fn((_buf: ArrayBuffer, paths: string[]) => {
+      const map = new Map<string, string>();
+      for (const p of paths) {
+        map.set(p, URL.createObjectURL(new Blob([])));
+      }
+      return map;
+    }),
+    createdUrls,
+    revokedUrls,
+  };
+});
+
+// ── stores/search モック ──
+// ResultsSection は results / selected をリアクティブに購読するため、実 SolidJS シグナルで
+// モックする（vi.fn の静的モックでは effect が再実行されない）。
+vi.mock("../stores/search", async () => {
+  const { createSignal } = await import("solid-js");
+  const [results, setResults] = createSignal<import("../lib/types").SearchResult[]>([]);
+  const [selected, setSelected] = createSignal(0);
+  return {
+    results,
+    selected,
+    getSearchGeneration: () => 0,
+    __setResults: setResults,
+    __setSelected: setSelected,
+  };
+});
+
+// ── 外部依存モック ──
+vi.mock("../lib/invoke", () => ({ getIconsBatch: mockGetIconsBatch }));
+vi.mock("../lib/iconBatch", () => ({ parseBinaryBatch: mockParseBinaryBatch }));
+vi.mock("../lib/perf", () => ({ perfMarkRenderDone: vi.fn() }));
+vi.mock("../lib/truncatePath", () => ({
+  truncatePath: (path: string) => path,
+  clearTruncateCaches: vi.fn(),
+}));
+vi.mock("../lib/i18n", () => ({ t: (key: string) => key }));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async () => () => {}),
+}));
+
+// ── モック確立後にインポート ──
+import ResultsSection from "./ResultsSection";
+import * as searchStore from "../stores/search";
+import type { SearchResult } from "../lib/types";
+
+const setResults = (searchStore as unknown as {
+  __setResults: (items: SearchResult[]) => void;
+}).__setResults;
+const setSelected = (searchStore as unknown as {
+  __setSelected: (i: number) => void;
+}).__setSelected;
+
+// ── ヘルパー ──────────────────────────────────────────────────────────────────
+
+function makeResult(path: string): SearchResult {
+  return { name: path.split("\\").pop() ?? path, path, isFolder: false, isError: false };
+}
+
+const RESULTS_A = [makeResult("C:\\a1.exe"), makeResult("C:\\a2.exe")];
+const RESULTS_B = [makeResult("C:\\b1.exe"), makeResult("C:\\b2.exe")];
+
+/** マイクロタスク + macrotask を1周させて await 済みの継続を流す */
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/** getIconsBatch を手動 resolve 制御にする。呼び出しごとの resolver を返す */
+function deferIconsBatch(): Array<(buf: ArrayBuffer) => void> {
+  const resolvers: Array<(buf: ArrayBuffer) => void> = [];
+  mockGetIconsBatch.mockImplementation(
+    () => new Promise<ArrayBuffer>((resolve) => resolvers.push(resolve)),
+  );
+  return resolvers;
+}
+
+interface SetupOptions {
+  visible?: boolean;
+  showIcons?: boolean;
+  skipIcons?: boolean;
+  iconCacheSize?: number;
+}
+
+function setup(opts: SetupOptions = {}) {
+  const [visible, setVisible] = createSignal(opts.visible ?? true);
+  const [showIcons, setShowIcons] = createSignal(opts.showIcons ?? true);
+  const [skipIcons, setSkipIcons] = createSignal(opts.skipIcons ?? false);
+  const [iconCacheSize, setIconCacheSize] = createSignal(opts.iconCacheSize ?? 200);
+  const rendered = render(() => (
+    <ResultsSection
+      visible={visible()}
+      showIcons={showIcons()}
+      skipIcons={skipIcons()}
+      maxResults={8}
+      iconCacheSize={iconCacheSize()}
+      onClickResult={() => {}}
+      onDoubleClickResult={() => {}}
+    />
+  ));
+  return { ...rendered, setVisible, setShowIcons, setSkipIcons, setIconCacheSize };
+}
+
+function imgSrcs(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll("img")).map((img) => img.src);
+}
+
+// ── セットアップ ──────────────────────────────────────────────────────────────
+
+beforeAll(() => {
+  // jsdom 未実装 API のスタブ
+  Element.prototype.scrollIntoView = vi.fn();
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+
+  let urlCounter = 0;
+  URL.createObjectURL = vi.fn(() => {
+    const url = `blob:mock-${++urlCounter}`;
+    createdUrls.push(url);
+    return url;
+  });
+  URL.revokeObjectURL = vi.fn((url: string) => {
+    revokedUrls.push(url);
+  });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createdUrls.length = 0;
+  revokedUrls.length = 0;
+  setResults([]);
+  setSelected(0);
+  mockGetIconsBatch.mockResolvedValue(new ArrayBuffer(0));
+});
+
+afterEach(() => {
+  // vitest globals が無効のため testing-library の自動 cleanup は登録されない。
+  // 明示的に unmount しないと、前のテストのコンポーネントがシグナル購読を持ったまま残り、
+  // 後続テストの setResults に反応して getIconsBatch の呼び出し回数を汚染する。
+  cleanup();
+});
+
+// ── テスト ────────────────────────────────────────────────────────────────────
+
+describe("ResultsSection アイコンライフサイクル", () => {
+  it("results 到着でキャッシュ未取得パスのみ getIconsBatch が呼ばれ Blob URL が行に描画される", async () => {
+    setResults(RESULTS_A);
+    const { container } = setup();
+    await tick();
+
+    expect(mockGetIconsBatch).toHaveBeenCalledTimes(1);
+    expect(mockGetIconsBatch).toHaveBeenCalledWith(["C:\\a1.exe", "C:\\a2.exe"]);
+    expect(createdUrls).toHaveLength(2);
+    expect(imgSrcs(container)).toEqual(createdUrls);
+
+    // 同一 results の再取得は起きない（キャッシュ済みパスは missing から除外）
+    setSelected(1);
+    await tick();
+    expect(mockGetIconsBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("visible=false 遷移で revokeAll される（生成 URL がすべて revoke され img が消える）", async () => {
+    setResults(RESULTS_A);
+    const { container, setVisible } = setup();
+    await tick();
+    expect(createdUrls).toHaveLength(2);
+    expect(revokedUrls).toHaveLength(0);
+
+    setVisible(false);
+    await tick();
+
+    // 生成した全 Blob URL が回収される（リークなし不変条件）
+    expect([...revokedUrls].sort()).toEqual([...createdUrls].sort());
+    // 再表示時は再取得（キャッシュは破棄済み）
+    setVisible(true);
+    await tick();
+    expect(mockGetIconsBatch).toHaveBeenCalledTimes(2);
+    expect(imgSrcs(container)).toEqual(createdUrls.slice(2));
+  });
+
+  it("iconCacheSize 変更で revokeAll される（evict 済み URL の <img> 残留防止）", async () => {
+    setResults(RESULTS_A);
+    const { setIconCacheSize } = setup({ iconCacheSize: 200 });
+    await tick();
+    expect(createdUrls).toHaveLength(2);
+
+    setIconCacheSize(100);
+    await tick();
+
+    expect([...revokedUrls].sort()).toEqual([...createdUrls].sort());
+  });
+
+  it("stale ガード: 古い世代の応答は Blob URL を revoke して破棄し、キャッシュへ入れない", async () => {
+    const resolvers = deferIconsBatch();
+    setResults(RESULTS_A);
+    const { container } = setup();
+    expect(mockGetIconsBatch).toHaveBeenCalledTimes(1); // 世代1（A）が in-flight
+
+    // 応答前に results が変わり世代が進む
+    setResults(RESULTS_B);
+    expect(mockGetIconsBatch).toHaveBeenCalledTimes(2); // 世代2（B）も in-flight
+
+    // 古い世代1の応答が遅れて到着 → parse で生成された URL は即 revoke される
+    resolvers[0](new ArrayBuffer(0));
+    await tick();
+    const batch1Urls = createdUrls.slice(0, 2);
+    expect([...revokedUrls].sort()).toEqual([...batch1Urls].sort());
+    expect(imgSrcs(container)).toEqual([]);
+
+    // 現行世代2の応答は採用される
+    resolvers[1](new ArrayBuffer(0));
+    await tick();
+    const batch2Urls = createdUrls.slice(2, 4);
+    expect(imgSrcs(container)).toEqual(batch2Urls);
+    // 世代2の URL は revoke されていない
+    expect(revokedUrls).toHaveLength(2);
+  });
+
+  it("skipIcons=true 中は取得を抑制し、既存キャッシュは破棄しない", async () => {
+    setResults(RESULTS_A);
+    const { container, setSkipIcons } = setup();
+    await tick();
+    expect(mockGetIconsBatch).toHaveBeenCalledTimes(1);
+    const cachedUrls = [...createdUrls];
+
+    // skipIcons ON: 取得も破棄も起きない（IC モード中のキャッシュ保持）
+    setSkipIcons(true);
+    setResults(RESULTS_B);
+    await tick();
+    expect(mockGetIconsBatch).toHaveBeenCalledTimes(1);
+    expect(revokedUrls).toHaveLength(0);
+
+    // skipIcons OFF 復帰: 現在の results で取得再開、既存キャッシュは有効なまま
+    setSkipIcons(false);
+    await tick();
+    expect(mockGetIconsBatch).toHaveBeenCalledTimes(2);
+    expect(mockGetIconsBatch).toHaveBeenLastCalledWith(["C:\\b1.exe", "C:\\b2.exe"]);
+    expect(cachedUrls.every((u) => !revokedUrls.includes(u))).toBe(true);
+    void container;
+  });
+
+  it("unmount で revokeAll される（onCleanup の回収経路）", async () => {
+    setResults(RESULTS_A);
+    const { unmount } = setup();
+    await tick();
+    expect(createdUrls).toHaveLength(2);
+
+    unmount();
+
+    expect([...revokedUrls].sort()).toEqual([...createdUrls].sort());
+  });
+
+  it("取得できなかったパスは 2 回目以降の missing から除外される（fetchedNone）", async () => {
+    // parse 結果が空 = 全パス「アイコンなし」（Once: 他テストのデフォルト実装を汚さない）
+    mockParseBinaryBatch.mockImplementationOnce(() => new Map<string, string>());
+    setResults(RESULTS_A);
+    const { setSkipIcons } = setup();
+    await tick();
+    expect(mockGetIconsBatch).toHaveBeenCalledTimes(1);
+
+    // results 同一のまま skipIcons を往復 → fetchedNone 保持により再取得は 0 件で発火しない
+    setSkipIcons(true);
+    setSkipIcons(false);
+    await tick();
+    expect(mockGetIconsBatch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/lib/invoke.test.ts
+++ b/ui/src/lib/invoke.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Tauri invoke モック ────────────────────────────────────────────────────────
+// 目的: 各ラッパー関数が「正しいコマンド名 + 正しい引数キー」で invoke を呼ぶことを
+// 固定し、Rust 側 #[tauri::command] とのドリフト（改名・引数キー変更）を検知する。
+const { mockInvoke } = vi.hoisted(() => ({
+  mockInvoke: vi.fn(async (): Promise<unknown> => undefined),
+}));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: mockInvoke }));
+vi.mock("./trace", () => ({ trace: vi.fn() }));
+
+// ── モック確立後にインポート ──────────────────────────────────────────────────
+import * as api from "./invoke";
+
+beforeEach(() => {
+  mockInvoke.mockClear();
+  mockInvoke.mockResolvedValue(undefined);
+});
+
+// ── IPC 契約テーブル ──────────────────────────────────────────────────────────
+// command は Rust 側の関数名（snake_case）、args のキーは Rust 側引数の camelCase 版
+// （Tauri v2 は camelCase → snake_case を自動変換する）。
+// Rust 側でコマンドを改名・引数変更したら、このテーブルの期待値も同時に更新すること。
+const CONTRACT: Array<{
+  fn: string;
+  call: () => Promise<unknown>;
+  command: string;
+  args: Record<string, unknown> | undefined;
+}> = [
+  {
+    fn: "search",
+    call: () => api.search("firefox"),
+    command: "search",
+    args: { query: "firefox" },
+  },
+  {
+    fn: "getHistoryResults",
+    call: () => api.getHistoryResults(),
+    command: "get_history_results",
+    args: undefined,
+  },
+  {
+    fn: "launchItem",
+    call: () => api.launchItem("C:\\app.exe", "app"),
+    command: "launch_item",
+    args: { path: "C:\\app.exe", query: "app" },
+  },
+  {
+    fn: "listFolder",
+    call: () => api.listFolder("C:\\dir", "*.txt"),
+    command: "list_folder",
+    args: { dir: "C:\\dir", filter: "*.txt" },
+  },
+  {
+    fn: "getBootstrapPayload",
+    call: () => api.getBootstrapPayload(),
+    command: "get_bootstrap_payload",
+    args: undefined,
+  },
+  {
+    fn: "getIconsBatch",
+    call: () => api.getIconsBatch(["C:\\a.exe", "C:\\b.exe"]),
+    command: "get_icons_batch",
+    args: { paths: ["C:\\a.exe", "C:\\b.exe"] },
+  },
+  {
+    fn: "openSettings",
+    call: () => api.openSettings(),
+    command: "open_settings",
+    args: undefined,
+  },
+  {
+    fn: "saveSearchPlacement",
+    call: () => api.saveSearchPlacement(),
+    command: "save_search_placement",
+    args: undefined,
+  },
+  {
+    fn: "notifyMainShown",
+    call: () => api.notifyMainShown(),
+    command: "notify_main_shown",
+    args: undefined,
+  },
+  {
+    fn: "notifyMainHidden",
+    call: () => api.notifyMainHidden(),
+    command: "notify_main_hidden",
+    args: undefined,
+  },
+  {
+    fn: "getIndexingState",
+    call: () => api.getIndexingState(),
+    command: "get_indexing_state",
+    args: undefined,
+  },
+  {
+    fn: "rebuildIndex",
+    call: () => api.rebuildIndex(),
+    command: "rebuild_index",
+    args: undefined,
+  },
+  {
+    fn: "quitApp",
+    call: () => api.quitApp(),
+    command: "quit_app",
+    args: undefined,
+  },
+  {
+    fn: "recordFolderExpansion",
+    call: () => api.recordFolderExpansion("C:\\dir"),
+    command: "record_folder_expansion",
+    args: { path: "C:\\dir" },
+  },
+  {
+    fn: "getMatchingTools",
+    call: () => api.getMatchingTools("C:\\file.txt", false),
+    command: "get_matching_tools",
+    args: { path: "C:\\file.txt", isFolder: false },
+  },
+  {
+    fn: "launchWithTool",
+    call: () => api.launchWithTool("C:\\f.txt", "f", "C:\\tool.exe", "-a"),
+    command: "launch_with_tool",
+    args: { path: "C:\\f.txt", query: "f", toolExe: "C:\\tool.exe", toolArgs: "-a" },
+  },
+  {
+    fn: "getInstantCommands",
+    call: () => api.getInstantCommands("goo"),
+    command: "get_instant_commands",
+    args: { prefixInput: "goo" },
+  },
+  {
+    fn: "executeInstantCommand",
+    call: () => api.executeInstantCommand("google", "@google rust"),
+    command: "execute_instant_command",
+    args: { name: "google", query: "@google rust" },
+  },
+];
+
+describe("invoke.ts IPC 契約（コマンド名 + 引数キー）", () => {
+  for (const c of CONTRACT) {
+    it(`${c.fn} → invoke("${c.command}")`, async () => {
+      await c.call();
+
+      expect(mockInvoke).toHaveBeenCalledTimes(1);
+      if (c.args === undefined) {
+        expect(mockInvoke).toHaveBeenCalledWith(c.command, undefined);
+      } else {
+        expect(mockInvoke).toHaveBeenCalledWith(c.command, c.args);
+      }
+    });
+  }
+
+  it("契約テーブルは invoke.ts の公開ラッパーを網羅する（追加漏れ検知）", async () => {
+    // invoke.ts に新しいラッパーを追加したら CONTRACT にも行を追加すること。
+    const exported = Object.entries(api)
+      .filter(([, v]) => typeof v === "function")
+      .map(([k]) => k)
+      .sort();
+    const covered = CONTRACT.map((c) => c.fn).sort();
+    expect(exported).toEqual(covered);
+  });
+
+  it("invoke の解決値がそのまま返る（search）", async () => {
+    const items = [{ name: "a", path: "C:\\a", isFolder: false, isError: false }];
+    mockInvoke.mockResolvedValueOnce(items);
+
+    await expect(api.search("a")).resolves.toBe(items);
+  });
+
+  it("invoke の reject がそのまま伝播する", async () => {
+    mockInvoke.mockRejectedValueOnce(new Error("ipc down"));
+
+    await expect(api.search("a")).rejects.toThrow("ipc down");
+  });
+});


### PR DESCRIPTION
## 概要

ui/ の中で最もリークしやすい・複雑なロジック（Blob URL ライフサイクル・launched 分岐・IPC 契約）に回帰検知テストを追加する（#432）。**プロダクションコードの変更はゼロ**。

## 追加テスト（33件、全 green）

### `ui/src/components/ResultsSection.test.tsx`（7件）— アイコンライフサイクル

| テスト | 検証した不変条件 |
|---|---|
| results 到着でキャッシュ未取得パスのみ getIconsBatch | missing フィルタ（cache/fetchedNone 除外）と Blob URL の行描画 |
| visible=false 遷移で revokeAll | 生成した全 Blob URL の回収（CLAUDE.md「Blob URL 管理の不変条件」） |
| iconCacheSize 変更で revokeAll | evict 済み URL の `<img src="blob:revoked">` 残留防止 |
| stale ガード | 古い世代（`iconRequestId` ≠ `latestIconRequestId`）の応答は URL を即 revoke して破棄し、キャッシュへ入れない。現行世代は採用 |
| skipIcons=true 中は取得抑制・キャッシュ保持 | IC モード中の破棄なし + 復帰時に現在の results で取得再開 |
| unmount で revokeAll | onCleanup の回収経路 |
| fetchedNone 保持 | 「アイコンなし」確定パスは 2 回目以降の missing から除外 |

### `ui/src/MainApp.test.tsx`（5件）— handleClickResult / props 配線

| テスト | 検証した不変条件 |
|---|---|
| 起動成功 | `activateSelectedByIndex(index)` → `hideMainWindow` + `visible=false`（Blob URL の hide 前解放経路） |
| 起動失敗 | `hideMainWindow` は呼ばれず visible 維持 + `console.warn` |
| ダブルクリック | `setSelected(index)` のみ（起動しない・インデックス引数契約） |
| bootstrap 配線 | `visible_rows`→maxResults / `result_limit`→iconCacheSize / `show_icons`→showIcons |
| interpKind=instant | `skipIcons=true`（IC モード中の取得スキップ） |

### `ui/src/lib/invoke.test.ts`（21件）— IPC 契約

- 全 18 ラッパーの「コマンド名 + 引数キー」契約テーブル（Rust 側 `#[tauri::command]` とのドリフト検知が目的。`src-tauri/src/commands/*.rs` の関数名・引数と突き合わせ済み）
- 契約テーブルが `invoke.ts` の公開ラッパーを網羅することの検査（ラッパー追加時のテーブル追加漏れを検知）
- 解決値 passthrough / reject 伝播

## 抽出したプロダクションコード

**なし**。issue は「コンポーネント直接 render が困難な場合はフック抽出」としていたが、以下の 2 パターンで抽出なしに全項目をテストできたため、挙動変更リスクゼロの選択肢を採った:

1. **実シグナルによるストアモック**: `vi.mock` の async ファクトリ内で `createSignal` を作り setter を export。effect の再実行（stale ガード・revokeAll 遷移）を実コンポーネントで駆動できる
2. **子コンポーネントの props 捕捉モック**: `MainApp` テストで `ResultsSection` を `(props) => { captured = props; return null; }` にし、ハンドラ配線と props 導出を直接アサート

このため `createIconLifecycle` フック抽出は不要と判断（ResultsSection の描画構造・effect 発火順は当然無変更）。

## 発見事項（テスト基盤）

vitest globals 無効のため `@solidjs/testing-library` の auto-cleanup が登録されず、前のテストのコンポーネントがシグナル購読を持ったまま残り後続テストを汚染する事象を確認。明示 `afterEach(() => cleanup())` で解消し、`ui/CLAUDE.md` テスト基盤の注意点に上記 2 パターンと合わせて記録した。

## 見送り項目

- **MainApp の高さ計算 effect（`computeWindowHeight` 呼び出し側）の遷移テスト**: `shouldShowResults` はストアモック（非リアクティブ）のため effect の再発火遷移は検証できない。計算ロジック自体は既存 `windowHeight.test.ts` が担保済みで、費用対効果からモック配線の複雑化を見送り。#431 の search.ts 分割でストアが注入可能になればリアクティブな遷移テストが書ける
- **MainApp の `onMount` リスナー 12 件の個別テスト**: `registerConfigListeners()` 等への抽出（issue の「改善の方向性」）はプロダクションコード変更を伴うため本 PR のスコープ外。#431 系の後続リファクタで対応

## 検証

- [x] `npm run typecheck` — pass
- [x] `npm test` — 195件（既存 162 + 新規 33）全 green
- [x] `npm run build` — 成功

Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)
