### PR TITLE
docs: #536 retrospective を反映

### DIFF
--- a/RETROSPECTIVE.md
+++ b/RETROSPECTIVE.md
@@ -1,24 +1,25 @@
-# Retrospective — issue #535 起動レーンの `activationInFlight` を `exclusive`(mutex) primitive へ集約
+# Retrospective — issue #536 検索/instant の生タイマーを所有 `OwnedTimer` primitive へ統合
 
-純粋 refactor。`search.ts` の 4 関数が手書き反復していた二重起動防止 mutex（module boolean `activationInFlight`）を、`createExclusive()` single-flight primitive へ集約した。検索 lane の supersede primitive（`latestRun`・#540）の姉妹。挙動不変・公開 API 不変（384 テスト + 変異テストで実証）。
+純粋 refactor（primitive 抽出プログラム第 3 弾。`latestRun`(supersede)・#540 / `exclusive`(mutex)・#541 の姉妹）。散在した生 `setTimeout`/`clearTimeout`（search debounce の `debounceTimer`+`leadingFired`、instant の `instantCmdDebounceTimer`）を、timer resource だけを所有する `createOwnedTimer(ms)`（`arm`/`cancel`/`isPending`）へ統合。挙動不変・公開 API 不変（396 テスト + adapter テスト + codex 敵対レビューで実証）。設計は当初 `createDebouncer`（leading policy 内包）から、多レンズ探索を経て `OwnedTimer`（resource/policy 分離）へ転換した。
 
 ## よかったこと
 
-### 独立再導出（plan-review Step 2b）が「作者の盲点」を 1 件拾った
-成果物監査（Explore）と独立導出（Plan・plan.md を読ませない）の 2 体が、いずれも独立に「`withLaunchLifecycle` の JSDoc が削除予定の `activationInFlight` を名指しで残す」漏れを検出した。計画初版はこのコメントを列挙し損ねていた。#495 の「Step 2b は常に実施」方針が、局所的な単一ファイル refactor でも実効を持った実例。一致（同期起動タイミング・boolean 契約・単一 mutex・SPEC 更新不要）が積み上がったことも、盲点なしの能動的証拠として機能した。
+### 多レンズ設計探索 + codex 敵対レビューが issue の前提を覆した
+「一段離れて別の should-be は?」という問いに、canonical / minimalist / FSM の 3 レンズを持つサブエージェント + codex 2 回（計画反証・設計攻め）を走らせた。**枠組みの独立した 4 視点が、独立に 2 点へ収束**——①`leadingFired` は `timer !== undefined` と等価で冗長、②再入は同期発火をなくせば構造的に不能（文書契約が要らない）。これが設計を `createDebouncer`（leading policy を primitive に内包）から `OwnedTimer`（timer resource だけ所有・policy は呼び出し側）へ転換させ、偶発的複雑さ（フラグ・再入契約・未使用 `dispose`）を**設計で消した**。単一 framing の plan-review では出ない盲点を、framing の多様性が暴いた。「実行の独立」より「枠組みの独立」が盲点に効く、を実証。
 
-### 偽陽性テストの罠を実装中に発見し、変異テストで判別能力を接地した
-「起動 in-flight 中の 2 回目が弾かれる」テストを通常モードで書くと、`withLaunchLifecycle` の `clearResults()` により 2 本目が空 results で無条件 false になり、mutex が壊れていても launch 呼び出しが増えず判別不能（false green）だと気づいた。`launchWithSelectedTool` が `results()` ではなく `frame.tools` を読む点を利用し、ツール選択モードへ切替えて判別可能にした。さらに primitive の guard を一時無効化する変異テストで、テストが確実に落ちることを確認した——「テストが本当にバグを検知するか」を接地する実践。
+### 「緑は等価の十分条件でない」を adapter テストで能動的に埋めた
+既存 `search.test.ts` は `runAllTimersAsync` で一括 flush し leading/trailing を区別しない。codex がこの片方向性（既存緑 ≠ 挙動固定）を指摘。50ms/30ms 境界をまたぐ adapter テスト 4 件（leading 即時 IPC・burst の trailing 1 回/最後の query・instant の即時クリア・最新 filterName の 1 回取得）を足し、載せ替えの等価性を **store 越しに直接固定**した。回帰の十分条件（1 つ赤なら挙動変更）と、必要挙動の能動的固定を分けて設計した。
 
-### 構造的一致により差分が最小化された
-`try {`（2-space）+ body（4-space）という現行構造が `return (await activationLane(async () => {`（2-space）へそのまま置き換わり、body の再インデントが一切不要だった。手書き mutex 反復を primitive 1 箇所へ畳んだ結果、`activationInFlight` の 12 参照が消えた。姉妹 `latestRun` の品位（純粋ファクトリ・JSDoc・同期起動）に揃えたことでレビューの見通しも良かった。
-
----
+### code-reviewer が「計画に書き込まれたバグ」を捕捉（実コードは正しい）
+Phase 2 で plan.md が `leadingFired` の等価性を**符号反転**（`=== undefined` と記述）していたのを code-reviewer が検出。実コードは正しく `!== undefined` を使っていたが、放置すると「コードを計画に合わせる」将来修正が退行を生む。**実コードとドキュメントの不一致は、ドキュメント側が誤っていても危険**——訂正した。
 
 ## 伸びしろ
 
