### PR TITLE
chore(claude-md): 小型モデル向けに全 CLAUDE.md をルール前置・表形式へ再構成

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,34 +2,53 @@
 
 このリポジトリで Claude Code が作業するときの運用ガイド。
 
+- 共通開発プロセス（ワークフロー・事前チェック・環境制約）は `AGENTS.md`（次行で自動読込）
+- モジュール固有の不変条件は各サブディレクトリの `CLAUDE.md`（`snotra-core/` / `src-tauri/` / `ui/` / `snotra-settings/`）
+- 本ファイルの各ルールは「**太字 = 守る指示**、後続 = 理由・過去の事故」の形式。迷ったら太字部分に従えば安全
+
 @AGENTS.md
 
-## 補足（Claude Code 固有）
+## 最重要ルール（常に適用）
 
-- context7 MCP が設定済み。Tauri v2 / SolidJS / Rust クレートの最新 API を調べる際は context7 を使う
+作業種別を問わず適用される4つ。詳細は各セクションを参照。
+
+1. **`main` へ直接コミット・プッシュしない** — 必ず feature ブランチ（`feat/<機能名>` / `fix/<バグ名>` / `chore/<作業名>`）を作成してからコミットする
+2. **`git` コマンドを `&&` でチェーンしない** — 1操作 = 1呼び出し（→「Git/GitHub 運用」）
+3. **bash の HEREDOC（`<<EOF`）を使わない** — 複数行テキストは一時ファイルか PowerShell here-string（→「シェル環境」）
+4. **エージェント設定（スキル・フック・rules）の変更は合意してから** — Claude が単独で判断しない（→「チーム憲章」）
+
+## MCP ツール
+
+- **Tauri v2 / SolidJS / Rust クレートの最新 API 調査には context7 MCP を使う**（設定済み）
 
 ## シェル環境（Windows / PowerShell）
 
 このリポジトリは Windows + PowerShell 環境で運用されている。Bash 系の慣習をそのまま持ち込むと、過去のセッションで複数回踏んだ摩擦を再発させる。
 
-- **bash の HEREDOC（`<<EOF` / `<<'EOF'`）を使わない** — PowerShell では here-string の引用境界が壊れ、終端マーカーがコミットメッセージ本文に漏れる事故が起きている。複数行のコミットメッセージは一時ファイルに書き出して `git commit -F <tmpfile>` を使うか、PowerShell の here-string `@'...'@`（閉じ `'@` は必ず行頭）を使う
-- **パス区切りは `/` を優先** — PowerShell でも Git/Node/Cargo は `/` を受け付ける。`\` を含めるとエスケープが必要になるため、文字列中のパスは `/` で統一する
-- **Bash ツールに `/tmp` は無い（Windows）** — 一時ファイルは `$env:TEMP` 配下に置くか Write ツールで作る。`cat > /tmp/...` は `FileNotFoundError` で失敗する
-- **Python で非 ASCII を標準出力するときは `PYTHONIOENCODING=utf-8` を付ける** — cp932 コンソールで `—`・日本語などを print すると `UnicodeEncodeError` で落ちる（JSON/ログ整形で多用）
+| やらないこと | 代わりにやること | 理由（過去の事故） |
+|---|---|---|
+| bash の HEREDOC（`<<EOF` / `<<'EOF'`） | 一時ファイルに書き出して `git commit -F <tmpfile>`、または PowerShell here-string `@'...'@`（閉じ `'@` は必ず行頭） | here-string の引用境界が壊れ、終端マーカーがコミットメッセージ本文に漏れる事故が起きている |
+| 文字列中のパスに `\` 区切り | `/` で統一する | PowerShell でも Git/Node/Cargo は `/` を受け付ける。`\` はエスケープが必要になり壊れやすい |
+| `/tmp` への書き込み | `$env:TEMP` 配下に置くか Write ツールで作る | Windows の Bash ツールに `/tmp` は無く、`cat > /tmp/...` は `FileNotFoundError` で失敗する |
+| Python で非 ASCII をそのまま標準出力 | `PYTHONIOENCODING=utf-8` を付ける | cp932 コンソールで `—`・日本語などを print すると `UnicodeEncodeError` で落ちる（JSON/ログ整形で多用） |
 
 ## Git/GitHub 運用
 
-- **`git` コマンドをチェーンしない** — `git checkout <branch> && git rebase main` のような連鎖は `block-main-commit` フックを誤発火させた実績がある。`checkout` と `rebase`、`add` と `commit` のように影響範囲の異なる操作はそれぞれ独立した呼び出しに分ける
+- **`git` コマンドをチェーンしない** — `checkout` と `rebase`、`add` と `commit` のように影響範囲の異なる操作はそれぞれ独立した呼び出しに分ける。`git checkout <branch> && git rebase main` のような連鎖は `block-main-commit` フックを誤発火させた実績がある
 - **main の fast-forward 同期は `git pull --ff-only` を使う** — `git merge --ff-only origin/main` はコミットを作らない FF でも `block-main-commit` フックに弾かれる（コマンド文字列一致で判定するため）
-- **複数 issue にまたがる PR を squash マージするとき auto-close を明示制御する** — ブランチ各コミット本文の `Fixes/Closes #N` は squash 時に GitHub が拾い、意図しない issue を閉じうる。一部だけ閉じたい場合（例: 中核 issue は Phase 残しで open、対症療法 issue のみ close）は `gh pr merge --squash --subject "...(#issue) (#PR)" --body-file <tmp>` で最終メッセージを明示し、`Closes`/`Refs` を制御する。マージ後は `gh issue view <N> --json state` で意図どおりか検証する
+- **複数 issue にまたがる PR を squash マージするとき auto-close を明示制御する** — ブランチ各コミット本文の `Fixes/Closes #N` は squash 時に GitHub が拾い、意図しない issue を閉じうる。一部だけ閉じたい場合（例: 中核 issue は Phase 残しで open、対症療法 issue のみ close）の手順:
+  1. `gh pr merge --squash --subject "...(#issue) (#PR)" --body-file <tmp>` で最終メッセージを明示し、`Closes`/`Refs` を制御する
+  2. マージ後に `gh issue view <N> --json state` で意図どおり閉じた/残ったかを検証する
 
 ## フック（.claude/settings.json）
 
 エージェントの操作には以下のフックが介入する。発火条件の正確な定義は `.claude/settings.json` を SSOT とする。
 
-- **`block-main-commit`（PreToolUse）**: main ブランチ上の `git commit` / `merge` / `rebase` を拒否する。feature ブランチを作成してから操作する
-- **PR 作成前 push チェック（PreToolUse）**: 未 push コミットまたは upstream 未設定の状態での `gh pr create` を拒否する（空 PR / `Closes` 誤 close 防止）。`git push -u origin HEAD` してから PR を作る
-- **編集後の自動検証（PostToolUse）**: `.rs` 編集で clippy（`snotra-core` 編集では core テストも）、`.ts`/`.tsx` 編集で typecheck が自動実行される。Edit/Write 後に会話へ流れる clippy / typecheck 出力はこのフック由来であり、手動での再実行は不要
+| フック | 発火条件 | 正しい対応 |
+|---|---|---|
+| `block-main-commit`（PreToolUse） | main ブランチ上の `git commit` / `merge` / `rebase` | feature ブランチを作成してから操作する |
+| PR 作成前 push チェック（PreToolUse） | 未 push コミットまたは upstream 未設定での `gh pr create`（空 PR / `Closes` 誤 close 防止） | `git push -u origin HEAD` してから PR を作る |
+| 編集後の自動検証（PostToolUse） | `.rs` 編集 → clippy（`snotra-core` 編集では core テストも）、`.ts`/`.tsx` 編集 → typecheck | Edit/Write 後に会話へ流れる clippy / typecheck 出力はこのフック由来であり、手動での再実行は不要 |
 
 ## チーム憲章
 
