### PR TITLE
feat(settings): egui_kittest による設定 GUI ヘッドレス UI テスト導入 (#440)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "accesskit_consumer"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cf47daed85312e763fbf85ceca136e0d7abc68e0a7e12abe11f48172bc3b10"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,6 +1257,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_kittest"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "002c31e1f41461ce206333ffbd2e07563b79e87eb71c27e026151d12ee7b78e0"
+dependencies = [
+ "egui",
+ "kittest",
+ "log",
+ "serde",
+ "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,6 +2092,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
@@ -2635,6 +2667,16 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kittest"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ceaa75eb0036a32b6b9833962eb18137449e9817e2e586006471925b727fd5"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+]
 
 [[package]]
 name = "kqueue"
@@ -4660,6 +4702,7 @@ name = "snotra-settings"
 version = "0.1.0"
 dependencies = [
  "eframe",
+ "egui_kittest",
  "image",
  "open",
  "rfd",

--- a/snotra-settings/CLAUDE.md
+++ b/snotra-settings/CLAUDE.md
@@ -126,7 +126,33 @@ OpenerRule のターゲットは文字列プレフィックスで種別を表現
 - 境界チェック: 配列アクセス前に必ずインデックスの有効性を確認する（`if idx < vec.len()`）
 - opener のターゲット変更: ツールを旧ルールから削除し、新ルールに追加する。OpenerRule.target を上書きしない（他のツールが巻き添えになる）
 - ユニットテストは書かない方針（egui UI コードはモック困難）。ロジックのテストは `snotra-core` 側で行う
-  - 例外: 純粋な非 egui ヘルパー（例 `font.rs` の `face_index_valid`）の境界テストはインラインで置いてよい。egui モック困難の理由が当たらず、かつ degrade パスが視覚スモークで再現できない（dev 機には対象フェイスが在る）ため、テストが唯一の検証手段になる
+  - 例外1: 純粋な非 egui ヘルパー（例 `font.rs` の `face_index_valid`）の境界テストはインラインで置いてよい。egui モック困難の理由が当たらず、かつ degrade パスが視覚スモークで再現できない（dev 機には対象フェイスが在る）ため、テストが唯一の検証手段になる
+  - 例外2: **UI 操作 + 状態観測**は `egui_kittest`（AccessKit）でヘッドレステストできる（下記「ヘッドレス UI テスト」）。「egui モック困難」は描画のモックを指し、AccessKit ツリー経由の操作には当たらない
+
+## ヘッドレス UI テスト（egui_kittest）
+
+`egui_kittest`（dev-dependency）で AccessKit ツリー経由の操作テストを書ける。対象は
+**フッターボタン（Save/Discard/Reset）の wiring + draft/saved フロー**——実 UI を操作して初めて
+検証できる死角（#440）。テストは `app.rs` の `#[cfg(test)] mod tests` に**インラインで置く**
+（`SettingsApp` / `new` / `has_changes` が private のため `tests/` の integration test からは不可視）。
+
+- **パターン**: `Harness::new_ui_state(|ui, app| app.ui_impl(ui), app)` で `SettingsApp` を state
+  として載せ、`harness.get_by_label(...).click()` で操作、`harness.state()` / `state_mut()` で
+  内部状態を観測。`ui_impl` は `App::ui` から `eframe::Frame` 依存を除いた本体（`ui()` は 1 行委譲）。
+- **`run()` でなく固定ステップ（`settle`）を使う**: この UI は checkbox 等のアニメーションで毎フレーム
+  repaint を要求し、収束前提の `Harness::run()` は `max_steps` 超過で panic する。観測対象は描画の
+  収束ではなく draft の内部状態なので、`step()` を数回回してクリック（press→release）を処理させる。
+- **言語は `Language::En` 固定**: `default_language()` は OS 依存でラベルが非決定的になる。
+- **重複させない**: dirty-dot 導出（`section_table_*`）とモーダル状態機械（`tabs::common::tests`）は
+  純ロジックテスト済み。kittest は「実 UI 操作でしか検証できない wiring」に絞る。
+
+### 境界（kittest で検証できないもの）
+
+`egui_kittest` は AccessKit ツリー（操作・状態）の検証に限る。**レイアウト・レンダリング欠陥**
+（#399 型のベースラインずれ・フォント混在・overflow 等）は**引き続き人手の視覚スモークが唯一の検知手段**。
+wgpu スナップショット比較は評価の結果**採用しない**（フォント/GPU/driver 依存で CI flaky、かつ環境差を
+吸収する threshold が #399 型欠陥そのものをマスクするため ROI が低い。#440 の判断）。CI に GPU 依存を
+持ち込まないため dev-dependency は `default-features = false`（wgpu/snapshot/x11 を引き込まない）。
 
 ## 本体との連携パターン
 

--- a/snotra-settings/Cargo.toml
+++ b/snotra-settings/Cargo.toml
@@ -14,6 +14,11 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 open = "5"
 rfd = "0.17"
 
+[dev-dependencies]
+# ヘッドレス UI テスト（AccessKit 経由）。default-features = false で wgpu/snapshot/x11 を
+# 引き込まない（GPU 依存を CI に持ち込まないため。0.35 時点で default feature は無いが将来防御）。
+egui_kittest = { version = "0.35", default-features = false }
+
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62.2", features = [
     "Win32_Graphics_Gdi",

--- a/snotra-settings/src/app.rs
+++ b/snotra-settings/src/app.rs
@@ -737,43 +737,130 @@ mod tests {
         }
     }
 
-    // === Phase 1 スパイク（#440）: egui_kittest による AccessKit 操作テストの実証 ===
-    // 目的: (1) ヘッドレスで SettingsApp の UI を Harness に載せられるか
-    //       (2) AccessKit 経由でウィジェットを操作し内部状態（draft/saved）を観測できるか
-    //       (3) wgpu なし（GPU 不要）で決定的に回るか — CI 安定性の裏取り
-    #[test]
-    fn kittest_general_checkbox_toggles_dirty_state() {
-        use egui_kittest::Harness;
-        use egui_kittest::kittest::Queryable;
+    // === egui_kittest による AccessKit ヘッドレス操作テスト（#440） ===
+    //
+    // 対象は「フッターボタン（Save/Discard/Reset）の wiring + draft/saved フロー」——
+    // 実 UI を操作して初めて検証できる死角。dirty-dot 導出（`section_table_*`）と
+    // モーダル状態機械（`tabs::common::tests`）は純ロジックテスト済みのため重複させない。
+    //
+    // 実装メモ:
+    // - `Harness::new_ui_state` に SettingsApp を state として渡し、Frame 非依存の
+    //   `ui_impl` を呼ぶ。`harness.state()` で内部状態（private フィールド含む・同 mod）を観測。
+    // - `run()` は「repaint 要求が止まる」収束前提だが、この UI は checkbox 等の
+    //   アニメーションで毎フレーム repaint を要求し発散する。観測対象は描画の収束ではなく
+    //   draft の内部状態なので、固定ステップ（`settle`）でクリック（press→release）を
+    //   処理させれば十分。wgpu 不要 = GPU なし CI で決定的に回る。
+    // - 言語は En 固定（`default_language()` は OS 依存でラベルが非決定的になるため）。
 
-        // 言語を明示（default_language() は OS 依存でラベルが非決定的になるため）。
+    use egui_kittest::Harness;
+    use egui_kittest::kittest::Queryable;
+
+    /// En 言語の SettingsApp を Harness に載せる（未編集 = clean 状態）。
+    fn en_harness(config: Config) -> Harness<'static, SettingsApp> {
+        let app = SettingsApp::new(config, false, None, LoadOutcome::Loaded);
+        Harness::new_ui_state(|ui, app: &mut SettingsApp| app.ui_impl(ui), app)
+    }
+
+    fn en_config() -> Config {
         let mut config = Config::normalized_default();
         config.general.language = Language::En;
-        let app = SettingsApp::new(config, false, None, LoadOutcome::Loaded);
+        config
+    }
 
-        // SettingsApp を state として保持し、Frame 非依存の ui_impl を Harness から呼ぶ。
-        let mut harness =
-            Harness::new_ui_state(|ui, app: &mut SettingsApp| app.ui_impl(ui), app);
-
-        // 初期状態: 未編集なので dirty ではない。
-        assert!(!harness.state().has_changes(), "initial state must be clean");
-
-        // General タブの「Toggle window visibility with hotkey」チェックボックスを
-        // AccessKit ラベルで見つけてクリック。
-        let label = Tr(Language::En).cb_hotkey_toggle();
-        harness.get_by_label(label).click();
-        // run() は「repaint 要求が止まる」収束を前提とするが、この UI は checkbox の
-        // アニメーション等で毎フレーム repaint を要求し発散する。ここで観測するのは
-        // 収束後の描画ではなく draft の内部状態なので、固定ステップでクリック（press→release）
-        // を処理させれば十分。
+    /// クリック（press→release）とアニメーションを固定ステップで処理する。
+    fn settle(harness: &mut Harness<'static, SettingsApp>) {
         for _ in 0..4 {
             harness.step();
         }
+    }
 
-        // 編集後: draft != saved で dirty になる（内部状態を Harness 経由で観測）。
+    // 不変条件: General タブの checkbox クリックで draft != saved（dirty）になる。
+    #[test]
+    fn kittest_checkbox_click_makes_draft_dirty() {
+        let mut harness = en_harness(en_config());
+        assert!(!harness.state().has_changes(), "initial state must be clean");
+
+        harness.get_by_label(Tr(Language::En).cb_hotkey_toggle()).click();
+        settle(&mut harness);
+
         assert!(
             harness.state().has_changes(),
             "clicking the checkbox must make draft != saved (dirty)"
+        );
+    }
+
+    // 不変条件: Discard ボタンで draft が saved に戻る（編集が破棄される）。
+    #[test]
+    fn kittest_discard_reverts_draft_to_saved() {
+        let mut harness = en_harness(en_config());
+        let original_toggle = harness.state().saved.general.hotkey_toggle;
+
+        // 編集して dirty にする（Discard は has_changes() で有効化されるため先に編集）。
+        harness.get_by_label(Tr(Language::En).cb_hotkey_toggle()).click();
+        settle(&mut harness);
+        assert!(harness.state().has_changes());
+        assert_ne!(harness.state().draft.general.hotkey_toggle, original_toggle);
+
+        // Discard → draft = saved.clone()。
+        harness.get_by_label(Tr(Language::En).btn_discard()).click();
+        settle(&mut harness);
+
+        assert!(!harness.state().has_changes(), "discard must clear dirty state");
+        assert_eq!(
+            harness.state().draft.general.hotkey_toggle,
+            original_toggle,
+            "discard must revert the edited field"
+        );
+    }
+
+    // 不変条件: Reset to default で draft が normalized_default になり、
+    // saved が非既定なら has_changes() が true になる（保存が必要な状態）。
+    #[test]
+    fn kittest_reset_to_default_makes_dirty() {
+        // saved を「既定と1フィールド違う」状態にする（reset で差分が生まれるように）。
+        let default_toggle = Config::normalized_default().general.hotkey_toggle;
+        let mut config = en_config();
+        config.general.hotkey_toggle = !default_toggle;
+        let mut harness = en_harness(config);
+        assert!(!harness.state().has_changes(), "saved==draft initially = clean");
+
+        harness.get_by_label(Tr(Language::En).btn_reset_default()).click();
+        settle(&mut harness);
+
+        assert_eq!(
+            harness.state().draft.general.hotkey_toggle,
+            default_toggle,
+            "reset must set draft to normalized_default value"
+        );
+        assert!(
+            harness.state().has_changes(),
+            "reset changes draft but not saved → must be dirty (needs Save)"
+        );
+    }
+
+    // 不変条件: Save ボタンでバリデーションエラーがあると、ステータスにエラーが出て
+    // saved は更新されない（不正な draft を disk に書かない）。Save→validate 経路の UI wiring。
+    #[test]
+    fn kittest_save_with_validation_error_keeps_saved() {
+        let mut harness = en_harness(en_config());
+        let saved_before = harness.state().saved.clone();
+
+        // draft を「dirty かつ不正」にする（UI の DragValue で不正値まで駆動するのは煩雑なため
+        // 中間状態を直接構築。テストが検証するのは Save ボタン→save()→validate 分岐の wiring）。
+        // window_width を最小未満にすると ConfigError::WindowWidthTooSmall になる。
+        harness.state_mut().draft.appearance.window_width = 1;
+        assert!(harness.state().has_changes(), "draft must be dirty so Save is enabled");
+
+        harness.get_by_label(Tr(Language::En).btn_save()).click();
+        settle(&mut harness);
+
+        assert!(
+            !harness.state().status.is_empty(),
+            "validation error must surface a status message"
+        );
+        assert_eq!(
+            harness.state().saved, saved_before,
+            "saved must not be updated when validation fails"
         );
     }
 }

