### PR TITLE
docs: #535 retrospective の教訓を反映

### DIFF
--- a/RETROSPECTIVE.md
+++ b/RETROSPECTIVE.md
@@ -1,16 +1,24 @@
-# Retrospective — 背景再スキャンの世代競合防止（#525）
+# Retrospective — issue #535 起動レーンの `activationInFlight` を `exclusive`(mutex) primitive へ集約
+
+純粋 refactor。`search.ts` の 4 関数が手書き反復していた二重起動防止 mutex（module boolean `activationInFlight`）を、`createExclusive()` single-flight primitive へ集約した。検索 lane の supersede primitive（`latestRun`・#540）の姉妹。挙動不変・公開 API 不変（384 テスト + 変異テストで実証）。
 
 ## よかったこと
 
-### ロック取得後の世代検査で TOCTOU を構造的に防いだ
-設定 hash をロック外で照合する方式では、照合後に権威的ビルドが割り込める。権威的書き込み開始時に進む世代を `BackgroundRescanTask` が保持し、同じ書き込みロックの取得後に検査することで、古い snapshot が新しい `index.bin` を上書きできない構造にした。
+### 独立再導出（plan-review Step 2b）が「作者の盲点」を 1 件拾った
+成果物監査（Explore）と独立導出（Plan・plan.md を読ませない）の 2 体が、いずれも独立に「`withLaunchLifecycle` の JSDoc が削除予定の `activationInFlight` を名指しで残す」漏れを検出した。計画初版はこのコメントを列挙し損ねていた。#495 の「Step 2b は常に実施」方針が、局所的な単一ファイル refactor でも実効を持った実例。一致（同期起動タイミング・boolean 契約・単一 mutex・SPEC 更新不要）が積み上がったことも、盲点なしの能動的証拠として機能した。
 
-### 実ファイルの巻き戻りを回帰テストで固定した
-新 hash のキャッシュを書いた後に旧世代タスクを実行し、`Skipped`、新 hash の load 成功、旧 hash の load 失敗を同時に検証した。戻り値だけでなく永続化結果まで受け入れ条件として固定できた。
+### 偽陽性テストの罠を実装中に発見し、変異テストで判別能力を接地した
+「起動 in-flight 中の 2 回目が弾かれる」テストを通常モードで書くと、`withLaunchLifecycle` の `clearResults()` により 2 本目が空 results で無条件 false になり、mutex が壊れていても launch 呼び出しが増えず判別不能（false green）だと気づいた。`launchWithSelectedTool` が `results()` ではなく `frame.tools` を読む点を利用し、ツール選択モードへ切替えて判別可能にした。さらに primitive の guard を一時無効化する変異テストで、テストが確実に落ちることを確認した——「テストが本当にバグを検知するか」を接地する実践。
+
+### 構造的一致により差分が最小化された
+`try {`（2-space）+ body（4-space）という現行構造が `return (await activationLane(async () => {`（2-space）へそのまま置き換わり、body の再インデントが一切不要だった。手書き mutex 反復を primitive 1 箇所へ畳んだ結果、`activationInFlight` の 12 参照が消えた。姉妹 `latestRun` の品位（純粋ファクトリ・JSDoc・同期起動）に揃えたことでレビューの見通しも良かった。
 
 ---
 
 ## 伸びしろ
 
-### rustfmt が既存の未整形箇所まで変更する作用範囲を再確認した
-単一ファイルへの rustfmt でも、そのファイル内の無関係な既存未整形箇所が整形されて差分が広がった。`git diff` で検出し、意図した変更以外を戻した。format 実行後は検査結果だけでなく差分の意味的スコープも確認する必要がある。
+### 識別子を削除するとき、コメント/JSDoc 内の名指し参照を記憶から列挙して 1 件漏らした
+計画初版で `tryModalActivate` コメントの更新は挙げたが、同じ `activationInFlight` を参照する `withLaunchLifecycle` の JSDoc を漏らした。research 段階の grep は `files_with_matches` で「search.ts が持つ」までしか見ず、具体的な出現は読解の記憶から列挙したため取りこぼした。既存の「検証の作法」（真実源を grep で数え上げる）を content モードで徹底していれば初版で拾えた——原則は既にあり plan-review が捕捉したため新規ルールは追加しない（ドキュメントを重くしない判断）。次サイクルでは「識別子の改名・削除時は content grep で全出現を列挙してから計画に落とす」を意識する。
+
+### テストのモック実装リーク（`clearAllMocks` は `mockImplementation` を復元しない）
+test 1 で `launchWithTool` を deferred 化した実装が test 2 へ漏れ、never-resolve な launch を待ってタイムアウトした。`beforeEach` の `vi.clearAllMocks()` は `.mock.calls` を消すが実装差し替えは復元しない（復元するのは `resetAllMocks`）。今回は timeout で loud に落ちたが、`mockResolvedValue` の漏れなら誤った値で緑になる（false green）。repo 固有の落とし穴（`beforeEach` が `clearAllMocks` を使い、明示再設定するのは `api.search` のみ）として `ui/CLAUDE.md` テスト基盤に 1 行追記した。

--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -78,6 +78,7 @@ SolidJS + TypeScript フロントエンド。Tauri IPC 経由で Rust バック�
 - **Canvas API モック**: `truncatePath.ts` のように遅延初期化（初回呼び出しまで `document.createElement` しない）の場合、`vi.stubGlobal("document", { createElement: ... })` を `beforeAll` で設定すれば jsdom 不要でテスト可能
 - **コンポーネントテストでは `render(() => <Component />)` を使う**: SolidJS の `render` は関数ラッパーが必須（React と異なり直接 JSX を渡さない）
 - `cspValidation.test.ts`: Tauri v2 IPC の CSP 検証（`connect-src` に `ipc:` と `http://ipc.localhost` が必要）
+- **`beforeEach` の `vi.clearAllMocks()` は `.mock.calls` を消すが `mockImplementation`/`mockResolvedValue` の差し替えは復元しない**: あるテストで api モックの実装を差し替える（例: `mockImplementation` で deferred 化）と、次のテストへ漏れる（`vi.mock` の factory 既定には戻らない）。実装を差し替えたテストに依存する後続テストは、そのモックを自前で再設定すること（`beforeEach` が明示的に再設定するのは `api.search` のみ）。漏れは deferred なら timeout で loud に落ちるが、`mockResolvedValue` の漏れは誤った値で緑になる（false green）
 
 ### コンポーネントテスト（.test.tsx）のモックパターン
 


### PR DESCRIPTION
## 対応Issue
- 関連: #535（マージ済み PR #541 の retrospective follow-up。close 対象なし）

## 変更内容

#535 サイクルの retrospective で得た教訓を反映する docs のみの変更です（コード変更なし）。

- **`RETROSPECTIVE.md`**: #535 サイクルの内容へ上書き（よかったこと 3 / 伸びしろ 2）。
- **`ui/CLAUDE.md`** テスト基盤・注意点: `beforeEach` の `vi.clearAllMocks()` は `.mock.calls` を消すが `mockImplementation`/`mockResolvedValue` の差し替えは復元しない旨を 1 行追記。実装を差し替えたテストは後続テストへ漏れ、`mockResolvedValue` の漏れは false green になりうる（今サイクルで `launchWithTool` の deferred がテスト間に漏れタイムアウトした実例に基づく）。

これらは PR #541 実装後の retrospective で生成され、コミットに含められなかったため follow-up として起票します。
