### PR TITLE
refactor(ui): stores/search.ts の責務分割と横断規約の集約

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -140,7 +140,7 @@ ui/src/
 
 - 純ロジック: `snotra-core/src/instant.rs` — 変数展開 `{query}` / `{clip}` / `{date:書式}` / `{uuid}`（修飾子パイプ `{name | lower|upper|trim|default:x|raw}` 対応）+ `{{…}}` リテラルエスケープ + 前方一致フィルタ。date は strftime（不正書式は空文字でフォールバック＝panic 回避）、uuid は v4。`{{X}}` は literal `{X}`（変数名と衝突する literal の opt-out）。エンコードはシンク（種別）責務で URL 判定時に自動付与、`raw` で抑止。不明修飾子は `Config::validate` が保存時に拒否
 - IPC: `src-tauri/src/commands/instant.rs` — クリップボード読み取り + 種別分岐で実行（URL/Legacy は `expand_instant_command` → `launch_item_core`（ShellExecuteW）、Exec は `launch_exec_core`（exe + args 起動））
-- UI: `ui/src/stores/search.ts` — `interpKind()`（`query` + prefix からの純粋導出）でモード判定。query effect が instant コマンドの IPC 取得（getInstantCommands）を担う。indexing 中でも使用可能
+- UI: `ui/src/stores/search.ts` — `interpKind()`（`query` + prefix からの純粋導出）でモード判定。IPC 取得（getInstantCommands）は `stores/instantCommand.ts` の `scheduleInstantCommandFetch`（30ms デバウンス）に集約。indexing 中でも使用可能
 - 設定 GUI: `snotra-settings/src/tabs/instant.rs` — プレフィックス設定 + コマンド CRUD + 展開プレビュー
 - プレフィックス変更は `config_watcher.rs` が `instant-prefix-changed` イベントで UI に通知
 
@@ -185,7 +185,7 @@ sequenceDiagram
 
     SS->>SS: debouncedRefresh()<br/>setTimeout で leading+trailing 50ms
 
-    SS->>SS: refreshResults()<br/>searchGeneration++ (stale 検出用)
+    SS->>SS: refreshResults()<br/>nextGeneration() (stale 検出用)
     SS->>API: search(query)
     API->>Cmd: invoke("search", { query })
     Cmd->>Eng: engine.search(&query)

--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -17,9 +17,11 @@ SolidJS + TypeScript フロントエンド。Tauri IPC 経由で Rust バック�
 
 ### stores/
 
-- `search.ts`: 検索状態管理（クエリ/結果/選択/モード切替/`shouldShowResults` メモシグナル）。主要な公開関数: `resetForShow()`（window-shown 時の全状態リセット）、`refreshResults()`（ソースに応じた検索実行）、`initIndexingState()`（起動時のインデックス状態初期化 + `indexing-started` / `indexing-complete` リスナー登録）。`suppressNextQueryEffectRefresh` フラグで query effect の不要な再実行を抑制
-- `folder.ts`: フォルダモードの状態（`FolderFrame` シグナル + `folderFilter`）
-- `tool-selection.ts`: ツール選択モードの状態（`ToolSelectionFrame` シグナル）
+- `search.ts`: 検索状態管理（クエリ/結果/選択/モード切替/`shouldShowResults` メモシグナル）の調停役。主要な公開関数: `resetForShow()`（window-shown 時の全状態リセット）、`refreshResults()`（ソースに応じた検索実行）、`initIndexingState()`（起動時のインデックス状態初期化 + `indexing-started` / `indexing-complete` リスナー登録）。`suppressNextQueryEffectRefresh` フラグで query effect の不要な再実行を抑制。横断規約の choke point: `nextGeneration()`（`searchGeneration` 更新の唯一経路）、`withLaunchLifecycle()`（起動フロー三種の共通骨格）、`saveView()`/`restoreView()`（`SavedViewState` の退避/復元）、`allowsFolderNav()`（フォルダ展開・ツール選択遷移の許可述語、`viewKind`/`interpKind` 由来）。`instantCommand.ts`/`launchNotice.ts` を re-export し公開 API を単一箇所に保つ
+- `instantCommand.ts`: インスタントコマンド候補一覧の状態（`instantCommandItems`）と 30ms デバウンス IPC 取得（`scheduleInstantCommandFetch`）。`api`/`lib/types` のみに依存し `search.ts` へ逆依存しない（循環 import 回避）。staleness 判定・世代更新は呼び出し側が hooks（`nextRequestId`/`isStale`）で注入する
+- `launchNotice.ts`: 起動失敗・ホットキー失敗の一時通知（`launchNotice` シグナル + 自動クリアタイマー）。`notifyLaunchFailure`/`setLaunchNoticeWithAutoClear`/`setHotkeyFailureNotice`/`clearLaunchNotice` を提供
+- `folder.ts`: フォルダモードの状態（`FolderFrame` シグナル + `folderFilter`）。`FolderFrame` は `lib/types.ts` の `SavedViewState` を拡張
+- `tool-selection.ts`: ツール選択モードの状態（`ToolSelectionFrame` シグナル）。`ToolSelectionFrame` は `lib/types.ts` の `SavedViewState` を拡張
 
 ### lib/
 

--- a/ui/src/components/SearchWindow.test.tsx
+++ b/ui/src/components/SearchWindow.test.tsx
@@ -11,7 +11,7 @@ const {
   mockEnterToolSelection, mockActivateSelected, mockEnterFolderExpansion,
   mockNavigateFolderUp, mockMoveSelectionUp, mockMoveSelectionDown,
   mockSetQuery, mockSetFolderFilter, mockClearLaunchNotice,
-  mockHideMainWindow, mockViewKind, mockInterpKind,
+  mockHideMainWindow, mockViewKind, mockInterpKind, mockAllowsFolderNav,
 } = vi.hoisted(() => {
   globalThis.requestAnimationFrame = ((cb: Function) =>
     setTimeout(cb, 0)) as typeof requestAnimationFrame;
@@ -54,6 +54,8 @@ const {
       if (q.startsWith("/")) return "command";
       return "plain";
     }),
+    // 導出述語も下位軸モックから導出する（実装 allowsFolderNav() と同じ射影）
+    mockAllowsFolderNav: vi.fn((): boolean => mockViewKind() !== "tool" && mockInterpKind() !== "instant"),
   };
 });
 