--- a/snotra-settings/src/app.rs
+++ b/snotra-settings/src/app.rs
@@ -272,7 +272,18 @@ impl eframe::App for SettingsApp {
     // eframe 0.35: App::update は logic()/ui() に分割された。全レイアウトを ui() が受け取る
     // ルート Ui 上に置き、各 Panel は show(ui) で描画する（旧 Panel::show(ctx) は 0.35 で削除、
     // show_inside は show へ改名）。ctx はルート Ui から取得する。
+    // 本体は `ui_impl` に委譲する（`_frame` 未使用のため挙動不変）。egui_kittest の
+    // `Harness::new_ui_state` は `FnMut(&mut Ui, &mut State)` を取り Frame を渡せないため、
+    // Frame 非依存の `ui_impl` を切り出してヘッドレステストから直接呼べるようにしている。
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        self.ui_impl(ui);
+    }
+}
+
+impl SettingsApp {
+    /// eframe の `App::ui` 本体（`eframe::Frame` 非依存）。本番は `ui()` から、テストは
+    /// egui_kittest の Harness から呼ぶ。egui 描画コードはここに集約する。
+    fn ui_impl(&mut self, ui: &mut egui::Ui) {
         let ctx = ui.ctx().clone();
         // Update window title (language change + dirty indicator)
         let title = if self.has_changes() {
@@ -724,5 +735,45 @@ mod tests {
                 "Backup tab must not light for `{name}`"
             );
         }
+    }
+
+    // === Phase 1 スパイク（#440）: egui_kittest による AccessKit 操作テストの実証 ===
+    // 目的: (1) ヘッドレスで SettingsApp の UI を Harness に載せられるか
+    //       (2) AccessKit 経由でウィジェットを操作し内部状態（draft/saved）を観測できるか
+    //       (3) wgpu なし（GPU 不要）で決定的に回るか — CI 安定性の裏取り
+    #[test]
+    fn kittest_general_checkbox_toggles_dirty_state() {
+        use egui_kittest::Harness;
+        use egui_kittest::kittest::Queryable;
+
+        // 言語を明示（default_language() は OS 依存でラベルが非決定的になるため）。
+        let mut config = Config::normalized_default();
+        config.general.language = Language::En;
+        let app = SettingsApp::new(config, false, None, LoadOutcome::Loaded);
+
+        // SettingsApp を state として保持し、Frame 非依存の ui_impl を Harness から呼ぶ。
+        let mut harness =
+            Harness::new_ui_state(|ui, app: &mut SettingsApp| app.ui_impl(ui), app);
+
+        // 初期状態: 未編集なので dirty ではない。
+        assert!(!harness.state().has_changes(), "initial state must be clean");
+
+        // General タブの「Toggle window visibility with hotkey」チェックボックスを
+        // AccessKit ラベルで見つけてクリック。
+        let label = Tr(Language::En).cb_hotkey_toggle();
+        harness.get_by_label(label).click();
+        // run() は「repaint 要求が止まる」収束を前提とするが、この UI は checkbox の
+        // アニメーション等で毎フレーム repaint を要求し発散する。ここで観測するのは
+        // 収束後の描画ではなく draft の内部状態なので、固定ステップでクリック（press→release）
+        // を処理させれば十分。
+        for _ in 0..4 {
+            harness.step();
+        }
+
+        // 編集後: draft != saved で dirty になる（内部状態を Harness 経由で観測）。
+        assert!(
+            harness.state().has_changes(),
+            "clicking the checkbox must make draft != saved (dirty)"
+        );
     }
 }