@@ -43,14 +62,21 @@ Claude とユーザーが一緒に作業するときの関係性の原則。
 
 ## コミュニケーション原則
 
-- タスクが真に曖昧でない限り、分析・計画より実行にバイアスをかける
-- ユーザーが具体的な計画や修正指示を既に提示している場合、プランモードへの遷移・事前の全体探索を禁止する。読むファイルは直接関係する最小限（1〜2ファイル）に絞り、最初の Edit/Write から着手する
-- コミット・PR 作成を指示された場合、確認やプランモードなしに即実行する
-- コミットを作成するときは**必ず feature ブランチを作成してから**行う。`main` への直接コミット・プッシュは禁止。ブランチ名は `feat/<機能名>` / `fix/<バグ名>` / `chore/<作業名>` とする
-- ユーザーが計画書・設計書を提示して実装を依頼した場合、内容を忠実に実装する。計画書の要素を省略・統合・削除するのは明示的に指示された場合のみ行う
-- `/simplify` などのコードレビュー系スキルを実行するとき、意図的なリファクタリング（分割・名前変更・責務分離）の結果を元に戻さない。「重複に見えるが意図的に分けた」構造は、ユーザーに確認してから変更する
-- 不明点がある場合は、1つの焦点を絞った質問をしてから実装に移る
-- ユーザーが分析・調査・助言を求めた場合は、調査結果のみを報告する。明示的に指示されない限り、実装計画やコード変更に踏み込まない
+### 着手の判断
+
+- **タスクが真に曖昧でない限り、分析・計画より実行にバイアスをかける**
+- **ユーザーが具体的な計画や修正指示を既に提示している場合、プランモードへの遷移・事前の全体探索を禁止する** — 読むファイルは直接関係する最小限（1〜2ファイル）に絞り、最初の Edit/Write から着手する
+- **コミット・PR 作成を指示された場合、確認やプランモードなしに即実行する** — コミットは必ず feature ブランチで行う（→「最重要ルール」1）
+- **不明点がある場合は、1つの焦点を絞った質問をしてから実装に移る**
+
+### 実装・レビュー時
+
+- **計画書・設計書を提示された実装は、内容を忠実に実装する** — 計画書の要素を省略・統合・削除するのは明示的に指示された場合のみ行う
+- **意図的なリファクタリングの結果を元に戻さない** — `/simplify` などのコードレビュー系スキルを実行するとき、意図的な分割・名前変更・責務分離は維持する。「重複に見えるが意図的に分けた」構造は、ユーザーに確認してから変更する
+
+### 調査・助言の依頼
+
+- **分析・調査・助言を求められたら、調査結果のみを報告する** — 明示的に指示されない限り、実装計画やコード変更に踏み込まない
 
 ## 利用できるスキル
 

--- a/snotra-core/CLAUDE.md
+++ b/snotra-core/CLAUDE.md
@@ -2,13 +2,34 @@
 
 純ロジック lib crate（13モジュール + `lib.rs`）。Win32 非依存でユニットテスト可能。
 
+- 各ルールは「**太字 = 守る指示**、後続 = 理由・経緯」の形式。迷ったら太字部分に従えば安全
+- 本ファイルの構成: モジュール構成（責務 + モジュール別の不変条件）→ 開発ルール・実装前チェック → クロスモジュール不変条件 → データ永続化 → モジュール別の詳細規約
+
 ## モジュール構成
 