@@ -84,6 +86,7 @@ vi.mock("../stores/search", () => ({
   noResults: mockNoResults,
   viewKind: mockViewKind,
   interpKind: mockInterpKind,
+  allowsFolderNav: mockAllowsFolderNav,
 }));
 
 // ── 外部依存モック ──

--- a/ui/src/components/SearchWindow.tsx
+++ b/ui/src/components/SearchWindow.tsx
@@ -24,7 +24,7 @@ import {
   toolSelectionState,
   noResults,
   viewKind,
-  interpKind,
+  allowsFolderNav,
 } from "../stores/search";
 import { hideMainWindow } from "../lib/commands";
 import { computeParentDir } from "../lib/folderNav";
@@ -186,8 +186,8 @@ const SearchWindow: Component = () => {
         break;
       case "ArrowRight": {
         trace("ui:key_action", { action: "arrow_right" });
-        // tool(軸1) と instant(軸2) は別軸ゆえ別条件で名指す。command は結果空で展開不能のため含めない
-        if (viewKind() === "tool" || interpKind() === "instant") break;
+        // 優先度の導出は allowsFolderNav() 側に集約済み（command は結果空で展開不能のため含めない）
+        if (!allowsFolderNav()) break;
         const r = results()[selected()];
         if (r?.isFolder) {
           enterFolderExpansion(r.path);
@@ -197,7 +197,7 @@ const SearchWindow: Component = () => {
       }
       case "ArrowLeft":
         trace("ui:key_action", { action: "arrow_left" });
-        if (viewKind() === "tool" || interpKind() === "instant") break;
+        if (!allowsFolderNav()) break;
         if (viewKind() === "folder") {
           navigateFolderUp();
           e.preventDefault();
@@ -214,7 +214,7 @@ const SearchWindow: Component = () => {
         break;
       case "Enter":
         trace("ui:key_action", { action: "enter", shift: e.shiftKey });
-        if (e.shiftKey && viewKind() !== "tool" && interpKind() !== "instant") {
+        if (e.shiftKey && allowsFolderNav()) {
           // Shift+Enter: ツール選択メニューを表示（0/1 ツール時は通常起動にフォールバック）
           const r = results()[selected()];
           if (r && !r.isError) {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -13,6 +13,16 @@ export interface OpenerTool {
   args: string;
 }
 
+/** モーダル的なビュー（フォルダ展開・ツール選択）が退避する「戻り先」の共通部分。
+ *  `search.ts` の `saveView()`/`restoreView()` が唯一の生成/復元経路（choke point）。
+ *  各 frame（`FolderFrame`/`ToolSelectionFrame`）はこれを拡張し、固有の追加フィールド
+ *  （`savedQuery` の意味はモードごとに異なる——folder は復元用、tool は起動時の元クエリ）
+ *  を持つ。 */
+export interface SavedViewState {
+  savedResults: SearchResult[];
+  savedSelected: number;
+}
+
 export interface VisualConfig {
   preset: string;
   background_color: string;

--- a/ui/src/stores/folder.ts
+++ b/ui/src/stores/folder.ts
@@ -1,10 +1,9 @@
 import { createSignal } from "solid-js";
-import type { SearchResult } from "../lib/types";
+import type { SavedViewState } from "../lib/types";
 
-export interface FolderFrame {
+export interface FolderFrame extends SavedViewState {
   currentDir: string;
-  savedResults: SearchResult[];
-  savedSelected: number;
+  /** フォルダモード離脱時に setQuery() で復元する検索欄の値（tool の savedQuery とは用途が異なる） */
   savedQuery: string;
 }
 

--- a/ui/src/stores/instantCommand.ts
+++ b/ui/src/stores/instantCommand.ts
@@ -1,0 +1,78 @@
+import type { InstantCommand, SearchResult } from "../lib/types";
+import * as api from "../lib/invoke";
+
+/** インスタントコマンド候補の IPC 取得デバウンス（高速タイピング時の不要な IPC を削減）。 */
+const INSTANT_CMD_DEBOUNCE_MS = 30;
+
+/** インスタントコマンドモード中のコマンド一覧（activateSelected 系が起動対象を解決するときに
+ *  参照する）。書き込みは本モジュールの関数（setInstantCommandItems/clearInstantCommandItems/
+ *  scheduleInstantCommandFetch 内部）に閉じ、search.ts からは直接代入しない。 */
+let instantCommandItems: InstantCommand[] = [];
+let instantCmdDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+export function getInstantCommandItems(): InstantCommand[] {
+  return instantCommandItems;
+}
+
+/** 失敗時のロールバック（executeInstantCommandSelected）用に候補一覧を差し替える。 */
+export function setInstantCommandItems(items: InstantCommand[]) {
+  instantCommandItems = items;
+}
+
+export function clearInstantCommandItems() {
+  instantCommandItems = [];
+}
+
+export function hasPendingInstantCommandFetch(): boolean {
+  return instantCmdDebounceTimer !== undefined;
+}
+
+/** 保留中の IPC デバウンスタイマーを破棄する（モード離脱・resetForShow 等で呼ぶ）。 */
+export function cancelInstantCommandDebounce() {
+  if (instantCmdDebounceTimer !== undefined) {
+    clearTimeout(instantCmdDebounceTimer);
+    instantCmdDebounceTimer = undefined;
+  }
+}
+
+/** インスタントコマンド候補の取得を 30ms デバウンスでスケジュールする唯一の経路（choke point）。
+ *  world 世代（searchGeneration）は search.ts 側の関心事のため、staleness 判定・世代更新は
+ *  呼び出し側が hooks 経由で担う（本モジュールは api/types にのみ依存し、search.ts への
+ *  逆依存を持たない——循環 import を避ける設計）。
+ *  IPC 応答前の Enter/クリックで古いコマンドを誤起動しないよう、呼び出し時点で即座に
+ *  候補一覧をクリアする。 */
+export function scheduleInstantCommandFetch(
+  filterName: string,
+  hooks: {
+    /** 世代を進めて今回のリクエスト ID を発行する（search.ts の nextGeneration）。 */
+    nextRequestId: () => number;
+    /** 応答到着時に world 世代が変わっていれば true（stale として破棄）。 */
+    isStale: (requestId: number) => boolean;
+    onFetched: (results: SearchResult[]) => void;
+    onError: (error: unknown) => void;
+  },
+): void {
+  instantCommandItems = [];
+  cancelInstantCommandDebounce();
+  instantCmdDebounceTimer = setTimeout(() => {
+    instantCmdDebounceTimer = undefined;
+    void (async () => {
+      const requestId = hooks.nextRequestId();
+      try {
+        const commands = await api.getInstantCommands(filterName);
+        if (hooks.isStale(requestId)) return;
+        instantCommandItems = commands;
+        const results: SearchResult[] = commands.map((cmd) => ({
+          name: cmd.name,
+          path: cmd.name,
+          isFolder: false,
+          isError: false,
+          description: cmd.description || cmd.display,
+        }));
+        hooks.onFetched(results);
+      } catch (e) {
+        hooks.onError(e);
+      }
+    })();
+  }, INSTANT_CMD_DEBOUNCE_MS);
+}

--- a/ui/src/stores/launchNotice.ts
+++ b/ui/src/stores/launchNotice.ts
@@ -1,0 +1,43 @@
+import { createSignal } from "solid-js";
+import type { LaunchResult } from "../lib/invoke";
+import { t } from "../lib/i18n";
+
+/** 起動失敗・ホットキー失敗などの一時通知（search-overlay に表示）。
+ *  自動クリアタイマーは本モジュールが一元管理する（唯一のタイマーハンドル）。 */
+const [launchNotice, setLaunchNotice] = createSignal<string | null>(null);
+let launchNoticeTimer: ReturnType<typeof setTimeout> | undefined;
+
+export function clearLaunchNotice() {
+  if (launchNoticeTimer !== undefined) {
+    clearTimeout(launchNoticeTimer);
+    launchNoticeTimer = undefined;
+  }
+  if (launchNotice() !== null) {
+    setLaunchNotice(null);
+  }
+}
+
+export function setLaunchNoticeWithAutoClear(message: string, delayMs = 2400) {
+  clearLaunchNotice();
+  setLaunchNotice(message);
+  launchNoticeTimer = setTimeout(() => {
+    launchNoticeTimer = undefined;
+    setLaunchNotice(null);
+  }, delayMs);
+}
+
+export function setHotkeyFailureNotice(message: string) {
+  setLaunchNoticeWithAutoClear(message, 5000);
+}
+
+/** LaunchResult の失敗/タイムアウトに応じた通知を表示する */
+export function notifyLaunchFailure(result: LaunchResult) {
+  const detail = result.message ? ` (${result.message})` : "";
+  if (result.status === "timeout") {
+    setLaunchNoticeWithAutoClear(t("notice.launch.timeout", { detail }));
+  } else {
+    setLaunchNoticeWithAutoClear(t("notice.launch.failed", { detail }));
+  }
+}
+
+export { launchNotice };

--- a/ui/src/stores/search.test.ts
+++ b/ui/src/stores/search.test.ts
@@ -49,6 +49,7 @@ import {
   shouldShowResults,
   viewKind,
   interpKind,
+  allowsFolderNav,
   toolSelectionState,
   launchNotice,
   clearLaunchNotice,
@@ -805,5 +806,34 @@ describe("interpKind", () => {
     setInstantCommandPrefix("");
     setQuery("@goo");
     expect(interpKind()).toBe("plain");
+  });
+});
+
+// ── allowsFolderNav（Phase 2: 複合条件の一本化） ──────────────────────────────
+
+describe("allowsFolderNav", () => {
+  it("通常モードでは true", () => {
+    expect(allowsFolderNav()).toBe(true);
+  });
+
+  it("folder モード中は true（フォルダ内でのさらなる展開・離脱は許可）", () => {
+    setFolderState(FOLDER_FRAME);
+    expect(allowsFolderNav()).toBe(true);
+  });
+
+  it("tool 選択中は false", () => {
+    setToolSelectionState(TOOL_FRAME);
+    expect(allowsFolderNav()).toBe(false);
+  });
+
+  it("instant コマンドモード中は false", () => {
+    setQuery("@goo");
+    expect(allowsFolderNav()).toBe(false);
+  });
+
+  it("tool が folder の上に積まれている場合も false（tool 優先）", () => {
+    setFolderState(FOLDER_FRAME);
+    setToolSelectionState(TOOL_FRAME);
+    expect(allowsFolderNav()).toBe(false);
   });
 });

--- a/ui/src/stores/search.ts
+++ b/ui/src/stores/search.ts
@@ -1,6 +1,6 @@
 import { createSignal, createEffect, createRoot, on, createMemo, batch } from "solid-js";
 import { listen } from "@tauri-apps/api/event";
-import type { InstantCommand, OpenerTool, SearchResult } from "../lib/types";
+import type { OpenerTool, SavedViewState, SearchResult } from "../lib/types";
 import * as api from "../lib/invoke";
 import { findCommand } from "../lib/commands";
 import { perfStartSearch, perfMarkSearchDone, perfCancelSearch } from "../lib/perf";
@@ -8,14 +8,21 @@ import { clampSelectedIndex, computeParentDir } from "../lib/folderNav";
 import { trace } from "../lib/trace";
 import { folderState, setFolderState, folderFilter, setFolderFilter } from "./folder";
 import { toolSelectionState, setToolSelectionState } from "./tool-selection";
-import { t } from "../lib/i18n";
+import { clearLaunchNotice, notifyLaunchFailure } from "./launchNotice";
+import {
+  getInstantCommandItems,
+  setInstantCommandItems,
+  clearInstantCommandItems,
+  hasPendingInstantCommandFetch,
+  cancelInstantCommandDebounce,
+  scheduleInstantCommandFetch,
+} from "./instantCommand";
 
 const [query, setQuery] = createSignal("");
 const [results, setResults] = createSignal<SearchResult[]>([]);
 const [selected, setSelected] = createSignal(0);
 const [indexing, setIndexing] = createSignal(false);
 const [launching, setLaunching] = createSignal(false);
-const [launchNotice, setLaunchNotice] = createSignal<string | null>(null);
 const [instantCommandPrefix, setInstantCommandPrefix] = createSignal("@");
 const [noResults, setNoResults] = createSignal(false);
 
@@ -33,20 +40,37 @@ function clearResults() {
   setSelected(0);
 }
 
-/** インスタントコマンドモード中のコマンド一覧（activateSelected で参照） */
-let instantCommandItems: InstantCommand[] = [];
+/** モーダル的なビュー（フォルダ展開・ツール選択）に入る直前の results/selected を退避する
+ *  唯一の生成経路（choke point）。frame 固有の追加フィールド（currentDir・savedQuery 等）は
+ *  呼び出し側でスプレッドして合成する。 */
+function saveView(): SavedViewState {
+  return { savedResults: results(), savedSelected: selected() };
+}
+
+/** saveView() で退避した results/selected を復元する唯一の経路（choke point）。
+ *  frame 固有のフィールド（savedQuery 等）の復元は意味が呼び出し側ごとに異なるため含まない
+ *  （folder は setQuery で復元、tool は復元せず起動時の元クエリとして使うのみ）。 */
+function restoreView(saved: SavedViewState) {
+  updateResults(saved.savedResults);
+  setSelected(saved.savedSelected);
+}
 
 const DEBOUNCE_MS = 50;
-const INSTANT_CMD_DEBOUNCE_MS = 30;
 let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 /** leading edge: デバウンス区間の最初の入力で即時発火済みなら true */
 let leadingFired = false;
-let instantCmdDebounceTimer: ReturnType<typeof setTimeout> | undefined;
-let launchNoticeTimer: ReturnType<typeof setTimeout> | undefined;
 let refreshInFlight: Promise<void> | undefined;
 let searchGeneration = 0;
 let activationInFlight = false;
 let suppressNextQueryEffectRefresh = false;
+
+/** 世代カウンタの唯一の更新経路（choke point）。呼ぶたびに `searchGeneration` を +1 して
+ *  新しい世代番号を返す。`searchGeneration` への書き込みはここだけを経由すること
+ *  ——手書きの `++searchGeneration` を各所に散在させると加算漏れ・重複が stale 表示バグに
+ *  直結する（#431）。読み取り（staleness チェック）は引き続き `searchGeneration` を直読してよい。 */
+function nextGeneration(): number {
+  return ++searchGeneration;
+}
 
 export type ViewKind = "results" | "folder" | "tool";
 export type InterpKind = "plain" | "command" | "instant";
@@ -77,6 +101,15 @@ const interpKind = createMemo<InterpKind>(() => {
   return "plain";
 });
 
+/** フォルダ展開（ArrowRight/Left）・ツール選択（Shift+Enter）という「新規モーダル遷移」を
+ *  許可するかの述語。tool 選択中（viewKind()==="tool"）または instant コマンドモード中
+ *  （interpKind()==="instant"）はいずれも遷移をブロックする——という優先度をここに集約し、
+ *  SearchWindow のキーハンドラはこれを消費するだけにする（複合条件を個別に再導出しない。
+ *  development-principles.md「優先度・排他律は導出源の一箇所だけに書く」#431）。 */
+function allowsFolderNav(): boolean {
+  return viewKind() !== "tool" && interpKind() !== "instant";
+}
+
 /** 結果を表示すべきかの派生シグナル。MainApp がリアクティブにウィンドウ高さを変更するために使用。
  *  tool/folder は indexing 中でも表示。results は instant 中のみ indexing を無視する。 */
 const shouldShowResults = createMemo(() => {
@@ -94,41 +127,8 @@ const shouldShowResults = createMemo(() => {
   }
 });
 
-function clearLaunchNotice() {
-  if (launchNoticeTimer !== undefined) {
-    clearTimeout(launchNoticeTimer);
-    launchNoticeTimer = undefined;
-  }
-  if (launchNotice() !== null) {
-    setLaunchNotice(null);
-  }
-}
-
-/** LaunchResult の失敗/タイムアウトに応じた通知を表示する */
-function notifyLaunchFailure(result: api.LaunchResult) {
-  const detail = result.message ? ` (${result.message})` : "";
-  if (result.status === "timeout") {
-    setLaunchNoticeWithAutoClear(t("notice.launch.timeout", { detail }));
-  } else {
-    setLaunchNoticeWithAutoClear(t("notice.launch.failed", { detail }));
-  }
-}
-
-export function setLaunchNoticeWithAutoClear(message: string, delayMs = 2400) {
-  clearLaunchNotice();
-  setLaunchNotice(message);
-  launchNoticeTimer = setTimeout(() => {
-    launchNoticeTimer = undefined;
-    setLaunchNotice(null);
-  }, delayMs);
-}
-
-export function setHotkeyFailureNotice(message: string) {
-  setLaunchNoticeWithAutoClear(message, 5000);
-}
-
 function clearCommandModeState() {
-  ++searchGeneration;
+  nextGeneration();
   setQuery("");
   clearResults();
 }
@@ -165,7 +165,7 @@ async function refreshResults() {
   if (viewKind() === "tool") return;
   if (interpKind() === "instant") return;
 
-  const requestId = ++searchGeneration;
+  const requestId = nextGeneration();
   const fs = folderState();
   const q = query();
   const trimmed = q.trim();
@@ -247,6 +247,69 @@ async function refreshResults() {
   perfMarkSearchDone(requestId, items.length);
 }
 
+/** instant コマンド入力のディスパッチ（interpKind()==="instant"）。30ms デバウンス IPC 取得は
+ *  stores/instantCommand.ts の choke point（scheduleInstantCommandFetch）に委譲し、ここでは
+ *  世代管理（staleness 判定用の hooks）と結果反映のみを担う。 */
+function handleInstantQueryInput(q: string) {
+  cancelDebounce();
+  const prefix = instantCommandPrefix();
+  // trimStart() を使用: trailing whitespace はクエリの一部として保持する
+  const trimmedStart = q.trimStart();
+  const input = trimmedStart.slice(prefix.length);
+  // スペースがあればコマンド名部分のみでフィルタ（SPEC §18.5: スペースでマッチング確定）
+  const spaceIdx = input.indexOf(" ");
+  const filterName = spaceIdx >= 0 ? input.slice(0, spaceIdx) : input;
+  trace("search:query_effect:instant_command", { prefix, input, filterName });
+  scheduleInstantCommandFetch(filterName, {
+    nextRequestId: nextGeneration,
+    isStale: (requestId) => requestId !== searchGeneration,
+    onFetched: (fetchedResults) => {
+      updateResults(fetchedResults);
+      setSelected(0);
+    },
+    onError: (e) => {
+      trace("search:instant_command:error", { error: String(e) });
+    },
+  });
+}
+
+/** スラッシュコマンド入力のディスパッチ（interpKind()==="command"）。"/r" は履歴の即時表示という
+ *  特例、それ以外は完全一致コマンドの実行 or 候補なしクリアに分岐する。 */
+function handleCommandQueryInput(q: string) {
+  const trimmed = q.trim();
+  if (trimmed === "/r") {
+    cancelDebounce();
+    setSelected(0);
+    trace("search:query_effect:immediate_refresh", { reason: "slash_r" });
+    void runRefresh();
+    return;
+  }
+
+  const cmd = findCommand(q);
+  if (cmd && cmd.command !== "/r") {
+    cancelDebounce();
+    trace("search:query_effect:run_command", { command: cmd.command });
+    clearCommandModeState();
+    cmd.action();
+    return;
+  }
+
+  // Command mode without exact match: no suggestions, just clear results.
+  cancelDebounce();
+  trace("search:query_effect:slash_noop", { input: q });
+  nextGeneration();
+  updateResults([]);
+  setSelected(0);
+}
+
+/** 通常クエリ入力のディスパッチ（interpKind()==="plain"）。leading+trailing デバウンスで
+ *  refreshResults() へ委譲する。 */
+function handlePlainQueryInput(q: string) {
+  setSelected(0);
+  trace("search:query_effect:debounced_refresh", { query: q });
+  debouncedRefresh();
+}
+
 createRoot(() => {
   // Auto-refresh when query changes (non-folder mode)
   createEffect(
@@ -265,92 +328,34 @@ createRoot(() => {
         trace("search:query_effect:ignored_folder_mode", { query: q });
         return;
       }
-      const trimmed = q.trim();
-      const prefix = instantCommandPrefix();
-      trace("search:query_effect", { query: q, trimmed });
+      trace("search:query_effect", { query: q, trimmed: q.trim() });
 
-      // インスタントコマンドモード判定（スラッシュコマンドより先に評価）
-      // trimStart() を使用: trailing whitespace はクエリの一部として保持する
-      const trimmedStart = q.trimStart();
-      if (isInstantPrefix(q, prefix)) {
-        cancelDebounce();
-        const input = trimmedStart.slice(prefix.length);
-        // スペースがあればコマンド名部分のみでフィルタ（SPEC §18.5: スペースでマッチング確定）
-        const spaceIdx = input.indexOf(" ");
-        const filterName = spaceIdx >= 0 ? input.slice(0, spaceIdx) : input;
-        trace("search:query_effect:instant_command", { prefix, input, filterName });
-        // IPC 応答前の Enter/クリックで古いコマンドを誤起動しないよう、先にクリアする
-        instantCommandItems = [];
-        // 高速タイピング時の不要な IPC を削減するため 30ms デバウンス
-        if (instantCmdDebounceTimer !== undefined) {
-          clearTimeout(instantCmdDebounceTimer);
-        }
-        instantCmdDebounceTimer = setTimeout(() => {
-          instantCmdDebounceTimer = undefined;
-          void (async () => {
-            const requestId = ++searchGeneration;
-            try {
-              const commands = await api.getInstantCommands(filterName);
-              if (requestId !== searchGeneration) return;
-              instantCommandItems = commands;
-              const items: SearchResult[] = commands.map((cmd) => ({
-                name: cmd.name,
-                path: cmd.name,
-                isFolder: false,
-                isError: false,
-                description: cmd.description || cmd.display,
-              }));
-              updateResults(items);
-              setSelected(0);
-            } catch (e) {
-              trace("search:instant_command:error", { error: String(e) });
-            }
-          })();
-        }, INSTANT_CMD_DEBOUNCE_MS);
+      // ディスパッチは interpKind() 経由（優先度の再導出はしない。development-principles.md
+      // 「優先度・排他律は導出源の一箇所だけに書く」#431 Phase3）。
+      const kind = interpKind();
+      if (kind === "instant") {
+        handleInstantQueryInput(q);
         return;
       }
 
       // プレフィックスなし → instant モードの保留 IPC / stale 候補を掃除する。
       // interpKind は query から純粋導出されるため「モード解除」自体は状態更新不要。
-      // 掃除すべき資源（pending timer / stale items）が現存するときだけ実行する（無ければ no-op）。
-      if (instantCmdDebounceTimer !== undefined || instantCommandItems.length > 0) {
-        if (instantCmdDebounceTimer !== undefined) {
-          clearTimeout(instantCmdDebounceTimer);
-          instantCmdDebounceTimer = undefined;
-        }
-        instantCommandItems = [];
+      // 掃除すべき資源（pending fetch / stale items）が現存するときだけ実行する（無ければ no-op）。
+      if (hasPendingInstantCommandFetch() || getInstantCommandItems().length > 0) {
+        cancelInstantCommandDebounce();
+        clearInstantCommandItems();
       }
 
-      if (trimmed === "/r") {
-        cancelDebounce();
-        setSelected(0);
-        trace("search:query_effect:immediate_refresh", { reason: "slash_r" });
-        void runRefresh();
-        return;
-      }
-
-      if (trimmed.startsWith("/")) {
-        const cmd = findCommand(q);
-        if (cmd && cmd.command !== "/r") {
-          cancelDebounce();
-          trace("search:query_effect:run_command", { command: cmd.command });
-          clearCommandModeState();
-          cmd.action();
+      switch (kind) {
+        case "command":
+          handleCommandQueryInput(q);
           return;
-        }
-
-        // Command mode without exact match: no suggestions, just clear results.
-        cancelDebounce();
-        trace("search:query_effect:slash_noop", { input: q });
-        ++searchGeneration;
-        updateResults([]);
-        setSelected(0);
-        return;
+        case "plain":
+          handlePlainQueryInput(q);
+          return;
+        default:
+          return assertNever(kind);
       }
-
-      setSelected(0);
-      trace("search:query_effect:debounced_refresh", { query: q });
-      debouncedRefresh();
     }),
   );
 
@@ -379,8 +384,7 @@ function enterFolderExpansion(dir: string) {
     // Save current state before entering folder mode
     setFolderState({
       currentDir: dir,
-      savedResults: results(),
-      savedSelected: selected(),
+      ...saveView(),
       savedQuery: query(),
     });
   } else {
@@ -400,9 +404,8 @@ function exitFolderExpansion(): boolean {
   // デバウンスタイマーをクリア（フォルダモード中の入力残り処理を防止）
   cancelDebounce();
 
-  ++searchGeneration;
-  updateResults(fs.savedResults);
-  setSelected(fs.savedSelected);
+  nextGeneration();
+  restoreView(fs);
   setFolderState(null);    // setQuery より先に null にする
   setFolderFilter("");
   setQuery(fs.savedQuery);
@@ -473,6 +476,35 @@ async function resolveActivationTarget(
 }
 
 
+/** 起動フローの共通骨格（choke point）。「通知クリア→launching→世代更新→結果クリア→
+ *  await→成功/失敗分岐→finally で launching 解除」を1箇所に閉じ込め、`launchAndReset` /
+ *  `launchWithSelectedTool` / `executeInstantCommandSelected` の三重複を解消する（#431）。
+ *  呼び出し側は「起動 API 呼び出し」と「成功/失敗時の後始末（trace・状態復元）」だけを渡す。
+ *  `activationInFlight` ガードは呼び出し元ごとに事前条件チェックの粒度が異なる（tool フレーム有無・
+ *  instant コマンド解決など）ため、ここでは扱わず各呼び出し元が個別に管理する。 */
+async function withLaunchLifecycle(
+  launch: () => Promise<api.LaunchResult>,
+  onSuccess: (result: api.LaunchResult) => void,
+  onFailure: (result: api.LaunchResult) => void,
+): Promise<boolean> {
+  clearLaunchNotice();
+  setLaunching(true);
+  try {
+    nextGeneration();
+    clearResults();
+    const launchResult = await launch();
+    if (launchResult.status !== "ok") {
+      notifyLaunchFailure(launchResult);
+      onFailure(launchResult);
+      return false;
+    }
+    onSuccess(launchResult);
+    return true;
+  } finally {
+    setLaunching(false);
+  }
+}
+
 async function launchWithSelectedTool(): Promise<boolean> {
   if (activationInFlight) return false;
   const frame = toolSelectionState();
@@ -484,43 +516,32 @@ async function launchWithSelectedTool(): Promise<boolean> {
     const tool = frame.tools[idx];
     if (!tool) return false;
 
-    clearLaunchNotice();
-    setLaunching(true);
     trace("search:launch_with_tool:start", {
       path: frame.targetPath,
       tool: tool.exe,
       query: frame.savedQuery,
     });
-    // 結果を隠す
-    ++searchGeneration;
-    clearResults();
-    const launchResult = await api.launchWithTool(
-      frame.targetPath,
-      frame.savedQuery,
-      tool.exe,
-      tool.args,
+    return await withLaunchLifecycle(
+      () => api.launchWithTool(frame.targetPath, frame.savedQuery, tool.exe, tool.args),
+      () => {
+        setToolSelectionState(null);
+        setFolderState(null);
+        setFolderFilter("");
+        clearResults();
+        nextGeneration();
+        trace("search:launch_with_tool:done", { path: frame.targetPath });
+      },
+      (launchResult) => {
+        trace("search:launch_with_tool:error", {
+          path: frame.targetPath,
+          status: launchResult.status,
+          code: launchResult.code,
+          message: launchResult.message,
+        });
+        void runRefresh();
+      },
     );
-    if (launchResult.status !== "ok") {
-      trace("search:launch_with_tool:error", {
-        path: frame.targetPath,
-        status: launchResult.status,
-        code: launchResult.code,
-        message: launchResult.message,
-      });
-      notifyLaunchFailure(launchResult);
-      void runRefresh();
-      return false;
-    }
-
-    setToolSelectionState(null);
-    setFolderState(null);
-    setFolderFilter("");
-    clearResults();
-    ++searchGeneration;
-    trace("search:launch_with_tool:done", { path: frame.targetPath });
-    return true;
   } finally {
-    setLaunching(false);
     activationInFlight = false;
   }
 }
@@ -547,8 +568,7 @@ async function enterToolSelection(result: SearchResult): Promise<boolean> {
     targetPath: result.path,
     targetIsFolder: result.isFolder,
     tools,
-    savedResults: results(),
-    savedSelected: selected(),
+    ...saveView(),
     savedQuery: query(),
     savedFolderFilter: folderFilter(),
   };
@@ -561,7 +581,7 @@ async function enterToolSelection(result: SearchResult): Promise<boolean> {
     isFolder: false,
     isError: false,
   }));
-  ++searchGeneration;
+  nextGeneration();
   updateResults(toolResults);
   setSelected(0);
   trace("search:enter_tool_selection:ok", { path: result.path, toolCount: tools.length });
@@ -572,9 +592,8 @@ function exitToolSelection(): boolean {
   const frame = toolSelectionState();
   if (!frame) return false;
 
-  ++searchGeneration;
-  updateResults(frame.savedResults);
-  setSelected(frame.savedSelected);
+  nextGeneration();
+  restoreView(frame);
   setToolSelectionState(null);
   // フォルダ展開中だった場合の folderFilter を復帰
   setFolderFilter(frame.savedFolderFilter);
@@ -585,43 +604,35 @@ function exitToolSelection(): boolean {
 async function launchAndReset(result: SearchResult): Promise<boolean> {
   if (result.isError) return false;
 
-  clearLaunchNotice();
-  setLaunching(true);
   trace("search:launch:start", { path: result.path, query: query() });
-  try {
-    // launch 開始時に results を隠す
-    ++searchGeneration;
-    clearResults();
-    const launchResult = await api.launchItem(result.path, query());
-    if (launchResult.status !== "ok") {
+  return withLaunchLifecycle(
+    () => api.launchItem(result.path, query()),
+    (launchResult) => {
+      setFolderState(null);
+      setFolderFilter("");
+      clearResults();
+      nextGeneration();
+      trace("search:launch:done", { path: result.path, code: launchResult.code });
+    },
+    (launchResult) => {
       trace("search:launch:error", {
         path: result.path,
         status: launchResult.status,
         code: launchResult.code,
         message: launchResult.message,
       });
-      notifyLaunchFailure(launchResult);
       void runRefresh();
-      return false;
-    }
-
-    setFolderState(null);
-    setFolderFilter("");
-    clearResults();
-    ++searchGeneration;
-    trace("search:launch:done", { path: result.path, code: launchResult.code });
-    return true;
-  } finally {
-    setLaunching(false);
-  }
+    },
+  );
 }
 
 async function executeInstantCommandSelected(): Promise<boolean> {
   if (activationInFlight) return false;
   activationInFlight = true;
   try {
-    const idx = clampSelectedIndex(selected(), instantCommandItems.length);
-    const cmd = instantCommandItems[idx];
+    const items = getInstantCommandItems();
+    const idx = clampSelectedIndex(selected(), items.length);
+    const cmd = items[idx];
     if (!cmd) return false;
 
     // クエリ部分を抽出（プレフィックス + コマンド名 + 空白以降）
@@ -630,50 +641,42 @@ async function executeInstantCommandSelected(): Promise<boolean> {
     const nameEnd = raw.indexOf(" ");
     const instantQuery = nameEnd >= 0 ? raw.slice(nameEnd + 1) : "";
 
-    clearLaunchNotice();
-    setLaunching(true);
     trace("search:instant_command:execute", { name: cmd.name, query: instantQuery });
 
     // 失敗時に復元するため、実行前の状態を保存
     const savedResults = results();
     const savedSelected = selected();
-    const savedItems = [...instantCommandItems];
-
+    const savedItems = [...items];
+    // withLaunchLifecycle が世代を+1する直前の値。await 中の追加変化を検知するベースライン。
     const preGen = searchGeneration;
-    ++searchGeneration;
-    clearResults();
 
-    const launchResult = await api.executeInstantCommand(cmd.name, instantQuery);
-    if (launchResult.status !== "ok") {
-      trace("search:instant_command:error", {
-        name: cmd.name,
-        status: launchResult.status,
-        code: launchResult.code,
-        message: launchResult.message,
-      });
-      notifyLaunchFailure(launchResult);
-      // 失敗時: await 中に状態が変わっていなければ候補リストを復元
-      if (searchGeneration === preGen + 1) {
-        ++searchGeneration;
-        instantCommandItems = savedItems;
-        updateResults(savedResults);
-        setSelected(savedSelected);
-      }
-      return false;
-    }
-
-    // 成功時: モードを完全にクリアする（query="" で interpKind は plain へ純粋導出）
-    if (instantCmdDebounceTimer !== undefined) {
-      clearTimeout(instantCmdDebounceTimer);
-      instantCmdDebounceTimer = undefined;
-    }
-    instantCommandItems = [];
-    suppressNextQueryEffectRefresh = true;
-    setQuery("");
-    trace("search:instant_command:done", { name: cmd.name });
-    return true;
+    return await withLaunchLifecycle(
+      () => api.executeInstantCommand(cmd.name, instantQuery),
+      () => {
+        // 成功時: モードを完全にクリアする（query="" で interpKind は plain へ純粋導出）
+        cancelInstantCommandDebounce();
+        clearInstantCommandItems();
+        suppressNextQueryEffectRefresh = true;
+        setQuery("");
+        trace("search:instant_command:done", { name: cmd.name });
+      },
+      (launchResult) => {
+        trace("search:instant_command:error", {
+          name: cmd.name,
+          status: launchResult.status,
+          code: launchResult.code,
+          message: launchResult.message,
+        });
+        // 失敗時: await 中に状態が変わっていなければ候補リストを復元
+        if (searchGeneration === preGen + 1) {
+          nextGeneration();
+          setInstantCommandItems(savedItems);
+          updateResults(savedResults);
+          setSelected(savedSelected);
+        }
+      },
+    );
   } finally {
-    setLaunching(false);
     activationInFlight = false;
   }
 }
@@ -742,11 +745,8 @@ function resetForShow() {
   clearLaunchNotice();
   setToolSelectionState(null);
   setFolderState(null);
-  if (instantCmdDebounceTimer !== undefined) {
-    clearTimeout(instantCmdDebounceTimer);
-    instantCmdDebounceTimer = undefined;
-  }
-  instantCommandItems = [];
+  cancelInstantCommandDebounce();
+  clearInstantCommandItems();
   if (query() !== "") {
     suppressNextQueryEffectRefresh = true;
   }
@@ -817,11 +817,10 @@ export {
   shouldShowResults,
   viewKind,
   interpKind,
+  allowsFolderNav,
   indexing,
   initIndexingState,
   launching,
-  launchNotice,
-  clearLaunchNotice,
   enterToolSelection,
   exitToolSelection,
   getSearchGeneration,
@@ -831,3 +830,10 @@ export {
 
 export { folderState, folderFilter, setFolderFilter } from "./folder";
 export { toolSelectionState } from "./tool-selection";
+// 公開 API は変えず、実装のみ stores/launchNotice.ts へ分割（#431 Phase3・DRY 再 export）
+export {
+  launchNotice,
+  clearLaunchNotice,
+  setLaunchNoticeWithAutoClear,
+  setHotkeyFailureNotice,
+} from "./launchNotice";

--- a/ui/src/stores/tool-selection.ts
+++ b/ui/src/stores/tool-selection.ts
@@ -1,12 +1,11 @@
 import { createSignal } from "solid-js";
-import type { OpenerTool, SearchResult } from "../lib/types";
+import type { OpenerTool, SavedViewState } from "../lib/types";
 
-export interface ToolSelectionFrame {
+export interface ToolSelectionFrame extends SavedViewState {
   targetPath: string;
   targetIsFolder: boolean;
   tools: OpenerTool[];
-  savedResults: SearchResult[];
-  savedSelected: number;
+  /** ツール起動時に渡す元クエリ（folder の savedQuery と異なり離脱時の復元には使わない） */
   savedQuery: string;
   savedFolderFilter: string;
 }


### PR DESCRIPTION
## Summary

`ui/src/stores/search.ts`（833行）の責務分割と横断規約の集約。issue #431 の Phase 1-3 をすべて実施。

**Phase 1（choke point 集約、機械的）**
- `nextGeneration()` を `searchGeneration` 更新の唯一経路にし、手書き `++searchGeneration` 13箇所を全置換
- `withLaunchLifecycle(launch, onSuccess, onFailure)` 高階関数で `launchAndReset` / `launchWithSelectedTool` / `executeInstantCommandSelected` の起動フロー三重複（通知クリア→launching→世代更新→結果クリア→await→成功/失敗分岐→finally）を解消
- `SavedViewState` 型（`lib/types.ts`）+ `saveView()`/`restoreView()` で `enter/exitFolderExpansion` と `enter/exitToolSelection` の退避/復元フレーム重複を共通化（`FolderFrame`/`ToolSelectionFrame` がこれを拡張。`savedQuery` の意味はモードごとに異なる点は維持）

**Phase 2（述語の一本化）**
- `SearchWindow.tsx` の `viewKind()==="tool" || interpKind()==="instant"` 複合条件（ArrowRight/Left・Shift+Enter の3箇所）を `search.ts` の `allowsFolderNav()` 述語に集約。キーハンドラは消費するだけにした

**Phase 3（モジュール分割）**
- インスタントコマンド関連（`instantCommandItems`・30ms デバウンス IPC 取得）を `stores/instantCommand.ts` へ分離。`api`/`lib/types` のみに依存し `search.ts` への逆依存を持たない（`nextRequestId`/`isStale` hooks で staleness 判定を注入することで循環 import を回避）
- 起動通知（`launchNoticeTimer` 等）を `stores/launchNotice.ts` へ分離
- `query` の `createEffect`（約100行）を `interpKind()` で分岐する薄い dispatch effect + `handleInstantQueryInput`/`handleCommandQueryInput`/`handlePlainQueryInput` へ再構成
- `search.ts` は両モジュールを re-export し公開 API（`setLaunchNoticeWithAutoClear` 等）を変えていない。既存コンポーネント・テストの import はそのまま

**見送り項目**: なし（Phase 1〜3 すべて実施）

## 追加/更新テスト + 検証した不変条件

- `search.test.ts`: `allowsFolderNav` の5ケース（通常/folder中/tool中/instant中/tool優先）を追加
- `SearchWindow.test.tsx`: `allowsFolderNav` モックを下位軸モック（`mockViewKind`/`mockInterpKind`）から導出するよう更新
- 検証した不変条件:
  - `viewKind()`/`interpKind()` の2軸導出と `assertNever` 網羅性は変更なし
  - 世代ガードの意味論（リクエスト発行時 `nextGeneration()`、応答時 `searchGeneration` 一致確認で stale 破棄）は変更なし（choke point 化のみで振る舞い不変）
  - デバウンス（検索 leading+trailing 50ms / instant 30ms）は変更なし
  - `suppressNextQueryEffectRefresh` の読み書き順序は変更なし

## Test plan

- [x] `npm test` — 既存195本 + 追加5本 = 200本 green
- [x] `npm run typecheck` / `npm run build` green
- [x] `npm run smoke:startup`（debug ビルド、5 iterations）ローカル実行 — 全 run `error_count=0`
- [ ] CI（`e2e` ラベル付与済み。`E2E & Smoke` workflow の自動実行を確認）

Closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)