--- a/workspace/plan.md
+++ b/workspace/plan.md
@@ -63,6 +63,16 @@ draft/saved モデルと検証死角に対応するシナリオを追加:
 
 **不要**。挙動変更なし（テストインフラ追加 + 機械的リファクタのみ）。IPC 契約・状態遷移・フローに変更なし。`ui_impl` 切り出しは実装事実の内部整理で、SPEC の意図に影響しない。
 
+## as-built（実装後の差分記録）
+
+Phase 1 スパイクの実証で計画から変わった点:
+
+- **テストは `tests/settings_ui.rs` でなくインライン `app.rs #[cfg(test)] mod tests`**: `SettingsApp`/`new`/`has_changes` が private のため integration test から不可視。内部状態 assert にはインラインが必須。
+- **font DI 不要**: `list_system_fonts()`（Win32 GDI）はヘッドレスでも動作。`new_for_test` は追加せず `new()` をそのまま使用（計画からさらに単純化）。
+- **`Harness::run()` でなく `settle`（固定 step）**: UI が checkbox アニメで毎フレーム repaint 要求 → `run()` は収束前提で panic。`step()` を数回。
+- **実装したテスト**: `kittest_checkbox_click_makes_draft_dirty` / `kittest_discard_reverts_draft_to_saved` / `kittest_reset_to_default_makes_dirty` / `kittest_save_with_validation_error_keeps_saved`（フッターボタン wiring + save→validate 経路。dirty-dot/modal は純ロジックテスト済みのため重複回避）。
+- **検証結果**: `cargo test -p snotra-settings` 32 passed / `cargo clippy --all-targets -D warnings` クリーン。
+
 ## セルフレビュー
 
 ### `/plan-review`（Explore 2体: Rust feasibility / CI・docs 同期）+ 主エージェント直接確認