-- `engine.rs`: `Engine` struct（`SearchEngine` + `HistoryStore` + `Config` の facade）。`FolderListContext`（ロック外スナップショット）と `PrebuiltIndex`（インデックス高速スワップ用）を公開。**`IndexInputs`（index 構築入力 scan/show_hidden_system/show_icons/include_path_env/migemo_enabled の単一定義）と `index_stale` ledger**（`mark_index_stale` / `begin_index_drain` → snapshot / `complete_index_drain` → swap + re-diff で stale をクリア / `is_index_stale`）でコヒーレンシ判断を engine Mutex（軸1）に閉じ、config 変更→index 再構築の lost-update を塞ぐ（#347/#348-A）。`complete_index_drain` は「ビルド開始時 snapshot == 現在 IndexInputs」のときだけ stale をクリアする（ビルド中変更を取りこぼさない）
-- `config.rs`: `%APPDATA%\Snotra\config.toml` の読込/保存、既定値補完。`Language` enum（`Ja`/`En`）と `default_language()`（`sys-locale` による OS 言語自動判定、非日本語は英語フォールバック）を定義。**件数パラメータ**（#388 で役割に合わせて改名済み）: `appearance.visible_rows`=可視行数、`search.result_limit`=**検索・フォルダの結果リスト最大長**（`Engine::search`/`capture_folder_list_context` の fetch_limit）、`search.recent_limit`=空クエリ recent 件数（`recent_history`）。旧キー（`max_results`/`top_n_history`/`max_history_display`）は `apply_migrations()` が `skip_serializing` の legacy フィールド経由で後方互換移行する（2層レガシー: `result_limit` ← `[search].top_n_history` ← `[appearance].top_n_history`）。フロント `iconCacheSize` と `Config::icon_cache_cap()` はこれらから派生。実上限は名前でなく `engine.rs` の dispatch で確認する。**`apply_migrations()` は migration 系統ごとの private fn（`migrate_legacy_additional_paths` / `migrate_legacy_count_params` / `resolve_count_param_defaults` / `sanitize_fuzzy_history_cap_ratio` / `migrate_instant_legacy_commands` / `fallback_hotkey_if_system_shortcut`）へ段階分解済み（issue #435）。呼び出し順は元と同一に固定し、`migrate_legacy_additional_paths`（`paths.additional`→`scan` 追加）→ `paths.normalize_scan_paths()`（dedup）の順序だけは真の依存（先に追加されたエントリを後続の正規化がまとめて dedup する）。他のステップは独立だが diff 最小化のため元の並びを保つ**
-- `opener.rs`: opener（外部ツール起動ルール）ターゲットの解析・正規化・マッチングエンジンと、Win 環境のプリセット検出。`OpenerRule` / `OpenerTool` / `OpenerPreset` 型、`find_matching_tools`（パス・フォルダ判定に対する最具体1ルール解決。具体度=パス条件の長さ）、`extract_path_condition` / `extract_ext_part`、`normalize_openers`（ターゲット正規化・具体度順ソート）、`opener_specificity_order`、`detect_opener_presets`（VSCode/Windows Terminal/Explorer の検出）、`is_preset_already_added` を公開。`config.rs` から分離済み（issue #435、旧 `config.rs:88-735`/`1260-1363`）。**依存方向は `config.rs` → `opener.rs`**（`OpenerRule`/`OpenerTool` は `Config.openers` として config.toml に紐づく serde 型のため型定義はこちらに置き、`config.rs` が `pub use crate::opener::{...}` で re-export して `snotra_core::config::...` の既存呼び出し元パスを維持する）。逆方向の依存として `normalize_opener_target` が `config.rs::normalize_scan_path_key` / `normalize_extensions`（`pub(crate)`、`paths.scan` の正規化とも共有する汎用ヘルパー）を使う
-- `search.rs`: 検索順位計算（Prefix/Substring/Kana/Fuzzy/Path）、履歴ブースト、incremental search キャッシュ、空クエリ時履歴候補。`SearchEngine` は並列 Vec レイアウト（`entries` / `lower_names` / `lower_file_names` / `normalized_keys` / `char_masks` / `file_name_char_masks` / `kana_lower_names`）で cache locality を確保。構築は `compute_wave1`（文字列正規化）→ `compute_wave2`（ビットマスク計算）のヘルパー関数で共通化し、`new()`（= `new_with_migemo(.., true)`）/ `new_with_migemo(entries, migemo_enabled)` / `new_with_cached_masks(.., migemo_enabled)` が共有する。**`kana_lower_names` は `migemo_enabled` が true のときのみ構築し、無効時は空 Vec**（migemo 無効ユーザーの死蔵メモリ ~2.1–2.7MB/50k を削る・構築も約 2 倍速、issue #337）。空 Vec のとき検索ループは `kana_available` 空ガードで `kana_lower_names[i]` アクセスを回避する（構築時 migemo OFF→検索時 ON の窓での panic 防止）。migemo トグルの反映は `update_config` が engine を再構築しないため、`config_watcher` が engine の `IndexInputs` 差分で `start_index_build` を kick する再構築に依存する（#347 Phase 2 で `needs_reindex` は `IndexInputs` に統合）。パスマッチング: クエリにパス区切り文字（`\` `/`）を含む場合、`normalized_key`（= `normalize_entry_key(target_path)`）に対して Substring マッチを試みる。スコアは `3000 - min(byte_pos, 500)`。name/file_name/kana 全て不成立時のフォールバック。`has_path_sep` 時は Fuzzy ビットマスク pre-filter をスキップする
-- `history.rs`: 起動履歴・クエリ別履歴・フォルダ展開履歴の管理、バイナリ永続化。**剪定容量 `top_n` は焼き込まず `save`/`save_if_dirty`/`prune` の引数で受け取る（live-read）**。`Engine` が呼び出し時に現在の config（`effective_result_limit()`）を渡すため、`result_limit` 設定変更が再起動なしで反映される（#348）。`HistoryStore` に `top_n` フィールドを再導入しないこと——焼き込むと設定変更が反映されないドリフトが復活する
+- `engine.rs`: `Engine` struct（`SearchEngine` + `HistoryStore` + `Config` の facade）。`FolderListContext`（ロック外スナップショット）と `PrebuiltIndex`（インデックス高速スワップ用）を公開
+  - **`IndexInputs`**: index 構築入力（scan / show_hidden_system / show_icons / include_path_env / migemo_enabled）の単一定義
+  - **`index_stale` ledger**: `mark_index_stale` / `begin_index_drain` → snapshot / `complete_index_drain` → swap + re-diff で stale をクリア / `is_index_stale`。コヒーレンシ判断を engine Mutex（軸1）に閉じ、config 変更→index 再構築の lost-update を塞ぐ（#347/#348-A）
+  - **`complete_index_drain` は「ビルド開始時 snapshot == 現在 IndexInputs」のときだけ stale をクリアする**（ビルド中変更を取りこぼさない）
+- `config.rs`: `%APPDATA%\Snotra\config.toml` の読込/保存、既定値補完。`Language` enum（`Ja`/`En`）と `default_language()`（`sys-locale` による OS 言語自動判定、非日本語は英語フォールバック）を定義
+  - **件数パラメータ**（#388 で役割に合わせて改名済み）: `appearance.visible_rows` = 可視行数 / `search.result_limit` = **検索・フォルダの結果リスト最大長**（`Engine::search`/`capture_folder_list_context` の fetch_limit）/ `search.recent_limit` = 空クエリ recent 件数（`recent_history`）
+  - **旧キーの後方互換移行**: 旧キー（`max_results`/`top_n_history`/`max_history_display`）は `apply_migrations()` が `skip_serializing` の legacy フィールド経由で移行する（2層レガシー: `result_limit` ← `[search].top_n_history` ← `[appearance].top_n_history`）
+  - フロント `iconCacheSize` と `Config::icon_cache_cap()` はこれらから派生。実上限は名前でなく `engine.rs` の dispatch で確認する
+  - **`apply_migrations()` は migration 系統ごとの private fn へ段階分解済み**（issue #435）: `migrate_legacy_additional_paths` / `migrate_legacy_count_params` / `resolve_count_param_defaults` / `sanitize_fuzzy_history_cap_ratio` / `migrate_instant_legacy_commands` / `fallback_hotkey_if_system_shortcut`
+  - **migration の呼び出し順は元と同一に固定する**: `migrate_legacy_additional_paths`（`paths.additional`→`scan` 追加）→ `paths.normalize_scan_paths()`（dedup）の順序だけが真の依存（先に追加されたエントリを後続の正規化がまとめて dedup する）。他のステップは独立だが diff 最小化のため元の並びを保つ
+- `opener.rs`: opener（外部ツール起動ルール）ターゲットの解析・正規化・マッチングエンジンと、Win 環境のプリセット検出。`config.rs` から分離済み（issue #435、旧 `config.rs:88-735`/`1260-1363`）
+  - 公開 API: `OpenerRule` / `OpenerTool` / `OpenerPreset` 型、`find_matching_tools`（パス・フォルダ判定に対する最具体1ルール解決。具体度=パス条件の長さ）、`extract_path_condition` / `extract_ext_part`、`normalize_openers`（ターゲット正規化・具体度順ソート）、`opener_specificity_order`、`detect_opener_presets`（VSCode/Windows Terminal/Explorer の検出）、`is_preset_already_added`
+  - **依存方向は `config.rs` → `opener.rs`**: `OpenerRule`/`OpenerTool` は `Config.openers` として config.toml に紐づく serde 型のため型定義はこちらに置き、`config.rs` が `pub use crate::opener::{...}` で re-export して `snotra_core::config::...` の既存呼び出し元パスを維持する
+  - 逆方向の依存として `normalize_opener_target` が `config.rs::normalize_scan_path_key` / `normalize_extensions`（`pub(crate)`、`paths.scan` の正規化とも共有する汎用ヘルパー）を使う
+- `search.rs`: 検索順位計算（Prefix/Substring/Kana/Fuzzy/Path）、履歴ブースト、incremental search キャッシュ、空クエリ時履歴候補
+  - **並列 Vec レイアウト**: `SearchEngine` は `entries` / `lower_names` / `lower_file_names` / `normalized_keys` / `char_masks` / `file_name_char_masks` / `kana_lower_names` の並列 Vec で cache locality を確保
+  - **構築の共通化**: `compute_wave1`（文字列正規化）→ `compute_wave2`（ビットマスク計算）のヘルパー関数を `new()`（= `new_with_migemo(.., true)`）/ `new_with_migemo(entries, migemo_enabled)` / `new_with_cached_masks(.., migemo_enabled)` が共有する
+  - **`kana_lower_names` は `migemo_enabled` が true のときのみ構築し、無効時は空 Vec**（migemo 無効ユーザーの死蔵メモリ ~2.1–2.7MB/50k を削る・構築も約 2 倍速、issue #337）。空 Vec のとき検索ループは `kana_available` 空ガードで `kana_lower_names[i]` アクセスを回避する（構築時 migemo OFF→検索時 ON の窓での panic 防止）
+  - **migemo トグルの反映は index 再構築経由**: `update_config` は engine を再構築しないため、`config_watcher` が engine の `IndexInputs` 差分で `start_index_build` を kick する再構築に依存する（#347 Phase 2 で `needs_reindex` は `IndexInputs` に統合）
+  - **パスマッチング**: クエリにパス区切り文字（`\` `/`）を含む場合、`normalized_key`（= `normalize_entry_key(target_path)`）に対して Substring マッチを試みる。スコアは `3000 - min(byte_pos, 500)`。name/file_name/kana 全て不成立時のフォールバック。`has_path_sep` 時は Fuzzy ビットマスク pre-filter をスキップする
+- `history.rs`: 起動履歴・クエリ別履歴・フォルダ展開履歴の管理、バイナリ永続化
+  - **剪定容量 `top_n` は焼き込まず `save`/`save_if_dirty`/`prune` の引数で受け取る（live-read）**: `Engine` が呼び出し時に現在の config（`effective_result_limit()`）を渡すため、`result_limit` 設定変更が再起動なしで反映される（#348）
+  - **`HistoryStore` に `top_n` フィールドを再導入しないこと** — 焼き込むと設定変更が反映されないドリフトが復活する
 - `folder.rs`: フォルダ内列挙とフィルタ/ソート
 - `indexer.rs`: スキャン対象列挙と重複排除、インデックスキャッシュ
 - `query.rs`: クエリ正規化（`normalize_query`）、履歴クエリキー正規化（`normalize_history_query_key` — `normalize_query` + パス区切り統一を一元化）、`char_bitmask`（文字存在ビットマスク計算 — `search.rs` と `indexer.rs` の両方が使用）
@@ -16,14 +37,20 @@
 - `error.rs`: `BinError`（バイナリシリアライズ/デシリアライズ失敗）と `ConfigError`（設定バリデーション失敗）の error 型定義
 - `window_data.rs`: ウィンドウ位置（`window.bin`）の保存/復元
 - `instant.rs`: インスタントコマンドの処理。**公開関数**:
-  - `split_args(args: &str) -> Vec<String>`: シェル風クォート対応の引数分割。`"..."` で囲まれた部分はスペースを含んでも1トークンとして扱う。**`{...}` 内のスペースも分割しない**（`{query | trim}` 等の修飾子パイプを1トークンに保つ）。`launch.rs` から移設。
-  - 変数展開は**修飾子パイプ `{name | mod | ...}`**（name = query/clip/date/uuid、v1 修飾子 `lower`/`upper`/`trim`/`default:<text>`/`raw`）に対応する。内部の単一 walker `expand_template`（private）が `{...}` を走査し、変数解決 → 修飾子チェーン（左→右）→ シンク処理（`encode && !raw` のとき URL エンコード）を行う。**エンコードはシンク（種別）の責務**で修飾子は内容変換のみ（`urlencode` 修飾子は提供せず、`raw` が唯一の抑止）。未認識 `{...}`・閉じ `}` 不在はリテラル温存（total）。**`{{X}}` はエスケープで literal `{X}`**（変数名と衝突する literal の唯一の表現＝予約語が増えても opt-out が常に存在。中身は変数/修飾子として解釈しない。`walk_template` の `{`-found 分岐で `{{…}}` をユニット処理）。`parse_placeholder` を runtime 適用と保存時検証で共有する。
-    - **name はオプション引数を `:` で取れる**（`date:<書式>`。name と arg は最初の `:` で分割、arg 内 `:` はリテラル）。query/clip/uuid は引数なし——引数付き `{query:x}` はリテラルに戻し後方互換を保つ。
-    - **date/uuid は実行時に解決する不純な源**: `expand_template` は `now: &DateTime<Local>` を受け取り、`expand_instant_command`/`expand_exec_args` が `Local::now()` を**1回だけ**捕捉して渡す（同一テンプレート内の複数 `{date}` が同一時刻を反映、`{uuid}` は出現ごとに `Uuid::new_v4()` で新規生成し意図的に異なる）。`format_date(now, fmt)` は **panic 安全**: `write!` で Display の Err を値として伝播させ、整形不能な書式（`%!` 等の不正指定子 + `%#z` 等の**パース専用指定子**の両方）を空文字列にフォールバックする（`to_string()` の unwrap-panic ＝ release `panic="abort"` のプロセス abort を回避、#394）。**`Item::Error` の事前走査では不十分**——`%#z` はパース成功・整形失敗のため走査を素通りする（code-reviewer 検出）。
-  - `expand_exec_args(args: &str, query: &str, clipboard: &str, env_expand: fn) -> Vec<String>`: exec 種別の引数列構築。手順: split_args で分割 → 各トークンに env 展開（`%VAR%`）→ 修飾子パイプ付き変数置換（encode なし）。この順序により (1) 外部入力 query/clip は env 展開されない、(2) env 値の空白はトークン内に留まり引数を割らない、(3) 空白入り query は1引数を保つ。修飾子適用後の値も同トークン内に in-place 置換され引数を増やさない。
-  - `expand_instant_command(command: &str, query: &str, clipboard: &str) -> String`: URL/コマンドの変数展開。`http://` / `https://` で始まる場合は各プレースホルダ単位で URL エンコード（`raw` 抑止）。それ以外は生のまま展開。
-  - `collect_unknown_modifiers(template: &str) -> Vec<String>`: テンプレート中の未知修飾子名を収集（`Config::validate` が保存時バリデーションに使用）。`walk_template` を `expand_template` と共有。
-  - `filter_instant_commands(commands: &[InstantCommand], input: &str) -> Vec<&InstantCommand>`: コマンド名を前方一致（大文字小文字区別しない）で絞り込み。空 input は全件返却。
+  - `split_args(args: &str) -> Vec<String>`: シェル風クォート対応の引数分割。`"..."` で囲まれた部分はスペースを含んでも1トークンとして扱う。**`{...}` 内のスペースも分割しない**（`{query | trim}` 等の修飾子パイプを1トークンに保つ）。`launch.rs` から移設
+  - 変数展開は**修飾子パイプ `{name | mod | ...}`**（name = query/clip/date/uuid、v1 修飾子 `lower`/`upper`/`trim`/`default:<text>`/`raw`）に対応する:
+    - 内部の単一 walker `expand_template`（private）が `{...}` を走査し、変数解決 → 修飾子チェーン（左→右）→ シンク処理（`encode && !raw` のとき URL エンコード）を行う
+    - **エンコードはシンク（種別）の責務**で修飾子は内容変換のみ（`urlencode` 修飾子は提供せず、`raw` が唯一の抑止）
+    - 未認識 `{...}`・閉じ `}` 不在はリテラル温存（total）
+    - **`{{X}}` はエスケープで literal `{X}`**（変数名と衝突する literal の唯一の表現＝予約語が増えても opt-out が常に存在。中身は変数/修飾子として解釈しない。`walk_template` の `{`-found 分岐で `{{…}}` をユニット処理）
+    - `parse_placeholder` を runtime 適用と保存時検証で共有する
+    - **name はオプション引数を `:` で取れる**（`date:<書式>`。name と arg は最初の `:` で分割、arg 内 `:` はリテラル）。query/clip/uuid は引数なし——引数付き `{query:x}` はリテラルに戻し後方互換を保つ
+    - **date/uuid は実行時に解決する不純な源**: `expand_template` は `now: &DateTime<Local>` を受け取り、`expand_instant_command`/`expand_exec_args` が `Local::now()` を**1回だけ**捕捉して渡す（同一テンプレート内の複数 `{date}` が同一時刻を反映、`{uuid}` は出現ごとに `Uuid::new_v4()` で新規生成し意図的に異なる）
+    - **`format_date(now, fmt)` は panic 安全**: `write!` で Display の Err を値として伝播させ、整形不能な書式（`%!` 等の不正指定子 + `%#z` 等の**パース専用指定子**の両方）を空文字列にフォールバックする（`to_string()` の unwrap-panic ＝ release `panic="abort"` のプロセス abort を回避、#394）。**`Item::Error` の事前走査では不十分**——`%#z` はパース成功・整形失敗のため走査を素通りする（code-reviewer 検出）
+  - `expand_exec_args(args: &str, query: &str, clipboard: &str, env_expand: fn) -> Vec<String>`: exec 種別の引数列構築。手順: `split_args` で分割 → 各トークンに env 展開（`%VAR%`）→ 修飾子パイプ付き変数置換（encode なし）。この順序により (1) 外部入力 query/clip は env 展開されない、(2) env 値の空白はトークン内に留まり引数を割らない、(3) 空白入り query は1引数を保つ。修飾子適用後の値も同トークン内に in-place 置換され引数を増やさない
+  - `expand_instant_command(command: &str, query: &str, clipboard: &str) -> String`: URL/コマンドの変数展開。`http://` / `https://` で始まる場合は各プレースホルダ単位で URL エンコード（`raw` 抑止）。それ以外は生のまま展開
+  - `collect_unknown_modifiers(template: &str) -> Vec<String>`: テンプレート中の未知修飾子名を収集（`Config::validate` が保存時バリデーションに使用）。`walk_template` を `expand_template` と共有
+  - `filter_instant_commands(commands: &[InstantCommand], input: &str) -> Vec<&InstantCommand>`: コマンド名を前方一致（大文字小文字区別しない）で絞り込み。空 input は全件返却
 - `ui_types.rs`: フロントエンドとの IPC 用データ型
 
 ## 開発ルール
@@ -40,7 +67,11 @@
 - `search.rs` の top-k 更新ロジックを変更する場合は、入力順を変えても結果が不変であるテストを追加または更新する
 - `SearchEngine` にフィールドを追加する前に: 既存の並列 Vec（特に `normalized_keys`）で代替できないか先に検討する。再利用できれば 5 箇所同時更新・IndexCache バージョンバンプが不要になる
 - `SearchEngine` に新しい並列 Vec フィールドを追加するとき: `EntryView` 構造体・`entry_view()` メソッド・`assemble()` 内の `debug_assert!` を同時に更新し、全 Vec 長の同期を保つ。Wave 1 の文字列正規化は `compute_wave1` に、Wave 2 のビットマスク計算は `compute_wave2` に追加する（`new()` / `new_with_migemo()` / `new_with_cached_masks()` が共有）
-- **`kana_lower_names` は条件付き構築（migemo 有効時のみ）で長さ `{0, entries.len()}` の例外**: `assemble` の `debug_assert!` は他 5 Vec を `== entries.len()` で検証するが kana は `is_empty() || == entries.len()` を許す。`kana_lower_names[i]` へアクセスする全箇所は `!kana_lower_names.is_empty()` ガードを通す。条件分岐は `compute_wave1(.., migemo_enabled)` と `new_with_cached_masks` の v4/v3 両パスに**同時に**入れる（片方だけだと migemo ON でも空になる）。migemo は index 構築入力なので、engine の `IndexInputs`（`config_watcher` の kick 判定と `complete_index_drain` の re-diff が共有する**単一定義**）に含める（#347 Phase 2 で `needs_reindex` / in-flight `needs_rebuild` を `IndexInputs` に統合・削除済み）
+- **`kana_lower_names` は条件付き構築（migemo 有効時のみ）で長さ `{0, entries.len()}` の例外**:
+  - `assemble` の `debug_assert!` は他 5 Vec を `== entries.len()` で検証するが、kana は `is_empty() || == entries.len()` を許す
+  - `kana_lower_names[i]` へアクセスする全箇所は `!kana_lower_names.is_empty()` ガードを通す
+  - 条件分岐は `compute_wave1(.., migemo_enabled)` と `new_with_cached_masks` の v4/v3 両パスに**同時に**入れる（片方だけだと migemo ON でも空になる）
+  - migemo は index 構築入力なので、engine の `IndexInputs`（`config_watcher` の kick 判定と `complete_index_drain` の re-diff が共有する**単一定義**）に含める（#347 Phase 2 で `needs_reindex` / in-flight `needs_rebuild` を `IndexInputs` に統合・削除済み）
 - `search.rs` の incremental search キャッシュ（`prev_*` フィールド群）に新しい述語を追加するとき: `use_incremental` の条件式と `prev_*` の更新箇所を同時に変更し、`/cache-check` で単調性を検証する
 - `query.rs` の正規化を変更する場合は、タブ・全角スペース・NBSP を `' '` に統一するテストと冪等性テストを追加または更新する
 - `folder.rs` のソート順変更時: ソート順は「`is_folder` 降順 → `exp_count` 降順 → `lower_name` 昇順」で、先頭要素が最良（最優先）。`select_nth_unstable_by`（O(N) 平均の top-k 選択）＋ `sort_by`（安定ソートで確定順）の2段階を崩さない。入力順に依存しないことを確認するテスト（`score_entries_top_k_order_independent_of_input_order`）を通す
@@ -80,10 +111,21 @@
 - シリアライザを切り替える場合は**必ずバージョン番号をバンプ**し、旧形式のフォールバックデシリアライザを追加する。切り替え前後でバイト列の互換性はほぼ存在しない（例: bincode の u32 は 4バイト LE、postcard は LEB128 varint）
 - **データの意味（セマンティクス）を変更する場合もバージョン番号をバンプする**。バイト列のフォーマットが同一でも、値の解釈が変わればデータ破損と同じ（例: 絶対座標→モニター相対座標。旧データをそのまま新セマンティクスで読むと位置がずれる）
 - `deserialize_failed → save()` パターン（デコード失敗時に空データを即時上書き保存）は HistoryStore など学習データを持つモジュールでデータ喪失を招く。フォールバック読み込みを先に試み、次回の通常 save() で新形式に昇格させること
-- **読み込み失敗は種類で扱いを分ける（`Config::load`）**: 不在（`NotFound`）= 既定値を生成・保存 / 内容破損（TOML parse 失敗・非 UTF-8 `InvalidData`）= `config.toml.bak` へ退避し既定値・**保存しない** / 一時的失敗（権限・ロック等）= 退避も上書きもせず既定値・**保存しない**。`Err(_)` 一括 first-run 扱いは一時的失敗で実データを既定値に潰す。**1分岐だけ直しても同じ `match` の兄弟分岐に同じ破壊的フォールバックが残る**ため、読み込み失敗を直すときは全分岐の保全方針を揃える（#338/#343: アドバーサリアルレビューが兄弟分岐＝read 失敗 arm の漏れと「後続 save で破損元が失われる」非対称を検出した）
+- **読み込み失敗は種類で扱いを分ける（`Config::load`）**:
+  - 不在（`NotFound`）= 既定値を生成・保存
+  - 内容破損（TOML parse 失敗・非 UTF-8 `InvalidData`）= `config.toml.bak` へ退避し既定値・**保存しない**
+  - 一時的失敗（権限・ロック等）= 退避も上書きもせず既定値・**保存しない**
+  - `Err(_)` 一括 first-run 扱いは一時的失敗で実データを既定値に潰す。**1分岐だけ直しても同じ `match` の兄弟分岐に同じ破壊的フォールバックが残る**ため、読み込み失敗を直すときは全分岐の保全方針を揃える（#338/#343: アドバーサリアルレビューが兄弟分岐＝read 失敗 arm の漏れと「後続 save で破損元が失われる」非対称を検出した）
 - **TOML フィールドを別の struct に移動するとき**: 旧フィールドを削除するのではなく `#[serde(default, skip_serializing)] pub field: Option<T>` として残し、`apply_migrations()` で `self.old.field.take()` → 新フィールドへ代入する。`Config::default()` の明示的 struct 初期化に `field: None` を追加するのを忘れない。また、`apply_migrations()` には複数のマイグレーションが存在するため、一部だけをテストする場合でも他の副作用（`additional → scan` 移行等）を踏まえたアサーション順序・内容を設計する
-- **serde 表現（enum variant・`#[serde(untagged/flatten/tag)]`）を変更するときは、旧オンディスク形式が deserialize できるテストを「新形式の往復」とは別に必ず追加する**: 旧形式が新構造体に deserialize 失敗すると `toml::from_str::<Config>` が失敗 → `config.toml.bak` 退避 → **全設定リセット**（`apply_migrations()` は deserialize の後に走るため移行では救えない）＝データ損失。旧形式は untagged の `Legacy { .. }` variant 等で必ず受理し、移行を `apply_migrations()` で行う。新形式の往復テストだけでは parse 失敗を検出できず false-green になる（#394: 多観点レビューが `toml` で実証）
-- **オンディスクのシリアライズ struct をリファクタするとき（「バイト形式不変」を主張する場合も含む）は、後方互換を *旧形式の凍結バイト列* を入力にした load テストで証明する**: 新コードの出力を golden 化しても保証されるのは forward-stability だけで、「新出力＝旧形式」を独立には証明しない（形式が壊れていても新 golden がそれを凍結して素通りする）。正しい向きは「旧形式の凍結バイト列 → 新コードで deserialize できる」の検証。加えて、形式を変える計画は着手前に最小 spike で往復バイト一致を実証してから plan を建てる（前提が崩れれば approach 自体が不成立ゆえ [[feedback_verify_issue_premises]]）。#461: owned/borrowed struct の `Cow` 統合で当初 golden を新コード出力から採取し forward-stability のみになっていたのを code-reviewer が検出、凍結バイト列からの deserialize に修正した
+- **serde 表現（enum variant・`#[serde(untagged/flatten/tag)]`）を変更するときは、旧オンディスク形式が deserialize できるテストを「新形式の往復」とは別に必ず追加する**:
+  - 旧形式が新構造体に deserialize 失敗すると `toml::from_str::<Config>` が失敗 → `config.toml.bak` 退避 → **全設定リセット**（`apply_migrations()` は deserialize の後に走るため移行では救えない）＝データ損失
+  - 旧形式は untagged の `Legacy { .. }` variant 等で必ず受理し、移行を `apply_migrations()` で行う
+  - 新形式の往復テストだけでは parse 失敗を検出できず false-green になる（#394: 多観点レビューが `toml` で実証）
+- **オンディスクのシリアライズ struct をリファクタするとき（「バイト形式不変」を主張する場合も含む）は、後方互換を *旧形式の凍結バイト列* を入力にした load テストで証明する**:
+  - 新コードの出力を golden 化しても保証されるのは forward-stability だけで、「新出力＝旧形式」を独立には証明しない（形式が壊れていても新 golden がそれを凍結して素通りする）
+  - 正しい向きは「旧形式の凍結バイト列 → 新コードで deserialize できる」の検証
+  - 形式を変える計画は着手前に最小 spike で往復バイト一致を実証してから plan を建てる（前提が崩れれば approach 自体が不成立ゆえ [[feedback_verify_issue_premises]]）
+  - #461: owned/borrowed struct の `Cow` 統合で当初 golden を新コード出力から採取し forward-stability のみになっていたのを code-reviewer が検出、凍結バイト列からの deserialize に修正した
 
 ## history.rs のキー正規化に関するチェックリスト
 

--- a/snotra-settings/CLAUDE.md
+++ b/snotra-settings/CLAUDE.md
@@ -2,6 +2,8 @@
 
 egui ベースの設定・about バイナリ crate。本体（`src-tauri`）とは別プロセスで動作する。
 
+各ルールは「**太字 = 守る指示**、後続 = 理由・経緯」の形式。迷ったら太字部分に従えば安全。
+
 ## アーキテクチャ
 
 - 本体との連携は `config.toml` ファイル1点のみ。IPC は使わない
@@ -14,7 +16,9 @@ egui ベースの設定・about バイナリ crate。本体（`src-tauri`）と�
 - `app.rs`: `eframe::App` 実装、タブ管理（About タブ含む）、保存/破棄/リセットロジック。色は `style` のトークンを参照
 - `font.rs`: 日本語フォント読み込み（Regular の `jp_font` + 見出し用 Semibold ファミリ `SEMIBOLD_FAMILY` を登録。Semibold 不在環境では未登録のまま graceful degrade）+ システムフォント列挙
 - `hotkey_input.rs`: ホットキーキャプチャウィジェット
-- `i18n.rs`: 翻訳構造体 `Tr(Language)`。`TrKey` enum（キー） + 言語別テーブル関数 `ja()`/`en()`（各キーの網羅 match）+ `Tr::t(key)`/`Tr::t_params(key, params)`（`{param}` プレースホルダ置換）でテーブル駆動。新キー追加時は `TrKey` に variant を足すだけで `ja()`/`en()` が非網羅コンパイルエラーになり網羅を強制する（`#[deny(clippy::wildcard_enum_match_arm)]` でワイルドアームによる回避も禁止）。タブ UI 関数は `tr: &Tr` を引数に取り、保存時に `self.tr = Tr(new_language)` で即時反映
+- `i18n.rs`: 翻訳構造体 `Tr(Language)`。`TrKey` enum（キー） + 言語別テーブル関数 `ja()`/`en()`（各キーの網羅 match）+ `Tr::t(key)`/`Tr::t_params(key, params)`（`{param}` プレースホルダ置換）でテーブル駆動
+  - **新キー追加時は `TrKey` に variant を足すだけ** — `ja()`/`en()` が非網羅コンパイルエラーになり網羅を強制する（`#[deny(clippy::wildcard_enum_match_arm)]` でワイルドアームによる回避も禁止）
+  - タブ UI 関数は `tr: &Tr` を引数に取り、保存時に `self.tr = Tr(new_language)` で即時反映
 - `style.rs`: デザイントークン（色 / 余白 / フォントサイズ / 幅）と共有スタイルヘルパー（`tab_scroll_area` / `section_heading` / `hint` / `settings_grid` / `list_item` / `reorder_controls` / `modal_header` / `modal_buttons` / `danger_button` / `apply_type_ramp`）。全タブと app.rs がこれ経由で描画する。詳細は `SETTINGS-DESIGN.md`
 - `tabs/`: 7タブの UI 実装
   - `mod.rs`: サブモジュール宣言のみ

--- a/src-tauri/CLAUDE.md
+++ b/src-tauri/CLAUDE.md
@@ -2,13 +2,27 @@
 
 Tauri v2 バイナリ crate。Win32 API 統合とフロントエンドとの IPC を担当。
 
+各ルールは「**太字 = 守る指示**、後続 = 理由・経緯」の形式。迷ったら太字部分に従えば安全。
+
 ## モジュール構成
 
 - `main.rs`: エントリポイント、Tauri セットアップ、イベントリスナー登録。起動時の背景再スキャン（`indexer::load_or_scan_with_stats` が返す `BackgroundRescanTask`）を `setup` フェーズで低優先度スレッドに spawn し、`RescanOutcome::Changed` なら `icon::invalidate_icon_cache` を呼ぶ
-- `state.rs`: `AppState` 定義（`Mutex<Engine>` + `AtomicBool` × 3: `indexing` / `index_build_started` / `main_visible`）。`Engine` は `snotra-core` の facade で、検索・履歴・設定を単一ロックに統合。`main_visible` は Win32 `is_visible()` の 35ms レイテンシを回避するためのキャッシュ。インデックスビルドの開始/終了は `try_begin_index_build()` / `finish_index_build()` メソッド経由で行い、`indexing`・`index_build_started` を coherent に更新する。**config 変更→index 再構築のコヒーレンシ判断は engine の `index_stale` ledger（軸1）に閉じており、この 2 AtomicBool は二重ビルド防止（CAS）と UI 表示専用に純化されている**（#347/#348-A）
+- `state.rs`: `AppState` 定義（`Mutex<Engine>` + `AtomicBool` × 3: `indexing` / `index_build_started` / `main_visible`）
+  - `Engine` は `snotra-core` の facade で、検索・履歴・設定を単一ロックに統合。`main_visible` は Win32 `is_visible()` の 35ms レイテンシを回避するためのキャッシュ
+  - **インデックスビルドの開始/終了は `try_begin_index_build()` / `finish_index_build()` メソッド経由で行う** — `indexing`・`index_build_started` を coherent に更新する
+  - **config 変更→index 再構築のコヒーレンシ判断は engine の `index_stale` ledger（軸1）に閉じており、この 2 AtomicBool は二重ビルド防止（CAS）と UI 表示専用に純化されている**（#347/#348-A）
 - `icon.rs`: アイコンのオンデマンド抽出（`SHGetFileInfoW` → PNG バイト列）、検索時に遅延ロードしキャッシュ永続化。`invalidate_icon_cache` はメモリ内 `IconCacheState` と `icons.bin` を**両方**無効化する（片方だけだと終了時の `save_if_dirty` で古いアイコンが復活する）
-- `indexing.rs`: バックグラウンドインデックス構築。`start_index_build` は `mark_index_stale`（**CAS の前**）→ CAS → spawn で **drain ループ**（`begin_index_drain` で現在 config の `IndexInputs` snapshot → ロック外で `rebuild_and_save` / `PrebuiltIndex::new` → `complete_index_drain` で swap + re-diff）を stale が消えるまで回す。ビルド本体は `catch_unwind` で包む（**panic 戦略依存**: unwind ビルド=debug/test では panic を捕捉し `finish_index_build` で flag 固着 wedge を防ぐ。release は Cargo.toml で `panic="abort"` のため build panic はプロセス abort＝ここに来ないが silent wedge にもならず、再起動で fresh build される。どちらでも UI 永久構築中は起きない）。finish 後に `is_index_stale` を再チェックし、finish 窓で刺さった変更を再 kick で拾う（**unwind の panic 経路では再 kick しない**＝決定論 panic の無限リトライ回避）。config 変更→index 再構築のコヒーレンシは engine の `index_stale` ledger に一元化（#347/#348-A）
-- `config_watcher.rs`: `notify` クレートで `config.toml` 変更を監視（100ms debounce）し、差分検出後にホットキー・トレイ・インデックス・テーマ・ウィンドウ幅・言語を反映する `apply_config_change()` を実行。**不変条件: 言語変更とホットキー変更が同時に発生した場合、`language-changed` イベントをホットキー失敗通知より先に発火する**（フロントエンドが正しい言語でエラー文字列を組み立てるため）。**不変条件: `LoadOutcome::ReadFailed`（一時的・環境的な read 失敗）では `apply_config_change` は何も適用せず早期 return する**（`should_apply_config_change()` で判定。fallback-default を実行中エンジンへ適用すると、live-read 化した履歴剪定が `history.bin` をデータ損失させ、index 再構築判定（`IndexInputs` 差分）が default scan で誤再構築を起こすため。`Config::load` の「一時的失敗は退避も上書きもしない」保全を適用側にも揃える、#348）。ただし早期 return の前に短いバウンドリトライ（`load_with_read_failed_retry`、既定 3 回 × 150ms）で一時的ロック解除を待ち、解ければ正規の変更を取りこぼさず適用する（予算超過時のみ skip。リトライ中は適用しないのでデータ損失安全は不変）。**不変条件: index 再構築の要否は `IndexInputs::from_config(old) != IndexInputs::from_config(new)` で判定し、ビルド進行中（`indexing`）でも `!indexing` ゲートなしで常に `start_index_build` を kick する**（`start_index_build` が `mark_index_stale` で stale を立て、in-flight ビルドの drain / finish 後再チェックが取りこぼしを拾う。CAS が二重起動を防ぐ。#347/#348-A）。発火するイベント: `language-changed` / `hotkey-registration-failed` / `visual-config-changed` / `show-icons-changed` / `max-results-changed` / `instant-prefix-changed` / `top-n-history-changed` / `indexing-started`（indexing.rs から）/ `indexing-complete`（indexing.rs から）
+- `indexing.rs`: バックグラウンドインデックス構築
+  - **`start_index_build` は `mark_index_stale`（CAS の前）→ CAS → spawn の順**で、**drain ループ**（`begin_index_drain` で現在 config の `IndexInputs` snapshot → ロック外で `rebuild_and_save` / `PrebuiltIndex::new` → `complete_index_drain` で swap + re-diff）を stale が消えるまで回す
+  - **ビルド本体は `catch_unwind` で包む（panic 戦略依存）**: unwind ビルド=debug/test では panic を捕捉し `finish_index_build` で flag 固着 wedge を防ぐ。release は Cargo.toml で `panic="abort"` のため build panic はプロセス abort＝ここに来ないが silent wedge にもならず、再起動で fresh build される。どちらでも UI 永久構築中は起きない
+  - **finish 後に `is_index_stale` を再チェック**し、finish 窓で刺さった変更を再 kick で拾う。**unwind の panic 経路では再 kick しない**（決定論 panic の無限リトライ回避）
+  - config 変更→index 再構築のコヒーレンシは engine の `index_stale` ledger に一元化（#347/#348-A）
+- `config_watcher.rs`: `notify` クレートで `config.toml` 変更を監視（100ms debounce）し、差分検出後にホットキー・トレイ・インデックス・テーマ・ウィンドウ幅・言語を反映する `apply_config_change()` を実行
+  - **不変条件: 言語変更とホットキー変更が同時に発生した場合、`language-changed` イベントをホットキー失敗通知より先に発火する**（フロントエンドが正しい言語でエラー文字列を組み立てるため）
+  - **不変条件: `LoadOutcome::ReadFailed`（一時的・環境的な read 失敗）では `apply_config_change` は何も適用せず早期 return する**（`should_apply_config_change()` で判定）。fallback-default を実行中エンジンへ適用すると、live-read 化した履歴剪定が `history.bin` をデータ損失させ、index 再構築判定（`IndexInputs` 差分）が default scan で誤再構築を起こすため。`Config::load` の「一時的失敗は退避も上書きもしない」保全を適用側にも揃える（#348）
+    - ただし早期 return の前に短いバウンドリトライ（`load_with_read_failed_retry`、既定 3 回 × 150ms）で一時的ロック解除を待ち、解ければ正規の変更を取りこぼさず適用する（予算超過時のみ skip。リトライ中は適用しないのでデータ損失安全は不変）
+  - **不変条件: index 再構築の要否は `IndexInputs::from_config(old) != IndexInputs::from_config(new)` で判定し、ビルド進行中（`indexing`）でも `!indexing` ゲートなしで常に `start_index_build` を kick する**（`start_index_build` が `mark_index_stale` で stale を立て、in-flight ビルドの drain / finish 後再チェックが取りこぼしを拾う。CAS が二重起動を防ぐ。#347/#348-A）
+  - 発火するイベント: `language-changed` / `hotkey-registration-failed` / `visual-config-changed` / `show-icons-changed` / `max-results-changed` / `instant-prefix-changed` / `top-n-history-changed` / `indexing-started`（indexing.rs から）/ `indexing-complete`（indexing.rs から）
 - `ime.rs`: IME オフ操作（`ImmSetOpenStatus(false)`）。Win32 IMM API の薄いラッパー
 - `trace.rs`: `SNOTRA_TRACE` 環境変数ゲートの構造化トレースログ（`trace_enabled` + `trace`）。`main.rs` の `trace_main` と `commands::trace_command` が薄いラッパーとしてここへ委譲する（#433 で重複を集約）。seq カウンタは単一の `AtomicU64` を共有するため、両者のトレース行は1本の単調増加列で interleave する（旧実装は 2 カウンタに分裂していた。トレースはデバッグ出力専用のため許容される挙動変更）
 - `monitor.rs`: マルチモニター対応の Win32 ヘルパー（`GetCursorPos` / `MonitorFromPoint` / `MonitorFromWindow` / `GetMonitorInfoW`）。物理座標ベースで作業領域を取得し、ウィンドウ位置のクランプ・中央配置を提供

--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -2,6 +2,8 @@
 
 SolidJS + TypeScript フロントエンド。Tauri IPC 経由で Rust バックエンドと通信。
 
+各ルールは「**太字 = 守る指示**、後続 = 理由・経緯」の形式。迷ったら太字部分に従えば安全。
+
 ## モジュール構成
 
 ### エントリポイント（single-page build）
@@ -17,7 +19,11 @@ SolidJS + TypeScript フロントエンド。Tauri IPC 経由で Rust バック�
 
 ### stores/
 
-- `search.ts`: 検索状態管理（クエリ/結果/選択/モード切替/`shouldShowResults` メモシグナル）の調停役。主要な公開関数: `resetForShow()`（window-shown 時の全状態リセット）、`refreshResults()`（ソースに応じた検索実行）、`initIndexingState()`（起動時のインデックス状態初期化 + `indexing-started` / `indexing-complete` リスナー登録）。`suppressNextQueryEffectRefresh` フラグで query effect の不要な再実行を抑制。横断規約の choke point: `nextGeneration()`（`searchGeneration` 更新の唯一経路）、`withLaunchLifecycle()`（起動フロー三種の共通骨格）、`saveView()`/`restoreView()`（`SavedViewState` の退避/復元）、`allowsFolderNav()`（フォルダ展開・ツール選択遷移の許可述語、`viewKind`/`interpKind` 由来）。`instantCommand.ts`/`launchNotice.ts` を re-export し公開 API を単一箇所に保つ
+- `search.ts`: 検索状態管理（クエリ/結果/選択/モード切替/`shouldShowResults` メモシグナル）の調停役
+  - 主要な公開関数: `resetForShow()`（window-shown 時の全状態リセット）、`refreshResults()`（ソースに応じた検索実行）、`initIndexingState()`（起動時のインデックス状態初期化 + `indexing-started` / `indexing-complete` リスナー登録）
+  - `suppressNextQueryEffectRefresh` フラグで query effect の不要な再実行を抑制
+  - **横断規約の choke point**: `nextGeneration()`（`searchGeneration` 更新の唯一経路）、`withLaunchLifecycle()`（起動フロー三種の共通骨格）、`saveView()`/`restoreView()`（`SavedViewState` の退避/復元）、`allowsFolderNav()`（フォルダ展開・ツール選択遷移の許可述語、`viewKind`/`interpKind` 由来）
+  - `instantCommand.ts`/`launchNotice.ts` を re-export し公開 API を単一箇所に保つ
 - `instantCommand.ts`: インスタントコマンド候補一覧の状態（`instantCommandItems`）と 30ms デバウンス IPC 取得（`scheduleInstantCommandFetch`）。`api`/`lib/types` のみに依存し `search.ts` へ逆依存しない（循環 import 回避）。staleness 判定・世代更新は呼び出し側が hooks（`nextRequestId`/`isStale`）で注入する
 - `launchNotice.ts`: 起動失敗・ホットキー失敗の一時通知（`launchNotice` シグナル + 自動クリアタイマー）。`notifyLaunchFailure`/`setLaunchNoticeWithAutoClear`/`setHotkeyFailureNotice`/`clearLaunchNotice` を提供
 - `folder.ts`: フォルダモードの状態（`FolderFrame` シグナル + `folderFilter`）。`FolderFrame` は `lib/types.ts` の `SavedViewState` を拡張
@@ -28,7 +34,9 @@ SolidJS + TypeScript フロントエンド。Tauri IPC 経由で Rust バック�
 - `invoke.ts`: 型付き Tauri IPC ラッパー
 - `theme.ts`: CSS 変数によるテーマ適用
 - `types.ts`: TypeScript 型定義の集約先（DRY）
-- `commands.ts`: スラッシュコマンド定義（`/r` `/o` `/s` `/q`）と `SLASH_COMMANDS` 配列・`findCommand()` 関数。`hideMainWindow()` は全 frontend hide（Escape / Enter / Shift+Enter / クリック起動 / フォーカス喪失 / `/s`）の単一チョークポイント。**`await win.hide()` → `notifyMainHidden()` の順を守る**——`notifyMainHidden` 内の `EmptyWorkingSet` trim を hide 完了後に走らせることで、可視中の再 touch による working set 回収の取りこぼしを避ける（hotkey 経路と同順。#361）。MainApp.tsx のフォーカス喪失・クリック起動経路もこの関数に集約する
+- `commands.ts`: スラッシュコマンド定義（`/r` `/o` `/s` `/q`）と `SLASH_COMMANDS` 配列・`findCommand()` 関数
+  - **`hideMainWindow()` は全 frontend hide（Escape / Enter / Shift+Enter / クリック起動 / フォーカス喪失 / `/s`）の単一チョークポイント**。MainApp.tsx のフォーカス喪失・クリック起動経路もこの関数に集約する
+  - **`await win.hide()` → `notifyMainHidden()` の順を守る** — `notifyMainHidden` 内の `EmptyWorkingSet` trim を hide 完了後に走らせることで、可視中の再 touch による working set 回収の取りこぼしを避ける（hotkey 経路と同順。#361）
 - `i18n.ts`: 多言語対応（日本語・英語）。`TranslationKey` 型と `t(key, params?)` 関数。`{param}` 形式プレースホルダー対応。SolidJS シグナルで言語を管理し、`setLanguage()` で切替。初期言語は `navigator.language` から同期的に決定（bootstrap 到着前のフラッシュ防止）
 - `folderNav.ts`: フォルダナビゲーション純粋ロジック（`computeParentDir`・`clampSelectedIndex`）。ドライブルート・UNC パス対応。テスト可能なため `stores/` から分離
 - `iconBatch.ts`: バイナリバッチ形式のアイコンデータをパースし、パスごとの Blob URL に変換する（`parseBinaryBatch`）。ResultsSection で使用


### PR DESCRIPTION
## 概要

Opus / Sonnet など Fable 以外のモデルでも運用ルールを確実に拾えるよう、リポジトリ内の全 CLAUDE.md（root + 4 サブディレクトリ）を「**太字 = 守る指示**、後続 = 理由・経緯」のルール前置形式へ統一する。**情報の追加・削除はなく、構造の変更のみ**（ルール本文・issue 参照・関数シグネチャはすべて保全）。

## 変更内容

### root `CLAUDE.md`（57d8801）

- 冒頭に「最重要ルール（常に適用）」ダイジェストを新設（main 直コミット禁止 / git チェーン禁止 / HEREDOC 禁止 / エージェント設定変更の合意、の4件を各セクションへのポインタ付きで前置）
- ドキュメントマップと形式規約を導入部に明記
- シェル環境4項目を「やらない / 代わりに / 理由」の表へ、フック3件を「フック / 発火条件 / 正しい対応」の表へ変換
- squash マージの auto-close 制御を番号付き手順に分解
- コミュニケーション原則を「着手の判断 / 実装・レビュー時 / 調査・助言」の3サブセクションへ分類（8項目すべて保持）
- feature ブランチ規則は最重要ルールへ昇格（コミュニケーション原則からは相互参照で維持）

### `snotra-core/CLAUDE.md`（23d7148）

- 導入部に形式規約とファイル構成マップを追記
- モジュール構成の長段落6件（engine / config / opener / search / history / instant）を「責務1行 + 不変条件のネスト箇条書き」に分解
- 実装前チェックの `kana_lower_names` 項を4箇条へ分解
- データ永続化の `Config::load` 失敗分類・serde 表現変更・凍結バイト列検証の3項を手順/根拠単位の箇条書きへ分解

### `src-tauri/` `ui/` `snotra-settings/` の `CLAUDE.md`（5c82405）

- 3ファイル共通: 導入部に形式規約を1行追記
- src-tauri: `state.rs` / `indexing.rs` / `config_watcher.rs` の長段落を不変条件単位のネスト箇条書きへ分解（config_watcher の3不変条件と発火イベント一覧が独立行に）
- ui: `stores/search.ts`（choke point 一覧）と `lib/commands.ts`（`hideMainWindow` チョークポイント + hide 順序規則）を分解
- snotra-settings: `i18n.rs` の網羅強制ルールを分解（他セクションは元より構造良好のため無変更）

## 検証

- root のスキル表は `.claude/skills/` の13スキルと一致、フック記述は `.claude/settings.json`（PreToolUse: Bash / PostToolUse: Edit|Write）と整合することを確認済み
- 各ファイルで新旧を項目単位で照合し、ルール・経緯・シグネチャの欠落がないことを確認済み
- チーム憲章・スキル表・Git 運用・クロスモジュール不変条件などルール本文は無変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)
