### PR TITLE
refactor(ipc): IPC 返り値契約を規約化し list_folder / rebuild_index の不整合を解消

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,7 +61,7 @@ Win32 依存なし（`#[cfg(windows)]` ゲート以外）、完全にユニッ�
 
 ### src-tauri（Tauri v2 バイナリ層）
 
-Tauri v2 バイナリ crate（パッケージ名 `snotra`）。Win32 API 統合（システムトレイ・グローバルホットキー・IME・マルチモニター）とフロントエンドとの IPC を担当。`commands/` は責務別に分割した `#[tauri::command]` ハンドラ群、`platform/` は Win32 メッセージループ・ホットキー・トレイのネイティブ統合。
+Tauri v2 バイナリ crate（パッケージ名 `snotra`）。Win32 API 統合（システムトレイ・グローバルホットキー・IME・マルチモニター）とフロントエンドとの IPC を担当。`commands/` は責務別に分割した `#[tauri::command]` ハンドラ群、`platform/` は Win32 メッセージループ・ホットキー・トレイのネイティブ統合。IPC コマンドの返り値契約（読み取り系/起動系/失敗しうる操作系の3系統）は `src-tauri/CLAUDE.md` の「IPC コマンドの返り値契約」節を参照（規約本文はそちらが SSOT）。
 
 → モジュール構成は `src-tauri/CLAUDE.md`
 

--- a/src-tauri/CLAUDE.md
+++ b/src-tauri/CLAUDE.md
@@ -27,6 +27,22 @@ Tauri v2 バイナリ crate。Win32 API 統合とフロントエンドとの IPC
 - Managed state として `IconCacheState`（`Mutex<Option<IconCache>>`、初回アイコン要求で遅延初期化）と `SettingsProcessState`（`Mutex<Option<Child>>`、設定プロセスのハンドル管理）を保持
 - **`show_main_and_emit` の操作順序制約**: 高さリセット（52px）→ `position_on_target_monitor` → `show()` の順。位置計算はウィンドウサイズ（`outer_size()`）でクランプするため、高さリセット前に位置を決めると展開時の高さでクランプされ、折りたたみ時に位置がずれる
 
+## IPC コマンドの返り値契約
+
+新規 `#[tauri::command]` は以下の3系統のいずれかに従う（#434: as-built で4系統に分裂していたものを整理した規約）。
+
+1. **読み取り・検索系**（失敗を結果 DTO で表現するもの）: 素の `T` を返す。エラーは DTO 内の `is_error` フラグ + UI 層で表示文字列を決定する（`snotra-core` の設計と整合）。例: `search` / `get_history_results` / `list_folder`
+2. **起動系**: `LaunchResult { status, code, message }` 契約（`launch_item` / `launch_with_tool` / `execute_instant_command`）
+3. **失敗しうる操作系**: `Result<T, String>`。「実行できない状態」（インデックス構築中など）も `Err(定数)` で表現する。例: `open_settings` / `rebuild_index`
+
+`bool` 返しは新規コマンドで使用しない（「成功/失敗」と「実行できない状態」を混同しやすく、フロントエンドが呼び出しごとに異なる判定を実装する原因になる）。
+
+補足:
+
+- `notify_main_shown` / `notify_main_hidden` の命名は実態（`AppState` のフラグ更新が主目的）とややズレるが、IPC 改名はフロントエンド・トレースログ双方に波及する churn の割に得られる整合性が小さいため改名しない
+- 「インデックス構築中で実行できない」という同一条件を表すエラー定数は、`open_settings`（`commands/window.rs` の `ERR_INDEXING_IN_PROGRESS`）と `rebuild_index`（同定数を再利用）で共有する。新たに「実行できない状態」を追加する場合もこの定数を再利用するか、命名パターン（`ERR_<状態>`）を揃える
+- 既存コマンドの一斉移行はしない。上記規約は「新規コマンド」と、契約と実装が乖離していた `list_folder`（型が `Result` だが `Err` を返さない死蔵の型）・`rebuild_index`（`bool` と `open_settings` の `Result` で同一条件が不一致）の是正に適用する
+
 ## Win32 メッセージ配送の注意
 
 Shell のトレイコールバック (`uCallbackMessage`) は `SendMessage` で配送される場合があり、`GetMessageW` ループに到達しない。カスタムメッセージ (`WM_APP + N`) をウィンドウプロシージャ (`DefWindowProcW`) だけで処理すると消滅するため、`platform_default_wnd_proc` で検出して `PostThreadMessageW` でスレッドキューに再投入する設計にしている。