--- a/workspace/plan.md
+++ b/workspace/plan.md
@@ -1,0 +1,92 @@
+# plan — #440 egui ヘッドレス UI テスト導入
+
+## 結論（推奨パス）
+
+research の実証に基づく判断:
+
+- **採用**: `egui_kittest` の **AccessKit 操作テスト**（wgpu なし）。決定的・GPU 不要・CI 安定。設定 GUI の状態遷移／バリデーション／ダーティ判定／モーダル状態機械という「ロジック検証死角」を自動化する。
+- **非採用（CI ゲート）**: **wgpu スナップショット**。フォント/GPU/driver 依存で flaky、かつ環境差吸収 threshold が #399 型欠陥をマスクするため ROI が低い。将来ローカル opt-in の余地は残すが CI では回さない。
+- **任意（低優先・別 issue 候補）**: 起動時スクショ artifact 保存。assert しない目視補助。release smoke（#441）の延長で安価だが、本 issue の必須スコープには含めない。
+
+この plan は **Phase 1（スパイク = 実証）を最初に置き、そこで採用是非を最終確定**する。スパイクが green なら Phase 2〜3 に進み、赤なら research の未解決点を反映して再判断する。
+
+## 変更ファイル一覧
+
+| ファイル | 変更内容 | Phase |
+|---------|---------|-------|
+| `snotra-settings/Cargo.toml` | `[dev-dependencies] egui_kittest = { version = "0.35", default-features = false }`（wgpu/snapshot feature は付けない） | 1 |
+| `snotra-settings/src/app.rs` | `SettingsApp::ui()` から `fn ui_impl(&mut self, ui: &mut egui::Ui)` を切り出し、eframe の `ui()` はそれを呼ぶだけにする。テスト用コンストラクタ `new_for_test(config, font_list)`（または `list_system_fonts` の DI）を追加 | 1 |
+| `snotra-settings/tests/settings_ui.rs`（新規） | egui_kittest による AccessKit 操作テスト（下記シナリオ） | 2 |
+| `snotra-settings/CLAUDE.md` | 「ユニットテストは書かない方針」の**例外拡張**を明文化（egui_kittest による操作テストは書ける／スナップショットは CI で回さない理由）。モジュール構成に `tests/` 追記 | 3 |
+| `.github/workflows/ci.yml` | rust-check の `cargo test (snotra-settings)` が新テストを含むことを確認（既に #444 で test ステップ追加済み。feature 追加なしなら**変更不要**の可能性大 → 実測で確定） | 3 |
+| `docs/build-commands.md` | 検証チェックリストに影響あれば同期（テストコマンドは既存の `cargo test -p snotra-settings` で足りる見込み → 差分が出たときのみ） | 3 |
+
+## 実装順序（フェーズ分け）
+
+### Phase 1 — スパイク（実証で採用是非を確定）
+1. `egui_kittest = "0.35"`（wgpu/snapshot なし）を dev-dependency に追加。
+2. `ui_impl` 切り出し + `new_for_test` 追加。`cargo build -p snotra-settings` green を確認。
+3. **最小テスト 1 本**（例: General タブでホットキー入力を変える → `harness` 経由で `has_changes()` 相当が true）を書いて `cargo test -p snotra-settings` が**ローカルで green** かつ **CI windows で green** になることを確認（この 1 点が採用可否の決め手＝実証）。
+   - `list_system_fonts()` がヘッドレスで空 Vec を返すだけなら DI 不要。panic するなら `new_for_test` で注入。→ 実測で分岐。
+4. **ゲート**: Phase 1 が赤（wgpu 抜きでも AccessKit が回らない / Harness に載らない）なら、fallback（スクショ artifact）へ切替を再検討し plan を更新してからユーザーに報告。
+
+### Phase 2 — 操作テスト拡充（Phase 1 green 前提）
+draft/saved モデルと検証死角に対応するシナリオを追加:
+- **dirty flow**: draft 編集 → `has_changes()` true → タイトル `*`
+- **Discard**: 編集後 Discard → `draft == saved`
+- **Reset to default**: → `draft == Config::normalized_default()`、`has_changes()` true
+- **バリデーションエラー**: 不正入力（例: window width を最小未満）で Save → ステータスにエラー、`saved` 不変（disk 非依存 = `validate()` 分岐）
+- **タブ別ダーティ点**: あるセクションを編集 → 対応タブのみ `•`
+- **モーダル状態機械**: index/opener/instant いずれかで Create → Save で Vec に push、Edit → 上書き、Delete（`tabs/common.rs` の境界チェック込み）
+
+各テストは AccessKit ノード操作 + 内部状態 assert。disk 書き込みを伴う Save 成功経路は snotra-core 側テストに委ね、settings 側は「Save 前分岐」「Discard」「dirty」に限定する。
+
+### Phase 3 — ドキュメント同期
+- `snotra-settings/CLAUDE.md`: 「ユニットテスト書かない方針」の例外に「egui_kittest 操作テスト（AccessKit）は書く。wgpu スナップショットは環境差 flaky + #399 型欠陥をマスクするため CI 非採用」を追記。`tests/settings_ui.rs` をモジュール構成へ。
+- 視覚回帰（#399 型・レイアウト崩れ）は依然として**人手視覚スモークが唯一の検知手段**である旨を維持（メモリ `feedback_codex_review_unreliable` の境界と整合）。
+- `docs/build-commands.md` / `ci.yml` は実測差分が出たときのみ同期。
+
+## 不変条件
+
+- **egui 描画コードを書き換えない**: `ui_impl` 切り出しは純粋な機械的抽出（`_frame` 未使用のため挙動不変）。eframe の `ui()` は `ui_impl` への 1 行委譲になる。切り出し前後で `cargo run -p snotra-settings` の視覚スモークが同一であることを目視確認する（レイアウト崩れ観点）。
+- **テスト専用経路が本番挙動を変えない**: `new_for_test` / font_list DI は `#[cfg(test)]` もしくはテスト専用引数に閉じ、`run()` の本番パス（`list_system_fonts()` 呼び出し）を変えない。
+- **CI に GPU 依存を持ち込まない**: dev-dependency は `default-features = false` で wgpu/snapshot を**引き込まない**。これにより既存 CI（windows ランナー、GPU なし）がそのまま回る。feature 追加は将来 opt-in の別判断。
+- **失敗時の挙動**: Phase 1 スパイクが CI で不安定なら、feature/インフラを増やす前に fallback へ退避（本 plan の Phase 1 ゲート）。回復不能な状態フラグ・プロセス・Win32 フックは導入しない（純テストコードのみ）。
+
+## テスト方針
+
+- 追加テスト: `snotra-settings/tests/settings_ui.rs`（egui_kittest）。検証する不変条件は各シナリオ（dirty / discard / reset / validation / dirty-dot / modal）。
+- 検証コマンド: `cargo test -p snotra-settings`（category A）、`cargo clippy -p snotra-settings`（PostToolUse フック自動）、`cargo run -p snotra-settings` 視覚スモーク（`ui_impl` 切り出しの挙動不変確認）。
+- Red→Green: Phase 1 の最小テストは、まず AccessKit で「操作 → 状態変化」を書き、切り出し前は Harness に載らない（コンパイル不可）= Red、`ui_impl` 追加で Green。
+
+## SPEC.md 更新要否
+
+**不要**。挙動変更なし（テストインフラ追加 + 機械的リファクタのみ）。IPC 契約・状態遷移・フローに変更なし。`ui_impl` 切り出しは実装事実の内部整理で、SPEC の意図に影響しない。
+
+## セルフレビュー
+
+### `/plan-review`（Explore 2体: Rust feasibility / CI・docs 同期）+ 主エージェント直接確認
+
+**要対処: なし。** Step 2b（独立再導出）は本計画が局所的（単一 crate・rename/config キー/移行/横断スイープなし）のためトリガー外 = 省略。
+
+**問題なし（一次資料で確認）**
+- `_frame` は `app.rs:275` のシグネチャのみに出現（他の一致はコメント `id_next_frame`）→ `ui_impl` 切り出しは**挙動不変**。
+- `SettingsApp::ui` の直接呼び出し元は src に無し（eframe 内部のみ）。タブの `ui` は別 free 関数で無関係。`SettingsApp::new` の呼び出し元は `run()`（`app.rs:619`）のみ → `new_for_test` 追加は本番パス不変。
+- `save()` は `validate()`（`app.rs:198`）を `config.save()`（`app.rs:208`, disk 書き込み）**前に**呼ぶ → バリデーションテストは disk 非依存で成立。
+- `egui_kittest 0.35` は `[features]` に `default` エントリが**無く全 opt-in**（`ci.yml` は windows-latest・GPU なし）→ AccessKit テストは feature 追加なしで回る。`ci.yml:68-69` に `cargo test -p snotra-settings` 実在、cargo autodiscovery で `tests/settings_ui.rs` を自動収集 → **CI 変更不要**（実測前でも確定）。`docs/build-commands.md:17` に該当コマンド既存。
+- CLAUDE.md 方針例外拡張 + `tests/` モジュール構成追記は計画に含む（AGENTS.md:42 準拠）。SPEC.md 更新不要は妥当。
+
+**軽微な懸念（実装時に注意）**
+1. `ci.yml:72` の clippy は `--all-targets -- -D warnings` → 新規 integration test も lint 対象。`tests/settings_ui.rs` は clippy クリーン必須。
+2. `egui_kittest` はデフォルト feature ゼロのため `default-features = false` は冗長。ただし将来版が default を追加した際の防御として**明示 + コメント**で残す（`# wgpu/snapshot を引き込まない意図`）。
+
+### セルフレビューチェックリスト（Step 5b）
+
+1. **対称コードパス**: `ui()`/`new()` に対称ペアなし。テストが行使する Create/Edit/Delete・Discard/Save は既存の状態機械で、新規ペアを追加しない。
+2. **影響範囲の網羅性**: `_frame`・`ui()`・`new()`・`list_system_fonts` の呼び出し元を grep 済み（上記）。
+3. **境界条件**: モーダル境界チェック（`common.rs` の index 陳腐化ガード）は既存テスト対象。バリデーション最小値・空入力を Phase 2 シナリオに含む。
+4. **リソース管理**: 新規リソース（listen/子プロセス/AtomicBool）の生成なし。純テストコード + dev-dependency のみ。
+5. **既存パターン整合**: egui 描画は書き換えず `ui_impl` 委譲のみ。テスト用 DI は `common.rs` の既存パターン（純ロジック分離）と整合。
+6. **YAGNI 違反**: wgpu スナップショットを**採らない**判断で範囲を絞る。fallback スクショは必須スコープ外（別 issue 候補）。
+7. **シンプル化**: `new_for_test` を増やすより `list_system_fonts` を「起動時に渡す引数」に変える方が薄いかは Phase 1 スパイクで実測比較（薄い方を採る）。新状態フラグ・Mutex・子プロセスの導入なし。
+8. **破壊不変条件**: Win32 フック/ホットキー/IPC に触れない。唯一の runtime リスクは `ui_impl` 切り出しのレイアウト崩れ = `cargo run -p snotra-settings` 視覚スモークで検知（不変条件に明記済み）。

