### PR TITLE
fix(webview2): TrySuspend を SetIsVisible(false) で成立させ frontend hide にも拡張

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -80,11 +80,30 @@ frontend hide（`hideMainWindow()`）で `notifyMainHidden()`（trim）を `awai
 | frontend(Escape) hide 後 | ~50 MB（3 回 50-61） | **~27 MB**（3 回 27-30） |
 | hotkey hide 後（参照・無変更） | ~10 MB | ~10 MB |
 
-frontend hide の総ツリー WS が**約半減**（frontend↔hotkey 差の ~57% を解消）。残差（~17MB）は frontend 経路が `suspend_webview`（TrySuspend）を行わない設計差に起因（tokio IPC スレッドの `with_webview` 非同期制約のため hotkey 限定。`src-tauri/CLAUDE.md`「TrySuspend / Resume パターン」節）。gap は「trim タイミング」成分（#361 で解消）+「suspend 有無」成分（設計上の意図的な差）の和。
+frontend hide の総ツリー WS が**約半減**（frontend↔hotkey 差の ~57% を解消）。残差（~17MB）は frontend 経路が `suspend_webview`（TrySuspend）を行わない設計差に起因（tokio IPC スレッドの `with_webview` 非同期制約のため hotkey 限定。`src-tauri/CLAUDE.md`「TrySuspend / Resume パターン」節）。gap は「trim タイミング」成分（#361 で解消）+「suspend 有無」成分（設計上の意図的な差）の和。**（2026-07-17 訂正: 下の follow-up のとおり、当時の TrySuspend は両経路とも同期失敗しており、この残差の「suspend 有無」解釈は成り立たない。実体は trim 実行タイミングの揺らぎだった）**
+
+### follow-up: TrySuspend は一度も成立していなかった（2026-07-17 計測）
+
+trace 計装（`suspend:call_returned` / `suspend:completed`）で、`TrySuspend` が hotkey 経路を含む**全 hide で同期 Err（0x8007139F ERROR_INVALID_STATE）を返し、導入以来一度も suspend が成立していなかった**ことを確認した。原因は `TrySuspend` の前提条件が `ICoreWebView2Controller.IsVisible=false`（HWND 非表示とは独立の controller プロパティ）であり、wry が `hide()` でこれを下げないこと。同期 Err では完了ハンドラが呼ばれないため、既存の握りつぶし（`let _ =`）では観測不能だった。
+
+対処: `suspend_webview` で `SetIsVisible(false)` を自前実行してから `TrySuspend`、`resume_webview` で `SetIsVisible(true)` + `Resume` の対称復帰。同時に `notify_main_hidden` へ `run_on_main_thread` 経由の suspend を拡張（frontend hide も hotkey と同一の suspend → trim 順・同一実行文脈）。
+
+計測（release ビルド・テスト index 数百件・プロセスツリー総 WorkingSet64・各 10 サイクル + アイドルプローブ）:
+
+| 変種 | hide 直後(中央値) | idle 30s | idle 60s | idle 120s | show p50 / max |
+|---|---:|---:|---:|---:|---|
+| 修正前 Escape | ~30MB | 85.7 | 86.0 | — | 33.3 / 53.4ms |
+| 修正前 hotkey | ~18MB | 69.9 | 70.5 | — | 33.9 / 52.3ms |
+| 修正後 Escape | ~27MB | **14.0** | **18.9** | 30.7 | 34.6 / 52.3ms |
+| 修正後 hotkey | ~37MB | **11.9** | **17.3** | 29.2 | 35.4 / 56.8ms |
+
+- **本質的な効果は hide 直後ではなく定常アイドル**: suspend が成立しないとレンダラーが動き続け、trim の成果がアイドル 30 秒で ~70-86MB へ巻き戻る。成立後は 12-31MB で低空安定（約 55-70MB 削減）。99% 非表示のランチャーでは定常値が真の指標
+- show レイテンシは劣化なし（suspend 成功率は両経路 10/10、クエリ入力 + アイコン取得を挟む 4 サイクルでも機能劣化なし）
+- #355 の「hotkey hide 9.4MB vs frontend 22.8MB」の差は suspend ではなく trim タイミング差の産物だった
 
 ### 効かなかった/見送った手法
 
-- **TrySuspend / MemoryUsageTargetLevel.Low 単独**: 論理目標を下げるだけで、メモリ圧迫のない実機では OS が物理 working set を回収しない（表示↔非表示・120 秒放置で 110MB 不変）。主効果は CPU 中断。working set 回収には `EmptyWorkingSet` の能動適用が必要（両者は別レイヤーで補完的）
+- **TrySuspend / MemoryUsageTargetLevel.Low 単独**: 当時「論理目標を下げるだけで物理 working set を回収しない（120 秒放置で 110MB 不変）」と結論したが、**2026-07-17 訂正: この時点の TrySuspend は `SetIsVisible(false)` を欠き同期失敗していた**——「効いているが物理を返さない」のではなく「そもそも動いていなかった」。成立後はアイドル再増殖の防止に有効（上の follow-up）。即時回収に `EmptyWorkingSet` が必要という結論自体は不変（両者は別レイヤーで補完的）
 - **tokio / rayon の worker スレッド削減**: Rust 本体は Tauri 既定の multi-thread tokio（worker = CPU コア数）+ rayon プールで ~50 スレッドを抱えるが、スレッドスタックは計 2.17MB（committed 42.8MB の 5%）に過ぎず、worker を絞っても RSS 削減は <1MB で**無意味**。30MB の大半はヒープ/フレームワーク baseline
 - **`--disable-gpu --disable-gpu-compositing`**: GPU プロセスは消えない（in-process ソフト合成に切替）が Private 18→6MB・合計 110→99MB。ただしブラウザフラグは Microsoft 非サポート（ランタイム更新で挙動変化）＋ CPU 合成化で描画レイテンシ未検証。限界効用は `EmptyWorkingSet`（~107MB）に対し桁違いに小さく見送り
 - **アイコン PNG 圧縮強化（issue #335）**: 16×16 アイコンで実測 ~0.06MB と桁違いに小さく却下（詳細は #335）

--- a/docs/build-commands.md
+++ b/docs/build-commands.md
@@ -91,6 +91,7 @@ npm run tauri build              # リリースビルド（フロント+Rust 一
 
 - `scripts/smoke-startup.ps1` は `SNOTRA_TRACE=1` で起動し、`*:error` トレースイベントが不在であることを検証する
 - `e2e/tauri.slash.e2e.ts` は Playwright runner 上で `tauri-driver + selenium-webdriver + edgedriver` を使い、起動入力・`/o` の動作を検証する
+- **E2E は `SNOTRA_DISABLE_SUSPEND=1` で app を起動する**（`spawnTauriDriver` が注入）。WebDriver は非表示中のレンダラーに `executeScript` で触り続けるため、hide 時の WebView2 suspend（TrySuspend）とは非互換（suspend されたレンダラーは script に応答せず 30s タイムアウトする）。suspend 経路自体は E2E では検証されない（ホットキー同様、実機計測でカバー）
 - E2E セットアップは `npx tauri build --no-bundle` を使う（`cargo build --release` は `localhost` 向きバイナリになり `ERR_CONNECTION_REFUSED` で失敗する）
 - スラッシュコマンドの実行順（`hide -> /r|/o|/s|/q`）は `ui/src/lib/commands.test.ts` で固定し、順序変更時は必ず更新する
 - Tauri Driver E2E の可視判定は `document.visibilityState` を真実源にしない。`plugin:window|is_visible` を優先して判定する

--- a/e2e/tauri.slash.e2e.ts
+++ b/e2e/tauri.slash.e2e.ts
@@ -264,8 +264,13 @@ async function spawnTauriDriver(): Promise<ChildProcessWithoutNullStreams> {
     }
   }
   const nativeDriverPath = await downloadEdgeDriver();
+  // WebDriver は非表示中のレンダラーへの executeScript で可視性判定・入力を行うため、
+  // hide 時の WebView2 suspend（TrySuspend）とは原理的に非互換（suspend された
+  // レンダラーは script に応答せず 30s タイムアウトする）。app 側の環境変数ゲートで
+  // suspend のみ無効化して起動する（EmptyWorkingSet trim は有効のまま）。
   const proc = spawn(tauriDriverPath, ["--native-driver", nativeDriverPath], {
     stdio: "pipe",
+    env: { ...process.env, SNOTRA_DISABLE_SUSPEND: "1" },
   });
   proc.on("error", () => {
     // handled by port timeout / session creation errors

--- a/e2e/tauri.slash.e2e.ts
+++ b/e2e/tauri.slash.e2e.ts
@@ -264,10 +264,9 @@ async function spawnTauriDriver(): Promise<ChildProcessWithoutNullStreams> {
     }
   }
   const nativeDriverPath = await downloadEdgeDriver();
-  // WebDriver は非表示中のレンダラーへの executeScript で可視性判定・入力を行うため、
-  // hide 時の WebView2 suspend（TrySuspend）とは原理的に非互換（suspend された
-  // レンダラーは script に応答せず 30s タイムアウトする）。app 側の環境変数ゲートで
-  // suspend のみ無効化して起動する（EmptyWorkingSet trim は有効のまま）。
+  // WebDriver は非表示中のレンダラーへ executeScript するため hide 時の suspend と
+  // 非互換。suspend のみ無効化して起動する（理由・詳細は src-tauri/CLAUDE.md
+  // 「WebView2 TrySuspend / Resume パターン」節の SNOTRA_DISABLE_SUSPEND の項）。
   const proc = spawn(tauriDriverPath, ["--native-driver", nativeDriverPath], {
     stdio: "pipe",
     env: { ...process.env, SNOTRA_DISABLE_SUSPEND: "1" },

--- a/src-tauri/CLAUDE.md
+++ b/src-tauri/CLAUDE.md
@@ -81,17 +81,20 @@ NOTIFYICON_VERSION_4 では、キーボード操作（Shift+F10 / Application �
 
 非表示中に WebView2 レンダラーを中断してメモリ・CPU を削減する。`ICoreWebView2_3::TrySuspend` / `Resume`（Edge 88+）を使用。
 
-- **hide 時（ホットキートグルのみ）**: `w.hide()` → `emit("window-hidden")` → `suspend_webview(&w)`。emit を suspend より先に送ることで、JS 側のクリーンアップ（Blob URL 解放等）がレンダラー中断前にキューイングされる。`TrySuspend` は `IsVisible=false` を要求するため hide が先
-- **show 時**: `resume_webview(&main)` → `set_size` → `show` → `emit`。Resume は同期 API で即座に復帰
-- **フロントエンド起因の hide（Escape / クリック起動 / フォーカス喪失）では suspend しない**: `notifyMainHidden` IPC は tokio スレッドで実行されるため `with_webview(TrySuspend)` は非同期ディスパッチになり、`win.hide()` より先にメインスレッドに到達すると IsVisible=true で失敗する。ホットキートグル（メインスレッドで同期実行）に限定することで順序を保証
-- **`with_webview()` の同期性はコンテキスト依存**: setup フェーズ / `app.listen` コールバック → 同期。IPC ハンドラ / `std::thread::spawn` → 非同期（fire-and-forget）
+- **`TrySuspend` の前提は `ICoreWebView2Controller.IsVisible=false` であり、HWND の非表示とは独立**（2026-07-17 実測）。wry は `win.hide()` で controller 側を下げないため、`suspend_webview` が `SetIsVisible(false)` を自前で実行してから `TrySuspend` を呼ぶ。これを欠くと `TrySuspend` は**同期 Err（0x8007139F ERROR_INVALID_STATE）で失敗し、完了ハンドラは呼ばれず沈黙する**——導入以来この失敗が全 hide で起きており、suspend は一度も成立していなかった。`SNOTRA_TRACE=1` で `suspend:call_returned`（同期戻り値）/ `suspend:completed`（成否）を観測できる
+- **hide 時（hotkey トグル）**: `w.hide()` → `emit("window-hidden")` → `suspend_webview(&w, "hotkey")`。emit を suspend より先に送ることで、JS 側のクリーンアップ（Blob URL 解放等）がレンダラー中断前にキューイングされる。ウィンドウ hide が先なのは UX 上の要請（中断は不可視状態でのみ行う）
+- **hide 時（フロントエンド起因: Escape / クリック起動 / フォーカス喪失 / `/s`）**: `notify_main_hidden` が `app.run_on_main_thread` で suspend → trim を実行する。IPC (tokio) スレッドの `with_webview` は非同期ディスパッチだが、`with_webview` / `run_on_main_thread` のクロージャは**メインスレッドのイベントループで FIFO 直列化**されるため、後続 show の resume に追い越されない。フロントは `await win.hide()` 完了後に本 IPC を呼ぶ（#361）
+- **再表示と競合した suspend は 2 段で無害化する**: 旧実装で「競合時は黙って失敗」を担っていたのは TrySuspend 自身の前提条件チェック（IsVisible=true → 同期 Err）だが、IsVisible を自前で下げる現実装ではその検査は機構として働かない。代わりに (1) suspend クロージャ内（メインスレッド実行時点）の `main_visible` ガードが「show 完了後に実行される」ケースを放棄し、(2) `show_main_and_emit` が show 完了後にもう一度 `resume_webview` を積んで「冒頭 resume の後〜可視フラグ反映前に滑り込む」残余窓を是正する。ガードは**必ずクロージャ内で読む**（外で読むとディスパッチ待ち中に show が完了する TOCTOU）
+- **show 時**: `resume_webview(&main)`（`SetIsVisible(true)` + `Resume`。suspend 側が下げた controller 可視フラグと対称）→ `set_size` → `show`（+ 末尾に resume 再適用）→ `emit`。Resume は同期 API で即座に復帰（実測: show p50 33→37ms 帯で劣化なし）
+- **`with_webview()` は呼び出しスレッドによらずクロージャがメインスレッドで実行される**: setup フェーズでは同期的に完了するが、それ以外（IPC ハンドラ / `std::thread::spawn` / イベント listener）では非同期ディスパッチとして扱うこと。順序が要る箇所はクロージャの FIFO 直列化（同一キュー）に依拠する
 - **TrySuspend と MemoryUsageTargetLevel は混用禁止**: TrySuspend が自動で MemoryUsageTargetLevel を Low に設定し、Resume が Normal に戻す
+- **`SNOTRA_DISABLE_SUSPEND=1` で suspend を無効化できる（E2E 専用エスケープハッチ）**: WebDriver は非表示中のレンダラーへの `executeScript` で可視性判定・入力を行うため、suspend されたレンダラーとは原理的に非互換（script が応答せずタイムアウト）。E2E ハーネス（`e2e/tauri.slash.e2e.ts` の `spawnTauriDriver`）がこの変数を立てて起動する。`EmptyWorkingSet` trim は無効化されない
 
 ## WebView2 working set の能動回収（EmptyWorkingSet）
 
-TrySuspend / MemoryUsageTargetLevel.Low は**論理目標**を下げるだけで、メモリ圧迫のない環境では OS が**物理 working set を回収しない**（実測: 非表示アイドル ~110MB が表示↔非表示・120 秒放置でも不変）。`working_set::trim_idle_working_set()` が hide 経路で Win32 `EmptyWorkingSet` をプロセスツリー全体（自プロセス + WebView2 子孫）へ能動適用し、アイドル物理 RSS を数MB まで落とす（再表示は OS の透過 re-fault で ~44ms 維持、UI 正常）。
+`working_set::trim_idle_working_set()` が hide 経路で Win32 `EmptyWorkingSet` をプロセスツリー全体（自プロセス + WebView2 子孫）へ能動適用し、hide 直後の物理 RSS を即時に落とす（再表示は OS の透過 re-fault で ~44ms 維持、UI 正常）。
 
-- **TrySuspend とは別レイヤーで補完的**: TrySuspend=論理目標（圧迫待ち・CPU 中断）、EmptyWorkingSet=物理 working set の即時トリミング。競合しない
+- **TrySuspend とは別レイヤーで補完的**: EmptyWorkingSet=物理 working set の**即時トリミング**、TrySuspend=レンダラー停止によるアイドル中の**再増殖防止**（+ CPU 静止）。suspend が成立しないと trim 後もレンダラーがページを touch し続け、アイドル 30 秒でツリー WS が ~70-86MB へ戻る（2026-07-17 実測。suspend 成立後は 12-31MB で低空安定）。なお旧記述「TrySuspend は物理 WS を回収しない（~110MB 不変）」は、TrySuspend が実は同期失敗していた期間の測定に基づく（→「TrySuspend / Resume パターン」）
 - **全 hide 経路に適用**: hotkey トグル（`main.rs`、`suspend_webview` の後）と `notify_main_hidden`（`commands/system.rs`、全フロントエンド hide の IPC チョークポイント）の両方から呼ぶ。**`EmptyWorkingSet` はスレッド非依存**（`with_webview` のような非同期制約がない）ため、tokio IPC スレッドの `notify_main_hidden` からも安全
 - **show 側に逆操作は不要**: trim されたページは show 時に OS が透過的に re-fault する。明示 untrim API は存在しない。trim が hide 前後どちらで走っても無害（再 fault するだけ）
 - **best-effort・物理 RAM のみ**: Toolhelp / `OpenProcess` / `EmptyWorkingSet` の全失敗は黙ってスキップ（機能影響ゼロ）。HANDLE は RAII ガードで解放。削減対象は working set であって commit ではない

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::Ordering;
 
-use tauri::{AppHandle, Emitter, State};
+use tauri::{AppHandle, Emitter, Manager, State};
 
 use crate::indexing;
 use crate::state::AppState;
@@ -66,10 +66,27 @@ pub fn notify_main_shown(state: State<AppState>) {
 pub fn notify_main_hidden(state: State<AppState>, app: AppHandle) {
     state.main_visible.store(false, Ordering::SeqCst);
     let _ = app.emit("window-hidden", ());
-    // フロントエンド起因の hide（フォーカス喪失/Escape/クリック起動/スラッシュ）も
-    // working set を回収する。EmptyWorkingSet はスレッド非依存ゆえ tokio IPC スレッドから
-    // 安全に呼べる（suspend_webview の with_webview 非同期制約がない）。best-effort。
-    crate::working_set::trim_idle_working_set(std::process::id());
+    // フロントエンド起因の hide（フォーカス喪失/Escape/クリック起動/スラッシュ）でも
+    // hotkey 経路と同じく suspend → trim を行う。with_webview は IPC (tokio) スレッド
+    // からは非同期ディスパッチになるため、run_on_main_thread でメインスレッドの
+    // イベントループへ移す（with_webview / run_on_main_thread のクロージャは同一キューで
+    // FIFO 直列化され、後続 show の resume に追い越されない）。フロントは `await win.hide()`
+    // 完了後に本 IPC を呼ぶ（#361）ため、ここに到達した時点でウィンドウは非表示。
+    // 再表示と競合した稀な逆転は suspend_webview 側の main_visible ガード +
+    // show_main_and_emit 末尾の resume 再適用が是正する。trim は可視中でも無害
+    //（OS が透過 re-fault するだけ）。すべて best-effort。
+    let pid = std::process::id();
+    let app_for_main = app.clone();
+    let scheduled = app.run_on_main_thread(move || {
+        if let Some(w) = app_for_main.get_webview_window("main") {
+            crate::suspend_webview(&w, "notify_main_hidden");
+        }
+        crate::working_set::trim_idle_working_set(pid);
+    });
+    if scheduled.is_err() {
+        // メインスレッドへ移せない場合も working set 回収だけは従来どおり行う。
+        crate::working_set::trim_idle_working_set(pid);
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -128,17 +128,67 @@ fn make_key_input(
 #[cfg(not(windows))]
 fn send_alt_key_up() {}
 
+/// WebDriver 自動化（E2E）は非表示中のレンダラーへの script 実行で成り立つため、
+/// suspend されたレンダラーとは原理的に非互換（`executeScript` が応答せず
+/// タイムアウトする）。E2E ハーネスは `SNOTRA_DISABLE_SUSPEND=1` で suspend を
+/// 無効化して起動する（`EmptyWorkingSet` trim は従来どおり有効のまま）。
+#[cfg(windows)]
+fn suspend_disabled() -> bool {
+    static DISABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *DISABLED.get_or_init(|| {
+        let Ok(v) = std::env::var("SNOTRA_DISABLE_SUSPEND") else {
+            return false;
+        };
+        matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
 /// Suspend the WebView2 renderer to reduce memory/CPU while hidden.
 ///
-/// Must be called AFTER `hide()` (`IsVisible=false` required by WebView2).
-/// Best-effort: silently ignored if WebView2 runtime is too old (< Edge 88)
-/// or `IsVisible` is still true.
+/// Must be called AFTER the window is hidden (UX: the user should never see a
+/// paused webview). `TrySuspend` requires `ICoreWebView2Controller.IsVisible`
+/// to be false — a controller-level property INDEPENDENT of the HWND
+/// visibility. wry does not lower it on `hide()`, so we lower it here
+/// ourselves; without this, `TrySuspend` fails synchronously with
+/// 0x8007139F (ERROR_INVALID_STATE) and the completion handler never runs
+/// (2026-07-17 実測: 導入以来この失敗が全 hide で起きていた).
+/// `resume_webview` restores it symmetrically (`SetIsVisible(true)` + `Resume`).
+///
+/// Best-effort: silently ignored if WebView2 runtime is too old (< Edge 88).
+/// 再表示と競合した場合はクロージャ内の `main_visible` ガードで suspend を放棄し、
+/// `show_main_and_emit` 末尾の resume 再適用が残余ケース（resume 実行後〜可視フラグ
+/// 反映前に滑り込む逆転）を是正する。
 #[cfg(windows)]
-fn suspend_webview(window: &tauri::WebviewWindow) {
-    let _ = window.with_webview(|platform_webview| {
+fn suspend_webview(window: &tauri::WebviewWindow, source: &'static str) {
+    if suspend_disabled() {
+        return;
+    }
+    let app_handle = window.app_handle().clone();
+    let _ = window.with_webview(move |platform_webview| {
         use webview2_com::Microsoft::Web::WebView2::Win32::ICoreWebView2_3;
         use webview2_com::TrySuspendCompletedHandler;
         use windows_core_0_61::Interface;
+
+        // 再表示と競合した場合は suspend を放棄する。旧実装ではこの安全弁を
+        // TrySuspend 自身の前提条件チェック（controller.IsVisible=true → 同期 Err）が
+        // 無償で担っていたが、IsVisible を自前で下げる本実装ではその検査が機構として
+        // 働かないため、メインスレッド実行時点の main_visible で明示的に再設置する。
+        // クロージャの外で読むと、ディスパッチ待ちの間に show が完了して古い値を
+        // 参照する TOCTOU になるため、必ずクロージャ内（実行時点）で読む。
+        let visible = app_handle
+            .try_state::<AppState>()
+            .map(|s| s.main_visible.load(Ordering::SeqCst))
+            .unwrap_or(false);
+        if visible {
+            trace_main(
+                "suspend:skipped",
+                json!({ "source": source, "reason": "visible" }),
+            );
+            return;
+        }
 
         let controller = platform_webview.controller();
         let Ok(webview) = (unsafe { controller.CoreWebView2() }) else {
@@ -148,9 +198,25 @@ fn suspend_webview(window: &tauri::WebviewWindow) {
             return;
         };
 
-        let handler =
-            TrySuspendCompletedHandler::create(Box::new(|_result, _is_successful| Ok(())));
-        let _ = unsafe { webview3.TrySuspend(&handler) };
+        let _ = unsafe { controller.SetIsVisible(false) };
+        let handler = TrySuspendCompletedHandler::create(Box::new(move |result, is_successful| {
+            trace_main(
+                "suspend:completed",
+                json!({
+                    "source": source,
+                    "successful": is_successful,
+                    "hr": format!("{result:?}"),
+                }),
+            );
+            Ok(())
+        }));
+        // 同期 Err（前提条件不成立など）は完了ハンドラが呼ばれず沈黙する故障モード。
+        // SNOTRA_TRACE 有効時は同期戻り値も残し、再発を観測可能にしておく。
+        let call_hr = unsafe { webview3.TrySuspend(&handler) };
+        trace_main(
+            "suspend:call_returned",
+            json!({ "source": source, "hr": format!("{call_hr:?}") }),
+        );
     });
 }
 
@@ -170,12 +236,18 @@ fn resume_webview(window: &tauri::WebviewWindow) {
             return;
         };
 
-        let _ = unsafe { webview3.Resume() };
+        // suspend_webview が下げた controller.IsVisible を戻してから Resume する
+        // （IsVisible=true 自体にも自動 resume の効果があり、両者とも冪等）。
+        let _ = unsafe { controller.SetIsVisible(true) };
+        let call_hr = unsafe { webview3.Resume() };
+        // suspend 側と同型の「同期 Err は沈黙する」故障モードを可観測にしておく
+        // （SNOTRA_TRACE ゲート済み）。
+        trace_main("resume:call_returned", json!({ "hr": format!("{call_hr:?}") }));
     });
 }
 
 #[cfg(not(windows))]
-fn suspend_webview(_window: &tauri::WebviewWindow) {}
+fn suspend_webview(_window: &tauri::WebviewWindow, _source: &'static str) {}
 
 #[cfg(not(windows))]
 fn resume_webview(_window: &tauri::WebviewWindow) {}
@@ -349,6 +421,13 @@ fn show_main_and_emit(app_handle: &AppHandle, ime_control: bool) {
         position_on_target_monitor(app_handle, &main);
 
         show_and_focus_main(app_handle, &main, t0);
+
+        // 逆転是正: notify_main_hidden の suspend クロージャは hide 完了後に非同期で
+        // 積まれるため、直後に show が来ると冒頭の resume より後に実行されうる。
+        // suspend 側の main_visible ガードは「show 完了後に実行される」ケースを捕捉するが、
+        // 「冒頭 resume の実行後〜main_visible=true 反映前」に滑り込むケースは通り抜ける。
+        // show 完了後にもう一度 resume を積む（冪等）ことで、この残余窓も閉じる。
+        resume_webview(&main);
 
         if ime_control {
             apply_ime_control(app_handle, &main, t0);
@@ -646,7 +725,7 @@ fn setup_hotkey_listener(app_handle: &AppHandle, hotkey_toggle: bool, ime_off: b
             // TrySuspend is best-effort and async: the renderer finishes processing
             // the queued emit before actually suspending.
             if let Some(w) = handle_for_hotkey.get_webview_window("main") {
-                suspend_webview(&w);
+                suspend_webview(&w, "hotkey");
             }
             // 非表示アイドルの物理 working set を回収（TrySuspend は圧迫なし環境では
             // 回収しないため能動適用）。best-effort・機能挙動には影響しない。

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -135,15 +135,7 @@ fn send_alt_key_up() {}
 #[cfg(windows)]
 fn suspend_disabled() -> bool {
     static DISABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *DISABLED.get_or_init(|| {
-        let Ok(v) = std::env::var("SNOTRA_DISABLE_SUSPEND") else {
-            return false;
-        };
-        matches!(
-            v.trim().to_ascii_lowercase().as_str(),
-            "1" | "true" | "yes" | "on"
-        )
-    })
+    *DISABLED.get_or_init(|| trace::env_flag("SNOTRA_DISABLE_SUSPEND"))
 }
 
 /// Suspend the WebView2 renderer to reduce memory/CPU while hidden.

--- a/src-tauri/src/trace.rs
+++ b/src-tauri/src/trace.rs
@@ -17,17 +17,22 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use serde_json::json;
 
+/// 真偽 env フラグの共通解析（受理値: `1`/`true`/`yes`/`on`、trim + ASCII 小文字化）。
+/// `trace_enabled`（`SNOTRA_TRACE`）と `suspend_disabled`（`SNOTRA_DISABLE_SUSPEND`、
+/// `main.rs`）が共有する受理仕様の SSOT。キャッシュは呼び出し側の `OnceLock` が担う。
+pub(crate) fn env_flag(name: &str) -> bool {
+    let Ok(v) = std::env::var(name) else {
+        return false;
+    };
+    matches!(
+        v.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
 pub(crate) fn trace_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
-    *ENABLED.get_or_init(|| {
-        let Ok(v) = std::env::var("SNOTRA_TRACE") else {
-            return false;
-        };
-        matches!(
-            v.trim().to_ascii_lowercase().as_str(),
-            "1" | "true" | "yes" | "on"
-        )
-    })
+    *ENABLED.get_or_init(|| env_flag("SNOTRA_TRACE"))
 }
 
 /// Emit one `[trace]` JSON line to stderr if `SNOTRA_TRACE` is enabled.

--- a/src-tauri/src/working_set.rs
+++ b/src-tauri/src/working_set.rs
@@ -1,9 +1,10 @@
 //! 非表示アイドル時に WebView2 プロセスツリー全体の working set を回収する。
 //!
-//! `TrySuspend` / `MemoryUsageTargetLevel.Low`（`main.rs`）は論理目標を下げるだけで、
-//! メモリ圧迫のない環境では OS が物理 working set を回収しない（実測: 非表示 120 秒でも
-//! 不変）。ここでは hide 経路で Win32 `EmptyWorkingSet` をプロセスツリー（自プロセス +
-//! WebView2 子孫）へ能動適用し、アイドル常駐の物理 RSS を削減する。
+//! `TrySuspend`（`main.rs`）はレンダラーを停止してアイドル中の working set 再増殖を防ぐが、
+//! 停止済みページの物理 working set を即時には返さない。ここでは hide 経路で Win32
+//! `EmptyWorkingSet` をプロセスツリー（自プロセス + WebView2 子孫）へ能動適用し、
+//! hide 直後の物理 RSS を即時に削減する（suspend とは補完関係。`src-tauri/CLAUDE.md`
+//! 「WebView2 working set の能動回収」節）。
 //!
 //! - show 時は OS がページを透過的に re-fault するため、逆操作（untrim）は不要かつ存在しない。
 //! - best-effort: Toolhelp / `OpenProcess` / `EmptyWorkingSet` の全失敗は黙ってスキップする

--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -38,7 +38,7 @@ SolidJS + TypeScript フロントエンド。Tauri IPC 経由で Rust バック�
 - `types.ts`: TypeScript 型定義の集約先（DRY）
 - `commands.ts`: スラッシュコマンド定義（`/r` `/o` `/s` `/q`）と `SLASH_COMMANDS` 配列・`findCommand()` 関数
   - **`hideMainWindow()` は全 frontend hide（Escape / Enter / Shift+Enter / クリック起動 / フォーカス喪失 / `/s`）の単一チョークポイント**。MainApp.tsx のフォーカス喪失・クリック起動経路もこの関数に集約する
-  - **`await win.hide()` → `notifyMainHidden()` の順を守る** — `notifyMainHidden` 内の `EmptyWorkingSet` trim を hide 完了後に走らせることで、可視中の再 touch による working set 回収の取りこぼしを避ける（hotkey 経路と同順。#361）
+  - **`await win.hide()` → `notifyMainHidden()` の順を守る** — `notifyMainHidden` 内の suspend（TrySuspend）+ `EmptyWorkingSet` trim を hide 完了後に走らせることで、可視中の再 touch による working set 回収の取りこぼしと suspend の前提（非表示）崩れを避ける（hotkey 経路と同じ hide→suspend→trim 順。#361）
 - `i18n.ts`: 多言語対応（日本語・英語）。`TranslationKey` 型と `t(key, params?)` 関数。`{param}` 形式プレースホルダー対応。SolidJS シグナルで言語を管理し、`setLanguage()` で切替。初期言語は `navigator.language` から同期的に決定（bootstrap 到着前のフラッシュ防止）
 - `folderNav.ts`: フォルダナビゲーション純粋ロジック（`computeParentDir`・`clampSelectedIndex`）。ドライブルート・UNC パス対応。テスト可能なため `stores/` から分離
 - `interpretQuery.ts`: 入力解釈の純関数（`interpret`・`isInstantPrefix`・`ViewKind`/`InterpKind`/`QueryIntent` 型）。「入力（query + prefix + viewKind）→ 意図（plain/command/instant + instant の filterName/instantQuery）」を副作用なしで返す。instant 判定・parse の SSOT。`stores/search.ts` の `interpKind` memo と `dispatchQueryInput` がこれを消費する（SolidJS/api 非依存・テスト可能なため分離・#537）

--- a/ui/src/MainApp.tsx
+++ b/ui/src/MainApp.tsx
@@ -98,6 +98,10 @@ const MainApp: Component = () => {
             trace("app:event:platform_event:initial_hotkey_failed");
             try {
               setMainVisible(true);
+              // 不変条件: suspend 後に到達しうる show 経路は必ず Rust 側の
+              // show_main_and_emit（resume_webview を含む）を通ること。この win.show() は
+              // 起動直後（初回 suspend 発生前）にしか発火しないため resume 不要の例外。
+              // 別のタイミングから再利用する場合は Rust 側の show 経路へ寄せ直すこと。
               await win.show();
               // Sync Rust-side visibility flag so hotkey toggle works correctly.
               api.notifyMainShown().catch(() => {});

--- a/ui/src/lib/commands.ts
+++ b/ui/src/lib/commands.ts
@@ -16,9 +16,9 @@ export interface SlashCommand {
 
 /** main webview コンテキストから呼び出すこと（getCurrentWindow() が main を返す前提）。
  *  全 frontend hide（Escape / Enter / Shift+Enter / クリック起動 / フォーカス喪失 / /s）の
- *  単一チョークポイント。notifyMainHidden() の trim（EmptyWorkingSet）は win.hide() 完了後に
- *  走らせる——可視中に trim するとレンダラがページを再 touch し working set 回収が削がれるため
- *  （hotkey 経路と同じ hide→trim 順に揃える。#361）。 */
+ *  単一チョークポイント。notifyMainHidden() の suspend（TrySuspend）+ trim（EmptyWorkingSet）は
+ *  win.hide() 完了後に走らせる——可視中に trim するとレンダラがページを再 touch し working set
+ *  回収が削がれ、suspend は非表示が前提のため（hotkey 経路と同じ hide→suspend→trim 順。#361）。 */
 export async function hideMainWindow() {
   await getCurrentWindow().hide();
   api.notifyMainHidden().catch(() => {});


### PR DESCRIPTION
## 概要

WebView2 の `TrySuspend`（非表示中のレンダラー中断）が**導入以来一度も成功していなかった**ことを trace 計装で確認し、根本修正の上で frontend hide 経路にも suspend を拡張しました。

`TrySuspend` の前提条件は `ICoreWebView2Controller.IsVisible = false`（**HWND の非表示とは独立した controller プロパティ**）ですが、wry は `hide()` でこれを下げません。そのため毎回同期 Err `0x8007139F`（ERROR_INVALID_STATE）で失敗し、完了ハンドラは呼ばれず沈黙していました（同期 Err はコールバックが発火しないため、既定の握りつぶしでは観測不能な故障モード）。

## 変更点

- **`suspend_webview`**: `SetIsVisible(false)` を `TrySuspend` の前に実行（本質的修正）。再表示との競合はクロージャ内（メインスレッド実行時点）の `main_visible` ガードで放棄
- **`resume_webview`**: `SetIsVisible(true)` + `Resume` の対称復帰
- **`show_main_and_emit`**: show 完了後に resume を再適用し、suspend クロージャが「冒頭 resume の後〜可視フラグ反映前」に滑り込む残余レース窓を閉塞（ガードと 2 段構え）
- **`notify_main_hidden`**: `run_on_main_thread` 経由で suspend → trim を実行し、frontend hide（Escape / クリック起動 / フォーカス喪失 / `/s`）へ suspend を拡張（クロージャはメインスレッドのイベントループで FIFO 直列化）
- **`SNOTRA_DISABLE_SUSPEND=1`**: E2E 専用エスケープハッチ。WebDriver は非表示中のレンダラーへの `executeScript` で可視性判定・入力を行うため、suspend されたレンダラーとは原理的に非互換（30s タイムアウト）。E2E ハーネスが注入する
- **SNOTRA_TRACE 計装の恒久化**: `suspend:call_returned` / `suspend:completed` / `suspend:skipped` / `resume:call_returned`
- **ドキュメント同期**: `src-tauri/CLAUDE.md`・`PERFORMANCE.md`・`ui/CLAUDE.md`・`docs/build-commands.md` の旧前提（「TrySuspend の主効果は CPU 中断」「frontend hide では suspend しない」等）を実測に基づき訂正

## 実測（release・プロセスツリー総 WorkingSet64・各 10 サイクル）

| 変種 | hide 直後(中央値) | idle 30s | idle 60s | idle 120s | show p50 / max |
|---|---:|---:|---:|---:|---|
| 修正前 Escape | ~30MB | 85.7 | 86.0 | — | 33.3 / 53.4ms |
| 修正前 hotkey | ~18MB | 69.9 | 70.5 | — | 33.9 / 52.3ms |
| 修正後 Escape | ~27MB | **14.0** | **18.9** | 30.7 | 34.6 / 52.3ms |
| 修正後 hotkey | ~37MB | **11.9** | **17.3** | 29.2 | 35.4 / 56.8ms |

- 本質的な効果は hide 直後ではなく**定常アイドル**: suspend 不成立だとレンダラーが動き続け、trim の成果が 30 秒で ~70-86MB へ再増殖していた。成立後は 12-31MB で安定（**約 55-70MB 削減**）
- suspend 成功率は両経路 10/10（`suspend:completed successful:true`）。ガード入り最終ビルドでも 4/4・誤発動なし
- クエリ入力（検索 + アイコン取得 + Blob 解放）を挟む 4 サイクルでも機能劣化なし

## 検証

- `cargo check --workspace` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test -p snotra`（70 件）
- `npm run typecheck` / `npm run build` / `npm test`（424 件）
- `npm run smoke:startup`（5 runs・`*:error` なし）
- `npm run e2e:tauri`（16 件全通過・16.9s。ゲート導入前は suspend と WebDriver の非互換で 2 件が 30s タイムアウト失敗していた）
- code-reviewer 3 フェーズレビュー実施済み。High（競合時ガードの喪失）・Medium（文書の過剰主張）・Low（resume 計装非対称・`MainApp.tsx` の show 経路コメント）を反映。SPEC.md は対象外（suspend / メモリ管理の記述なし・IPC 契約不変）を確認

## 残タスク（follow-up・本 PR 対象外）

- hide 経路の「suspend → trim」列が hotkey / notify_main_hidden の 2 箇所に重複（DRY）。`suspend_and_trim_on_main` ヘルパーへの統一はレビュアー判断により別途
- suspend 中のレンダラーへの eval（config 変更イベント等）は WebView2 が自動 resume するため、非表示中に config 変更があるとその hide サイクルの suspend 効果は失われる（best-effort の受容残余）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
