### PR TITLE
chore(hooks): typecheck hook の --pretty を外し診断の切り捨てを解消

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,7 +33,7 @@
           },
           {
             "type": "command",
-            "command": "input=$(cat); if echo \"$input\" | grep -qE '\\.(ts|tsx)\"'; then cd /c/workspace/Snotra && npm run typecheck 2>&1 | head -30; fi"
+            "command": "input=$(cat); if echo \"$input\" | grep -qE '\\.(ts|tsx)\"'; then cd /c/workspace/Snotra && mkdir -p node_modules/.cache && node node_modules/typescript/bin/tsc --noEmit --incremental --tsBuildInfoFile node_modules/.cache/hook-typecheck.tsbuildinfo 2>&1 | head -30; fi"
           },
           {
             "type": "command",
@@ -42,5 +42,8 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "rust-analyzer-lsp@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## 何を変えたか

typecheck hook から `--pretty` を外した。incremental 化と `enabledPlugins`（rust-analyzer-lsp、意図的）はそのまま維持する。

## なぜ

`--pretty` はパイプ出力（非 TTY）でも色付けを強制するため、hook の出力に生の ANSI エスケープが混入していた。

```
^[[96mui/src/api.ts^[[0m:^[[93m1^[[0m:^[[93m14^[[0m - ^[[91merror^[[0m^[[90m TS2322: ^[[0m...
```

さらに 1 エラーあたり約 6 行を消費するため、`head -30` の予算をすぐ食い潰す。**hook が最も役に立つ「エラーが大量に出た場面」で、診断が切り捨てられていた。**

| 型エラー 10 件を仕込んだとき | `head -30` に収まる件数 |
|---|---|
| `--pretty` あり | 6 / 10 |
| `--pretty` なし（本 PR） | **10 / 10** |

incremental 化そのものは実測で安全かつ約 2 倍速（2802 ms → warm 約 1400 ms）だったため、こちらは残す。

## 検証

`settings.json` から実際のコマンド文字列を抽出し、hook と同じ payload を流して実行した。無出力は「エラーなし」と「grep が発火しなかった」を区別できないため、故意に型エラーを仕込んで確認している。

- 型エラー 10 件 → **10 件すべて報告**、ANSI エスケープの混入 **0 行**
- incremental キャッシュは 2 回目以降の実行でも同じ診断を再報告する（握り潰さない）
- probe 撤去後は古い診断を残さず clean に復帰（exit 0）
- tsbuildinfo を共有した tsc の並列実行 3 本でも破損は再現せず、buildinfo は valid JSON のまま

## スコープ外

点検で見つかった hook の構造的課題 5 件（payload 全体への grep による誤爆・絶対パス `cd` による worktree での誤検査・SSOT 分裂・出力予算・tsconfig include とのスコープ不一致）は、共通の根を持つため本 PR では扱わない。

Refs #471

## マージ前チェックリスト

- [ ] CI グリーン確認
- [ ] 手動マージ（`#471` は根治の追跡先として open のまま残すこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