--- a/workspace/research.md
+++ b/workspace/research.md
@@ -1,0 +1,94 @@
+# research — #440 egui 設定 GUI のヘッドレス UI テスト導入検討
+
+## issue の要約
+
+設定 GUI（`snotra-settings`, egui）は「型検査 + clippy + 人手の視覚スモーク」だけで守られており、コードベース最大の検証死角。egui はネイティブ描画のため WebDriver ベース E2E から原理的に不可視。egui 公式のヘッドレステストハーネス `egui_kittest`（AccessKit 経由の操作 + スナップショット比較）を評価し、以下を判断する:
+
+1. draft/saved フロー・バリデーションの**操作テスト**が書けるか（AccessKit 経由）
+2. **スナップショット比較**で #399 型の視覚回帰を検知できるか（フォントレンダリングの環境差にどう耐えるか）
+3. **CI**（GitHub Actions windows ランナー）で安定して回るか
+
+導入コストが見合わない場合の代替（起動スモーク + タブのスクリーンショット保存）も比較する。
+
+## 確定した事実（実証・一次情報）
+
+### egui_kittest 0.35 は存在し、eframe 統合機能を持つ
+
+`cargo add egui_kittest@0.35 --dev -p snotra-settings --dry-run` の実行結果:
+
+```
+Adding egui_kittest v0.35 to dev-dependencies
+Features as of v0.35.0:
+- document-features
+- eframe      ← eframe::App を直接テストする統合
+- snapshot    ← 画像スナップショット比較（wgpu 必須）
+- wgpu        ← GPU レンダラ（スナップショットに必要）
+- x11
+```
+
+- eframe 0.35 と**バージョン整合**（egui_kittest は egui/eframe とロックステップでリリース）。本 crate は `eframe = "0.35"` なので追加互換性リスクは低い。
+- `eframe` feature があり、`SettingsApp`（`impl eframe::App`）をそのまま Harness に載せる経路がありうる（詳細は要スパイク）。
+
+### API 形状が `SettingsApp::ui()` とほぼ一致（切り出しが薄い）
+
+context7（`/websites/crates_io_crates_egui_kittest`）の README:
+
+```rust
+let app = |ui: &mut egui::Ui| { ui.checkbox(&mut checked, "Check me!"); };
+let mut harness = Harness::new_ui(app);
+let checkbox = harness.get_by_label("Check me!");
+checkbox.click();
+harness.run();
+assert_eq!(harness.get_by_label("Check me!").accesskit_node().toggled(), Some(Toggled::True));
+harness.fit_contents();
+#[cfg(all(feature = "wgpu", feature = "snapshot"))]
+harness.snapshot("readme_example");   // 画像スナップショットは wgpu+snapshot 限定
+```
+
+- `Harness::new_ui(|ui: &mut egui::Ui| …)` は**現行の `SettingsApp::ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame)`（`app.rs:275`）とシグネチャがほぼ一致**。`_frame` は未使用（アンダースコア）なので、`fn ui_impl(&mut self, ui: &mut egui::Ui)` を切り出して両方（eframe の `ui()` と kittest Harness）から呼べば、egui 描画コードを一切書き換えずにヘッドレステスト可能。
+- 操作は AccessKit ツリー経由（`get_by_label` / `.click()` / `.run()`）。**wgpu 不要**。
+
+### スナップショットの環境差リスク（context7 一次情報）
+
+egui_kittest 公式ドキュメント「What to do when CI / another computer produces a different image?」が明示:
+
+- 画像差は **GPU / OS / レンダリングバックエンド（Metal/Vulkan/DX12）/ グラフィックドライバ**依存。MSAA のサンプル配置・テクスチャフィルタ・浮動小数点評価・偏微分（dpdx）の実装差で発生。
+- 対策は「全 test run で feature を統一」「`SnapshotOptions::threshold` と許容ピクセル数を調整」だが、**「許容度を上げすぎると本物の失敗をマスクする」と警告**。
+
+## テスト可能性の分析（コード側の制約）
+
+### 操作テスト（AccessKit）— 実現可能・障壁小
+
+`SettingsApp` の draft/saved 二重状態モデルは純ロジック（`has_changes()` = `draft != saved`, `save()`, `reset_to_default()`, `SECTION_TABLE` ダーティ点導出）。AccessKit 経由で「入力ウィジェットを操作 → 内部状態を assert」が書ける。
+
+検証死角として issue が挙げた項目のうち **AccessKit で書けるもの**:
+- draft 編集 → `has_changes()` true → ウィンドウタイトル `*` 付与
+- Discard クリック → `draft = saved` で編集破棄
+- Reset to default → `draft = normalized_default()`
+- バリデーションエラー時のステータス表示（`save()` は `validate()` を disk 書き込み前に呼ぶ = **バリデーション経路は disk に触れずテスト可能**）
+- タブ別ダーティ点（`•`）の導出
+- モーダル Create/Edit 状態機械（`tabs/common.rs`）
+
+### 障壁: `new()` の Win32 依存と `save()` の disk 書き込み
+
+- `SettingsApp::new()` は `crate::font::list_system_fonts()`（Win32）を呼ぶ（`app.rs:173`）。ヘッドレス CI では列挙結果が dev 機と異なる/空になりうる。テスト用に **font_list を注入する `new_for_test(config, font_list)` 経路**か、`list_system_fonts` を DI 可能にする必要がある。
+- `save()` の成功経路は `Config::save()` で**実 `config.toml` に書き込む**（`app.rs:208`）。Save クリックの成功をテストするには temp dir 注入が要る。ただし **disk 書き込み後の状態遷移（`saved = draft`）は snotra-core 側の `Config::save`/`load` テストで既にカバー**されており、settings 側の操作テストは「Save 前のバリデーション分岐」「Discard」「dirty 判定」に絞れば disk 注入なしで成立する。
+
+### スナップショットテスト — 実現可能だが CI 安定性に本質的リスク
+
+- `snapshot` + `wgpu` feature が要る。Windows GH Actions ランナーで wgpu を回すには DX12 か software adapter（WARP）が要り、**フォントレンダリングが system font（Yu Gothic UI / Segoe UI）依存**。日本語見出しを含む本 UI のスナップショットは dev 機と CI で確実にピクセル差が出る。
+- 環境差を吸収する高い threshold は、issue が検知したい **#399 型欠陥（混在見出しのサブピクセル・ベースラインずれ）そのものをマスク**する。つまりスナップショットは「守りたい欠陥クラス」と「吸収したいノイズ」が同じ粒度に居るため、この特定欠陥に対する ROI が低い。
+
+## 代替案（fallback）との比較
+
+| 手段 | 検知できる欠陥 | CI 安定性 | コスト | #399 型検知 |
+|------|--------------|----------|--------|-----------|
+| AccessKit 操作テスト | 状態遷移・バリデーション・ダーティ・モーダルの**ロジック回帰** | ◎ 決定的・GPU 不要 | 小（`ui_impl` 切り出し + テスト） | ✗（レイアウトは見ない） |
+| wgpu スナップショット | レイアウト・レンダリング回帰（理論上） | △ GPU/フォント/driver 依存で flaky | 中（feature + threshold 調整の継続コスト） | △ 高 threshold がマスクする |
+| 起動スモーク + スクショ保存（fallback） | クラッシュ・パニック（起動時）+ **人手レビュー補助** | ◎ assert しない artifact 保存なら安定 | 小（release smoke #441 の延長） | ✗ 自動検知はしない（目視補助のみ） |
+
+## 未解決の疑問（スパイクで確定させる = /implement Phase 1）
+
+1. `egui_kittest` の `eframe` feature で `SettingsApp`（`impl eframe::App`）を直接載せられるか、それとも `Harness::new_ui(ui_impl)` の方が薄いか。→ 両方試して薄い方を採る。
+2. `list_system_fonts()` のヘッドレス挙動（空 Vec を返すか panic か）。→ 空でも Harness が回るなら注入不要かもしれない。
+3. GH Actions windows ランナーで `cargo test -p snotra-settings`（wgpu **なし**、AccessKit のみ）が追加インフラなしで green になるか。