--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -40,15 +40,14 @@ pub fn get_history_results(state: State<AppState>) -> Vec<SearchResult> {
     results
 }
 
-// 戻り値型は Result<_, String> だが、現在の実装ではすべてのエラーパスが
-// is_error エントリを Ok() で包んで返すため、Err 変体は実際には返されない。
-// フロントエンドとの IPC 型として Result を使い続けているため、将来の拡張に備えて維持する。
+// IPC 返り値契約（src-tauri/CLAUDE.md「IPC コマンドの返り値契約」）の「読み取り・検索系」:
+// 失敗は is_error エントリを含む SearchResult で表現し、素の Vec<SearchResult> を返す。
+// 以前は Result<_, String> だったが、全エラーパスが is_error エントリを Ok() で包んで返し
+// Err 変体を返さない死蔵の型だったため、実装に合わせて素の型へ揃えた（#434）。
+// wire 互換性: Tauri IPC は Result<T, E>::Ok(v) と v を成功パスで同一シリアライズするため、
+// Err を返したことがないこのコマンドの型変更はフロントエンドから見て無害。
 #[tauri::command]
-pub async fn list_folder(
-    dir: String,
-    filter: String,
-    app: AppHandle,
-) -> Result<Vec<SearchResult>, String> {
+pub async fn list_folder(dir: String, filter: String, app: AppHandle) -> Vec<SearchResult> {
     trace_command(
         "cmd:list_folder:start",
         json!({
@@ -80,7 +79,7 @@ pub async fn list_folder(
                     "error": true,
                 }),
             );
-            return Ok(results);
+            return results;
         }
     };
 
@@ -97,5 +96,5 @@ pub async fn list_folder(
             "result_count": results.len(),
         }),
     );
-    Ok(results)
+    results
 }

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -5,12 +5,30 @@ use tauri::{AppHandle, Emitter, State};
 use crate::indexing;
 use crate::state::AppState;
 