-### 識別子を削除するとき、コメント/JSDoc 内の名指し参照を記憶から列挙して 1 件漏らした
-計画初版で `tryModalActivate` コメントの更新は挙げたが、同じ `activationInFlight` を参照する `withLaunchLifecycle` の JSDoc を漏らした。research 段階の grep は `files_with_matches` で「search.ts が持つ」までしか見ず、具体的な出現は読解の記憶から列挙したため取りこぼした。既存の「検証の作法」（真実源を grep で数え上げる）を content モードで徹底していれば初版で拾えた——原則は既にあり plan-review が捕捉したため新規ルールは追加しない（ドキュメントを重くしない判断）。次サイクルでは「識別子の改名・削除時は content grep で全出現を列挙してから計画に落とす」を意識する。
+### 状態フラグの冗長性を、当初計画の自己レビューで見抜けなかった
+当初計画（`createDebouncer`）は `leadingFired` を「残す」前提で書かれ、self-review「シンプル化の挑戦」も冗長性を素通りした。`leadingFired ≡ (timer !== undefined)` の等価性は、外部の敵対的レンズ（FSM + codex）が初めて暴いた。教訓: **状態フラグを導入するとき「既に所有する別状態（timer の有無等）から導出できないか」を、フラグを計画に落とす前に検算する。** 既存の「シンプル化の挑戦」の射程内だが、"新しいフラグ" にも明示的に当てる意識が要る。新規ルールは追加しない（既存原則で包含・ドキュメントを重くしない判断）。
 
-### テストのモック実装リーク（`clearAllMocks` は `mockImplementation` を復元しない）
-test 1 で `launchWithTool` を deferred 化した実装が test 2 へ漏れ、never-resolve な launch を待ってタイムアウトした。`beforeEach` の `vi.clearAllMocks()` は `.mock.calls` を消すが実装差し替えは復元しない（復元するのは `resetAllMocks`）。今回は timeout で loud に落ちたが、`mockResolvedValue` の漏れなら誤った値で緑になる（false green）。repo 固有の落とし穴（`beforeEach` が `clearAllMocks` を使い、明示再設定するのは `api.search` のみ）として `ui/CLAUDE.md` テスト基盤に 1 行追記した。
+### 計画に書く等価性/不変条件の主張を、代表状態で向きを検算していなかった
+plan.md の符号反転は、AGENTS.md「検証の作法」の既存原則——「計画に書いた判定ロジック（述語）は実装前に代表入力で実行して測る」——を**等価性の主張に適用し損ねた**もの。「明らか」に見える等価も、各状態で値を辿って向きを確かめる。既存原則の射程内ゆえ新規追加なし。次サイクルでは「plan に `A ≡ B` を書いたら、全状態で A と B の真偽表を並べて確かめる」を意識する。
+
+### codex 敵対レビューの既定ターゲットは working tree（全コミット済みでは空を見る）
+初回 `/codex:adversarial-review` が working tree を対象にし、全コミット済みの #536 実装ではなく無関係な未追跡 JSON を見た（verdict は approve だが空レビュー）。出力の "Target: working tree diff" で気づき `--base main` で再実行。**ブランチ全体を敵対レビューするには `--base <ref>` が要る**（working tree がクリーンなとき）。メモリ [[codex-exec-adversarial-review]] へ追記。


### PR DESCRIPTION
## 概要

issue #536（`OwnedTimer` primitive 統合・#543 でマージ）のサイクル振り返りを `RETROSPECTIVE.md` に反映する。上書きファイルの記録更新のみ（コード変更なし）。

## 内容

**よかったこと 3 点**
- 多レンズ設計探索（canonical / minimalist / FSM）+ codex 敵対レビューが issue の前提を覆し、`createDebouncer`（leading 内包）→ `OwnedTimer`（resource/policy 分離）へ転換した
- adapter テストで「既存緑 ≠ 挙動固定」を能動的に埋めた（50ms/30ms 境界越しに leading/trailing を直接固定）
- code-reviewer が計画の符号反転（`leadingFired` の等価性記述）を捕捉——実コードは正しく、ドキュメント側の誤りを訂正

**伸びしろ 3 点**
- 状態フラグ（`leadingFired`）の冗長性を当初計画の self-review で見抜けず、外部の敵対的レンズが初めて暴いた
- 計画に書く等価性主張（`A ≡ B`）の向きを代表状態で検算していなかった
- codex 敵対レビューの既定ターゲットが working tree で、初回は空レビューになった（`--base main` が必要）

教訓の多くは既存原則（self-review「シンプル化の挑戦」・AGENTS.md「検証の作法」）で包含されるため、**新規 rules/skills は追加していない**（ドキュメントを軽く保つ検収条件）。cross-cycle の残タスク（残り trailing-only タイマーの OwnedTimer 流用）は #545 として起票済み。

関連: #536, #545