### PR DESCRIPTION
## 概要

設定 GUI（`snotra-settings`, egui）は「型検査 + clippy + 人手の視覚スモーク」だけで守られており、コードベース最大の検証死角だった（#440）。egui 公式ヘッドレステスト `egui_kittest`（AccessKit）を評価・導入し、**UI 操作 + 状態観測**の自動テストを追加する。

## 評価結論（#440 の 3 問への判断）

| 問い | 結論 |
|---|---|
| ① AccessKit 操作テストが書けるか | ✅ **採用**。実 `SettingsApp` UI をヘッドレスで Harness に載せ、ボタン/checkbox を操作して `draft/saved` 状態を観測できる |
| ② スナップショットで #399 型を検知できるか | ⛔ **非採用**。wgpu 必須・フォント/GPU/driver 依存で CI flaky、かつ環境差を吸収する threshold が狙う欠陥そのものをマスクする（ROI 低） |
| ③ CI で安定して回るか | ✅ wgpu なし（`default-features = false`）・GPU 不要・決定的。既存 `cargo test -p snotra-settings` ステップで自動収集 |

**境界**: レイアウト・レンダリング欠陥（#399 型）は引き続き人手の視覚スモークが唯一の検知手段。kittest は AccessKit ツリー（操作・状態）に限る。