-#[tauri::command]
-pub fn rebuild_index(state: State<AppState>, app: AppHandle) -> bool {
+use super::window::ERR_INDEXING_IN_PROGRESS;
+
+/// `state.indexing` が既に true かどうかだけを見る純粋な分岐。`start_index_build` 自体は
+/// `AppHandle` を要求し単体テスト不能なため、`AppHandle` 抜きでテスト可能な部分を切り出す。
+fn ensure_not_indexing(state: &AppState) -> Result<(), String> {
     if state.indexing.load(Ordering::SeqCst) {
-        return false;
+        return Err(ERR_INDEXING_IN_PROGRESS.to_string());
     }
-    indexing::start_index_build(&app)
+    Ok(())
+}
+
+// IPC 返り値契約（src-tauri/CLAUDE.md「IPC コマンドの返り値契約」）の「失敗しうる操作系」:
+// `open_settings` と同じ ERR_INDEXING_IN_PROGRESS 定数で「インデックス構築中」を表現する
+// （#434。以前は bool で open_settings の Result 契約と不一致だった）。
+#[tauri::command]
+pub fn rebuild_index(state: State<AppState>, app: AppHandle) -> Result<(), String> {
+    ensure_not_indexing(&state)?;
+    if indexing::start_index_build(&app) {
+        Ok(())
+    } else {
+        // try_begin_index_build の CAS に負けた（既に別スレッドがビルド中）場合も
+        // 同一のエラーコードで表現する。
+        Err(ERR_INDEXING_IN_PROGRESS.to_string())
+    }
 }
 
 #[tauri::command]
@@ -45,4 +63,43 @@ pub fn notify_main_hidden(state: State<AppState>, app: AppHandle) {
     // working set を回収する。EmptyWorkingSet はスレッド非依存ゆえ tokio IPC スレッドから
     // 安全に呼べる（suspend_webview の with_webview 非同期制約がない）。best-effort。
     crate::working_set::trim_idle_working_set(std::process::id());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snotra_core::config::Config;
+    use snotra_core::engine::Engine;
+    use snotra_core::history::HistoryStore;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Mutex;
+
+    fn test_state(indexing: bool) -> AppState {
+        AppState {
+            engine: Mutex::new(Engine::new(Vec::new(), HistoryStore::load(), Config::default())),
+            indexing: AtomicBool::new(indexing),
+            index_build_started: AtomicBool::new(false),
+            main_visible: AtomicBool::new(false),
+        }
+    }
+
+    #[test]
+    fn ensure_not_indexing_rejects_while_indexing_in_progress() {
+        let state = test_state(true);
+        assert_eq!(
+            ensure_not_indexing(&state),
+            Err(ERR_INDEXING_IN_PROGRESS.to_string()),
+            "rebuild_index must reject with ERR_INDEXING_IN_PROGRESS while a build is in flight \
+             (same contract as open_settings)"
+        );
+    }
+
+    #[test]
+    fn ensure_not_indexing_allows_when_idle() {
+        let state = test_state(false);
+        assert!(
+            ensure_not_indexing(&state).is_ok(),
+            "rebuild_index must allow starting a build when idle"
+        );
+    }
 }

--- a/ui/src/lib/commands.test.ts
+++ b/ui/src/lib/commands.test.ts
@@ -11,7 +11,7 @@ vi.mock("@tauri-apps/api/window", () => ({
 
 vi.mock("./invoke", () => ({
   openSettings: vi.fn(async () => {}),
-  rebuildIndex: vi.fn(async () => true),
+  rebuildIndex: vi.fn(async () => {}),
   quitApp: vi.fn(async () => {}),
   notifyMainHidden: vi.fn(async () => {}),
 }));
@@ -107,7 +107,6 @@ describe("slash command actions", () => {
     mockMainHide.mockImplementation(async () => { order.push("hideMain"); });
     vi.mocked(api.rebuildIndex).mockImplementation(async () => {
       order.push("rebuildIndex");
-      return true;
     });
 
     const cmd = findCommand("/s");
@@ -116,6 +115,21 @@ describe("slash command actions", () => {
 
     expect(order).toEqual(["hideMain", "rebuildIndex"]);
     expect(api.rebuildIndex).toHaveBeenCalledTimes(1);
+  });
+
+  it("/s インデックス構築中エラーは無視する（bool→Result 契約変更後もユーザー可視の挙動は現状維持、#434）", async () => {
+    vi.mocked(api.rebuildIndex).mockRejectedValueOnce(new Error("indexing_in_progress"));
+    const cmd = findCommand("/s");
+
+    await expect(cmd!.action()).resolves.toBeUndefined();
+    expect(mockSetLaunchNoticeWithAutoClear).not.toHaveBeenCalled();
+  });
+
+  it("/s 予期せぬエラーは再スローする", async () => {
+    vi.mocked(api.rebuildIndex).mockRejectedValueOnce(new Error("unexpected_error"));
+    const cmd = findCommand("/s");
+
+    await expect(cmd!.action()).rejects.toThrow("unexpected_error");
   });
 
   it("/q calls quitApp without hiding", async () => {

--- a/ui/src/lib/commands.ts
+++ b/ui/src/lib/commands.ts
@@ -58,7 +58,17 @@ export const SLASH_COMMANDS: SlashCommand[] = [
     get description() { return t("cmd.rebuild_index.description"); },
     action: async () => {
       await hideMainWindow();
-      await api.rebuildIndex();
+      try {
+        await api.rebuildIndex();
+      } catch (e) {
+        // rebuildIndex は bool → Result<(), String> に契約変更（#434）。以前は
+        // 「インデックス構築中」を false で表現し戻り値を無視していた（無反応・無音）。
+        // Err(ERR_INDEXING_IN_PROGRESS) も同様に無視し、ユーザー可視の挙動を変えない。
+        // それ以外のエラーは想定外のため再送出する。
+        if (!String(e).includes(ERR_INDEXING_IN_PROGRESS)) {
+          throw e;
+        }
+      }
     },
   },
   {

--- a/ui/src/lib/invoke.ts
+++ b/ui/src/lib/invoke.ts
@@ -116,8 +116,8 @@ export async function getIndexingState(): Promise<boolean> {
   return tracedInvoke<boolean>(IPC.GET_INDEXING_STATE);
 }
 
-export async function rebuildIndex(): Promise<boolean> {
-  return tracedInvoke<boolean>(IPC.REBUILD_INDEX);
+export async function rebuildIndex(): Promise<void> {
+  return tracedInvoke<void>(IPC.REBUILD_INDEX);
 }
 
 export async function quitApp(): Promise<void> {


### PR DESCRIPTION
## Summary

#434（IPC コマンドの返り値契約が4系統に分裂）の是正。新規コマンド向けの規約を文書化し、契約と実装が乖離していた `list_folder` / 同一条件の表現が不一致だった `rebuild_index` の2件を規約に合わせて是正した。

### A. 返り値契約の規約化（SSOT = `src-tauri/CLAUDE.md`）

「IPC コマンドの返り値契約」節を追加し、新規コマンドは以下の3系統のいずれかに従う旨を明文化:

1. **読み取り・検索系**: 素の `T`。エラーは DTO 内 `is_error` + UI 層が表示文字列を決定（例: `search` / `get_history_results` / `list_folder`）
2. **起動系**: `LaunchResult { status, code, message }`
3. **失敗しうる操作系**: `Result<T, String>`。「実行できない状態」も `Err(定数)` で表現（例: `open_settings` / `rebuild_index`）

`bool` 返しは新規コマンドで使用しない。`notify_main_shown`/`notify_main_hidden` の命名ズレは churn に見合わないため改名しない旨も注記した。`docs/architecture.md` からはこの節への参照のみを追加（規約本文の重複を避けるドキュメント間 DRY）。

### B. `list_folder` の型是正（wire 互換・挙動変更なし）

`Result<Vec<SearchResult>, String>` → 素の `Vec<SearchResult>`。実装は全エラーパスを `Ok(is_error エントリ)` で包み `Err` を返したことがない死蔵の型だったため、実装に合わせた。

- **wire 互換性の根拠**: Tauri IPC は成功パスで `Result<T, E>::Ok(v)` と `v` を同一シリアライズするため、`Err` を一度も返していないこのコマンドの型変更はフロントエンドから見て無害
- `ui/src/lib/invoke.ts` の `listFolder` は元々 `Promise<SearchResult[]>` を返す実装だったため型変更は不要（コントラクトテストも変更なし）

### C. `rebuild_index` の契約統一（挙動変更なし）

`bool`（indexing 中は `false`）→ `Result<(), String>`（indexing 中は `open_settings` と同じ `ERR_INDEXING_IN_PROGRESS` を再利用して `Err`）。`try_begin_index_build` の CAS 敗北時も同一エラーコードにした。

- **フロントエンド消費箇所**: `/s` スラッシュコマンド（`ui/src/lib/commands.ts`）のみ。以前は戻り値 `false` を無視するだけ（無反応・無音）だったため、新実装でも `Err(ERR_INDEXING_IN_PROGRESS)` を同様に無視し **ユーザー可視の挙動は変更なし**。想定外のエラーのみ再送出する
- `SPEC.md` の `/s` 説明（589-592行）はユーザー可視の挙動のみを記述しIPC型に触れていないため、挙動が現状維持である以上 SPEC 変更は不要と判断
- Rust 側: `rebuild_index` の「構築中は拒否」分岐を `ensure_not_indexing()` として `AppHandle` 抜きで切り出し、単体テスト2件を追加（`open_settings` にはテスト基盤自体が存在しなかったため新規に構築）

### D. テスト更新

- `ui/src/lib/commands.test.ts`: `/s` のインデックス構築中エラー無視・想定外エラー再送出のテストを追加
- `src-tauri/src/commands/system.rs`: `ensure_not_indexing` の2テスト（構築中は拒否/アイドル時は許可）

## 検証

- `cargo check -p snotra-core -p snotra -p snotra-settings`: パス
- `cargo clippy ... --all-targets -- -D warnings`: 警告なし
- `cargo test -p snotra`: 68 passed（新規2件含む）
- `npm run typecheck` / `npm run build`: パス
- `npm test`: 202 passed
- `npm run smoke:startup`（`/r` 系の e2e.yml 回帰ガード対象の起動経路）: 5 runs, error_count=0

## Test plan

- [ ] CI（typecheck / clippy / test）グリーン確認
- [ ] `e2e` ラベル付き e2e.yml の `/r` 再インデックステストがグリーンであることを確認

Closes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)