## 変更内容

- **`Cargo.toml`**: `egui_kittest = "0.35"` を dev-dependency 追加（`default-features = false` で wgpu/snapshot/x11 非導入）
- **`app.rs`**: `App::ui()` から `eframe::Frame` 非依存の `ui_impl()` を機械的切り出し（`_frame` 未使用 = 挙動不変）。`ui()` は 1 行委譲
- **`app.rs` テスト**（インライン `#[cfg(test)] mod tests`。`SettingsApp` が private のため `tests/` 不可）:
  - `kittest_checkbox_click_makes_draft_dirty` — 編集 → dirty
  - `kittest_discard_reverts_draft_to_saved` — Discard ボタン wiring
  - `kittest_reset_to_default_makes_dirty` — Reset ボタン wiring
  - `kittest_save_with_validation_error_keeps_saved` — Save → validate 経路（不正 draft を disk に書かない）
- **`snotra-settings/CLAUDE.md`**: 「ユニットテスト書かない方針」に egui_kittest 例外を明文化 + 「ヘッドレス UI テスト」節（パターン・境界・wgpu 非採用の判断）

## 検証

- `cargo test -p snotra-settings` — **32 passed**（kittest 4 本含む）
- `cargo clippy -p snotra-settings --all-targets -- -D warnings` — クリーン
- `ui_impl` 切り出しは既存 31 テスト green で挙動不変を確認

## マージ前チェックリスト

- [x] GitHub Actions windows ランナーで kittest テストが green（本 PR CI で最終確認）— rust-check pass 5m20s
- [ ] `cargo run -p snotra-settings` の視覚スモーク（`ui_impl` 切り出し後のレイアウト目視 — 機械的抽出だが plan の不変条件として明記）

## 関連

- Closes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)
