### PR TITLE
fix(e2e): restore WebView2 automation under High IL

### DIFF
--- a/RETROSPECTIVE.md
+++ b/RETROSPECTIVE.md
@@ -1,29 +1,25 @@
-# Retrospective — コメント一括スイープ (#561 / PR #563)
-
-`docs/comment-guidelines.md` へ既存コメントを揃える有界スイープ。挙動不変・コメントのみ（24 ソース + doc 2 行、+101/−82）。
+# Retrospective — WebView2 150 High IL E2E 復旧 (#555)
 
 ## よかったこと
 
-### 独立再導出が初期走査の網を約 3 倍に広げた（plan-review Step 2b が再び効いた）
+### 上流 Issue の最終回答と実行コードを照合し、原因を訂正できた
 
-初期 Explore 走査は「混在 1 件・履歴/逐語訳 4 件・TSDoc はほぼ不要」と見立てたが、plan.md を渡さない独立再導出（Plan agent）は混在 13 ブロック・履歴ナラティブ約 15 箇所・契約 TSDoc 2 件（iconBatch/lruIconCache）を拾った。差の原因は**走査語彙・枠組みの設計差**（「以前は/used to」grep vs「旧/かつて」+ コメント行ブロック化スクリプト）。目視系スイープの完全性は検出パターンの設計に従属し、単一枠組みは自身の盲点を継承する——「枠組みの独立」がそれを破った。retrospective 文書の「独立再導出だけが毎回漏れを拾う」がまた実証された。
+#555 と WebView2Feedback#5640 の初期説明は「High IL で DevTools の loopback socket が壊れる」という仮説だったが、Microsoft の最終回答は異なっていた。WebView2 150 は昇格ホストで、ユーザーが書き換え可能な `WEBVIEW2_*` 環境変数と HKCU policy の browser arguments を意図的に無視する。一方、アプリ API の `CoreWebView2EnvironmentOptions.AdditionalBrowserArguments` は有効である。Tauri から Wry、WebView2 API まで値の到達経路を実装で追い、旧回避策が msedgedriver capability にしか届いていなかったことを確認したため、de-elevation や上流待ちをせず根本原因へ直接対応できた。
 
-### 契約記述を実装照合してから書いた（「嘘のコメントは無いより悪い」）
+### production のセキュリティ境界を構造で維持した
 
-perf.ts / lruIconCache.ts / iconBatch.ts の新規契約 TSDoc は、plan.md で「revoke 挙動を実読してから書く」と明記し、code-reviewer が 3 件すべて実装一致を照合。DEV 専用の perf.ts は偵察間で分類が割れた（独立導出「契約なし・副作用自明」vs TS 偵察「契約あり・最有力」）が、実コード照合で呼び出し順序・解放義務の契約ありと確定。「DEV 専用＝契約なし」は早計だった。
+E2E 専用 Cargo feature とセッション環境変数の両方が揃ったときだけ trusted app API へ `--remote-debugging-port=0` と隔離 data directory を設定する構造にした。通常ビルドではユーザーが書き換え可能な環境変数から browser argument を有効化できない。さらに data directory 名を単一の安全な相対 component に制限し、driver とアプリが同一ディレクトリを使い、正常・異常終了の両方で削除する不変条件をテストと E2E ハーネスで固定した。
 
-### スコープの規律（docgen を先送りしつつ 1 点だけ前倒し整合）
+### High IL の真の実行環境で復旧を証明した
 
-サイクル中のユーザーの docgen 相談を #562 として issue 化し、#561 を肥大させなかった。ただし perf.ts の TSDoc 配置だけは `@packageDocumentation` にして将来の docgen（浮きブロックを TypeDoc が捨てる）と衝突しないよう前倒し。#562 を閉じない配慮（closing keyword を付けず・PR 作成直後に closingIssuesReferences を検算）も効いた。
-
----
+ローカルの E2E 16 件を 2 回通したうえで、GitHub-hosted Windows runner の `E2E & Smoke` workflow を手動実行した。startup smoke 5/5 と Playwright E2E 16/16 が成功し、従来の `DevToolsActivePort file doesn't exist` が High IL 環境で解消したことを確認できた。ローカルの sandbox 起因 `EPERM` は権限付き再実行で環境要因と切り分け、コード回帰として扱わなかった。
 
 ## 伸びしろ
 
-### 旧識別子の残存参照を走査で拾えず、review まで残った
+### Issue 本文の「根本原因」を一度は確定情報として扱いかけた
 
-`ResultsSection.tsx:28-31` の `iconCacheVersion` 参照を現在形化したが、90 行下の `:121-124` にあった同一識別子への参照が初期走査・独立再導出の**双方から漏れ**、code-reviewer が拾った（`ui/CLAUDE.md:130` にも同一ドリフト）。
+Issue 本文や上流 Issue の冒頭説明は、その後の maintainer コメントで訂正されうる。今回は実装前に最終コメントまで読み直して是正できたが、初期段階では trusted-origin / loopback 仮説を前提に調査していた。根本原因の証拠は Issue の要約ではなく、上流の最終回答、依存ライブラリの実装、失敗・成功する実行経路の三点で確定する必要がある。この教訓は既存の「issue 前提のコード裏取り」と一致し、今回固有の High IL E2E 境界は `src-tauri/CLAUDE.md` に配置した。
 
-根本原因: 改名は過去 PR で済んでおり「改名 → 呼び出し元 grep」の引き金が発火しない。残存参照はコメント内にしか無く、**当の識別子名の grep でしか到達しない**。1 箇所直したら識別子名で repo 全体を grep すべきだった——`AGENTS.md`「バグ発見時は同一パターン全コードパス検索」の**コメントスイープ版**（既存原則の射程内だが、コメント整理には明示的に当てる意識が要る）。
+### driver 側設定とアプリ側設定を同じ概念として見ない精度が必要だった
 
-対処: 当初 `comment-guidelines.md`「コメントと実装の同期」への 1 段落追加を試みたが、#561 が「ガイドライン本体の変更は別 issue」とスコープ外に置いているため撤回し、PR #563 をコメントのみに保った。教訓は既存 AGENTS.md ルールの射程内であり、ガイドラインへの明示追記は別 issue の候補として `[[comment-guidelines-sweep-pending]]` メモリのフォローアップに記録。code-reviewer が拾ったのは機構が効いた証だが、走査段で拾うのが本筋。
+`tauri:options.webviewOptions.additionalBrowserArguments` という名前だけを見ると、WebView2 アプリ生成時の AdditionalBrowserArguments と同じ経路に見える。しかし実際は前者が msedgedriver capability、後者が Wry 経由のアプリ API であり、WebView2 150 のセキュリティ境界では結果が分かれた。層をまたぐ不具合では、設定名の類似ではなく「どのプロセスが、どの API を、どの整合性レベルで呼ぶか」まで追跡する必要がある。

--- a/docs/build-commands.md
+++ b/docs/build-commands.md
@@ -92,7 +92,7 @@ npm run tauri build              # リリースビルド（フロント+Rust 一
 - `scripts/smoke-startup.ps1` は `SNOTRA_TRACE=1` で起動し、`*:error` トレースイベントが不在であることを検証する
 - `e2e/tauri.slash.e2e.ts` は Playwright runner 上で `tauri-driver + selenium-webdriver + edgedriver` を使い、起動入力・`/o` の動作を検証する
 - **E2E は `SNOTRA_DISABLE_SUSPEND=1` で app を起動する**（`spawnTauriDriver` が注入）。WebDriver は非表示中のレンダラーに `executeScript` で触り続けるため、hide 時の WebView2 suspend（TrySuspend）とは非互換（suspend されたレンダラーは script に応答せず 30s タイムアウトする）。suspend 経路自体は E2E では検証されない（ホットキー同様、実機計測でカバー）
-- E2E セットアップは `npx tauri build --no-bundle` を使う（`cargo build --release` は `localhost` 向きバイナリになり `ERR_CONNECTION_REFUSED` で失敗する）
+- E2E セットアップは `npx tauri build --no-bundle --features e2e-webview-automation` を使う（`cargo build --release` は `localhost` 向きバイナリになり `ERR_CONNECTION_REFUSED` で失敗する）。feature はテスト用バイナリにだけ WebView2 の trusted application API 経由で `--remote-debugging-port=0` を設定可能にする。実際の有効化にはハーネスが生成する `SNOTRA_E2E_WEBVIEW_DATA_DIR` も必要で、通常配布ビルドや startup smoke に remote debugging を持ち込まない
 - スラッシュコマンドの実行順（`hide -> /r|/o|/s|/q`）は `ui/src/lib/commands.test.ts` で固定し、順序変更時は必ず更新する
 - Tauri Driver E2E の可視判定は `document.visibilityState` を真実源にしない。`plugin:window|is_visible` を優先して判定する
 - **`snotra-settings` は egui ネイティブウィンドウのため WebDriver から完全に不可視**: `waitForVisibleLabel(driver, "settings", ...)` は常にタイムアウトする。`/o` コマンドの副作用（`main.alwaysOnTop → false`）など、Tauri WebView 側で観測可能な状態変化で間接的に検証すること

--- a/e2e/tauri.slash.e2e.ts
+++ b/e2e/tauri.slash.e2e.ts
@@ -1,5 +1,6 @@
 import { test as base, expect } from "@playwright/test";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { access, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
 import net from "node:net";
@@ -19,6 +20,7 @@ type Harness = {
   tauriDriver: ChildProcessWithoutNullStreams;
   backup: ConfigBackup;
   fixtureDir: string;
+  webviewDataDir: string;
 };
 
 type WindowState = {
@@ -31,6 +33,7 @@ type WindowState = {
 
 const WD_SERVER = "http://127.0.0.1:4444/";
 const E2E_BUILD_HINT = "Run: npm run e2e:tauri:setup (or: npx tauri build --no-bundle)";
+const E2E_WEBVIEW_DATA_DIR_ENV = "SNOTRA_E2E_WEBVIEW_DATA_DIR";
 
 const E2E_FIXTURE_DIR = path.join(os.tmpdir(), "snotra-e2e-fixtures");
 const E2E_FIXTURE_FILENAMES = ["snotra-e2e-alpha.txt", "snotra-e2e-beta.txt", "snotra-e2e-gamma.txt"];
@@ -191,6 +194,33 @@ function getTauriDriverPath(): string {
   return path.join(cargoHome, "bin", binaryName);
 }
 
+function createE2EWebViewDataDir(): { name: string; path: string } {
+  const name = `snotra-e2e-webview2-${process.pid}-${randomUUID()}`;
+  const localAppData =
+    process.env.LOCALAPPDATA ?? path.join(os.homedir(), "AppData", "Local");
+  // Tauri resolves a configured relative dataDirectory beneath
+  // %LOCALAPPDATA%/<window-label>/ on Windows.
+  return { name, path: path.join(localAppData, "main", name) };
+}
+
+async function removeE2EWebViewDataDir(dataDir: string): Promise<void> {
+  await rm(dataDir, {
+    recursive: true,
+    force: true,
+    maxRetries: 5,
+    retryDelay: 200,
+  });
+}
+
+async function stopTauriDriver(proc: ChildProcessWithoutNullStreams): Promise<void> {
+  if (proc.exitCode !== null || proc.signalCode !== null) return;
+  proc.kill();
+  await Promise.race([
+    new Promise<void>((resolve) => proc.once("exit", () => resolve())),
+    sleep(2_000),
+  ]);
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -247,7 +277,9 @@ async function resolveWebView2DriverVersion(): Promise<string | undefined> {
   return undefined;
 }
 
-async function spawnTauriDriver(): Promise<ChildProcessWithoutNullStreams> {
+async function spawnTauriDriver(
+  webviewDataDirName: string,
+): Promise<ChildProcessWithoutNullStreams> {
   const tauriDriverPath = getTauriDriverPath();
   if (!(await fileExists(tauriDriverPath))) {
     throw new Error(
@@ -269,7 +301,11 @@ async function spawnTauriDriver(): Promise<ChildProcessWithoutNullStreams> {
   // 「WebView2 TrySuspend / Resume パターン」節の SNOTRA_DISABLE_SUSPEND の項）。
   const proc = spawn(tauriDriverPath, ["--native-driver", nativeDriverPath], {
     stdio: "pipe",
-    env: { ...process.env, SNOTRA_DISABLE_SUSPEND: "1" },
+    env: {
+      ...process.env,
+      SNOTRA_DISABLE_SUSPEND: "1",
+      [E2E_WEBVIEW_DATA_DIR_ENV]: webviewDataDirName,
+    },
   });
   proc.on("error", () => {
     // handled by port timeout / session creation errors
@@ -278,7 +314,7 @@ async function spawnTauriDriver(): Promise<ChildProcessWithoutNullStreams> {
   return proc;
 }
 
-async function createWebDriverSession(): Promise<WebDriver> {
+async function createWebDriverSession(webviewDataDir: string): Promise<WebDriver> {
   const appBinary = getAppBinaryPath();
   if (!(await fileExists(appBinary))) {
     throw new Error(`App binary not found at ${appBinary}. ${E2E_BUILD_HINT}`);
@@ -290,6 +326,9 @@ async function createWebDriverSession(): Promise<WebDriver> {
       browserName: "wry",
       "tauri:options": {
         application: appBinary,
+        webviewOptions: {
+          userDataFolder: webviewDataDir,
+        },
       },
     })
     .build();
@@ -438,11 +477,13 @@ async function runInstantCommand(
 async function createHarness(): Promise<Harness> {
   const fixtureDir = await setupFixtureDir();
   const backup = await prepareE2EConfig(fixtureDir);
+  const webviewData = createE2EWebViewDataDir();
   let tauriDriver: ChildProcessWithoutNullStreams | undefined;
   let driver: WebDriver | undefined;
   try {
-    tauriDriver = await spawnTauriDriver();
-    driver = await createWebDriverSession();
+    await mkdir(webviewData.path, { recursive: true });
+    tauriDriver = await spawnTauriDriver(webviewData.name);
+    driver = await createWebDriverSession(webviewData.path);
     await waitAndSwitchToLabel(driver, "main", 12_000);
     try {
       await driver.wait(until.elementLocated(By.css(".search-input")), 12_000);
@@ -467,26 +508,32 @@ async function createHarness(): Promise<Harness> {
         `search-input not found.${buildHint} states=${JSON.stringify(states)} snapshots=${JSON.stringify(snapshots)} cause=${String(e)}`,
       );
     }
-    return { driver, tauriDriver, backup, fixtureDir };
+    return {
+      driver,
+      tauriDriver,
+      backup,
+      fixtureDir,
+      webviewDataDir: webviewData.path,
+    };
   } catch (e) {
     if (driver) {
       await driver.quit().catch(() => {});
     }
-    if (tauriDriver && !tauriDriver.killed) {
-      tauriDriver.kill();
+    if (tauriDriver) {
+      await stopTauriDriver(tauriDriver);
     }
     await restoreConfig(backup).catch(() => {});
+    await removeE2EWebViewDataDir(webviewData.path).catch(() => {});
     throw e;
   }
 }
 
 async function disposeHarness(harness: Harness): Promise<void> {
   await harness.driver.quit().catch(() => {});
-  if (!harness.tauriDriver.killed) {
-    harness.tauriDriver.kill();
-  }
+  await stopTauriDriver(harness.tauriDriver);
   await restoreConfig(harness.backup);
   await rm(harness.fixtureDir, { recursive: true, force: true }).catch(() => {});
+  await removeE2EWebViewDataDir(harness.webviewDataDir);
 }
 
 const test = base.extend<{ harness: Harness }>({

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean:worktrees": "node scripts/clean-worktrees.mjs",
     "smoke:startup": "pwsh -NoProfile -File scripts/smoke-startup.ps1",
     "prepare:sidecar": "pwsh -NoProfile -File scripts/prepare-sidecar.ps1 -Release",
-    "e2e:tauri:setup": "cargo install tauri-driver --locked && npm run prepare:sidecar && npx tauri build --no-bundle",
+    "e2e:tauri:setup": "cargo install tauri-driver --locked && npm run prepare:sidecar && npx tauri build --no-bundle --features e2e-webview-automation",
     "e2e:tauri": "playwright test -c playwright.tauri.config.ts",
     "typecheck": "tsc",
     "prebuild": "npm run typecheck",

--- a/src-tauri/CLAUDE.md
+++ b/src-tauri/CLAUDE.md
@@ -88,6 +88,7 @@ NOTIFYICON_VERSION_4 では、キーボード操作（Shift+F10 / Application �
 - **`with_webview()` は呼び出しスレッドによらずクロージャがメインスレッドで実行される**: setup フェーズでは同期的に完了するが、それ以外（IPC ハンドラ / `std::thread::spawn` / イベント listener）では非同期ディスパッチとして扱うこと。順序が要る箇所はクロージャの FIFO 直列化（同一キュー）に依拠する
 - **TrySuspend と MemoryUsageTargetLevel は混用禁止**: TrySuspend が自動で MemoryUsageTargetLevel を Low に設定し、Resume が Normal に戻す
 - **`SNOTRA_DISABLE_SUSPEND=1` で suspend を無効化できる（E2E 専用エスケープハッチ）**: WebDriver は非表示中のレンダラーへの `executeScript` で可視性判定・入力を行うため、suspend されたレンダラーとは原理的に非互換（script が応答せずタイムアウト）。E2E ハーネス（`e2e/tauri.slash.e2e.ts` の `spawnTauriDriver`）がこの変数を立てて起動する。`EmptyWorkingSet` trim は無効化されない
+- **WebView2 150+ の High IL E2E はアプリ API から remote debugging を有効化する**: WebView2 150 は elevated host でユーザー書き換え可能な `WEBVIEW2_*` 環境変数と HKCU policy のブラウザ引数を無視するため、msedgedriver が通常使う経路では `DevToolsActivePort` が生成されない。`e2e-webview-automation` Cargo feature を有効にしたテスト専用バイナリだけが、`SNOTRA_E2E_WEBVIEW_DATA_DIR`（単一の相対ディレクトリ名）がある起動で `CoreWebView2EnvironmentOptions.AdditionalBrowserArguments` に `--remote-debugging-port=0` を直接設定する。通常ビルドには feature が無く、feature 付きでも環境変数のない startup smoke は現行設定のまま。E2E ハーネスは同じディレクトリを `webviewOptions.userDataFolder` に渡し、app/driver 終了後に削除する
 
 ## WebView2 working set の能動回収（EmptyWorkingSet）
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,6 +3,9 @@ name = "snotra"
 version.workspace = true
 edition = "2024"
 
+[features]
+e2e-webview-automation = []
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -31,6 +31,48 @@ use crate::state::AppState;
 const ALT_RELEASE_POLL_MS: u64 = 10;
 const ALT_RELEASE_TIMEOUT_MS: u64 = 350;
 
+#[cfg(any(test, feature = "e2e-webview-automation"))]
+const E2E_WEBVIEW_DATA_DIR_ENV: &str = "SNOTRA_E2E_WEBVIEW_DATA_DIR";
+#[cfg(any(test, feature = "e2e-webview-automation"))]
+const E2E_WEBVIEW_BROWSER_ARGS: &str = concat!(
+    "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection ",
+    "--remote-debugging-port=0"
+);
+
+/// Configure the test-only WebView2 environment through the trusted application API.
+///
+/// WebView2 150 ignores user-writable `WEBVIEW2_*` channels for elevated hosts, so
+/// msedgedriver cannot supply its remote-debugging port that way. The Cargo feature
+/// keeps this escape hatch out of production builds; the environment value only
+/// selects a per-session relative data directory in the feature-enabled E2E binary.
+#[cfg(any(test, feature = "e2e-webview-automation"))]
+fn configure_e2e_webview(
+    windows: &mut [tauri::utils::config::WindowConfig],
+    data_dir: Option<&std::ffi::OsStr>,
+) -> Result<bool, String> {
+    use std::path::{Component, Path};
+
+    let Some(data_dir) = data_dir else {
+        return Ok(false);
+    };
+    let data_dir = Path::new(data_dir);
+    let mut components = data_dir.components();
+    if !matches!(components.next(), Some(Component::Normal(_))) || components.next().is_some() {
+        return Err(format!(
+            "{E2E_WEBVIEW_DATA_DIR_ENV} must be one relative path component, got {}",
+            data_dir.display()
+        ));
+    }
+
+    let main = windows
+        .iter_mut()
+        .find(|window| window.label == "main")
+        .ok_or_else(|| "E2E WebView configuration requires the main window".to_string())?;
+    main.additional_browser_args = Some(E2E_WEBVIEW_BROWSER_ARGS.to_string());
+    main.data_directory = Some(data_dir.to_path_buf());
+    Ok(true)
+}
+
 /// Thin wrapper kept so call sites read `trace_main(...)`; logic lives in the
 /// shared `crate::trace` module (deduped with `commands::trace_command`, #433).
 fn trace_main(event: &str, data: serde_json::Value) {
@@ -519,6 +561,19 @@ fn main() {
         main_visible: AtomicBool::new(false),
     };
 
+    let app_context = tauri::generate_context!();
+    #[cfg(feature = "e2e-webview-automation")]
+    let app_context = {
+        let mut app_context = app_context;
+        let data_dir = std::env::var_os(E2E_WEBVIEW_DATA_DIR_ENV);
+        configure_e2e_webview(
+            &mut app_context.config_mut().app.windows,
+            data_dir.as_deref(),
+        )
+        .expect("invalid E2E WebView configuration");
+        app_context
+    };
+
     let ime_off_for_si = ime_off;
     tauri::Builder::default()
         .plugin(tauri_plugin_updater::Builder::new().build())
@@ -608,7 +663,7 @@ fn main() {
 
             Ok(())
         })
-        .run(tauri::generate_context!())
+        .run(app_context)
         .expect("error while running tauri application");
 }
 
@@ -866,5 +921,60 @@ fn setup_tray(app_handle: &AppHandle, show_tray: bool, load_outcome: LoadOutcome
 fn setup_startup_display(app_handle: &AppHandle, show_on_startup: bool, ime_off: bool) {
     if show_on_startup {
         show_main_and_emit(app_handle, ime_off);
+    }
+}
+
+#[cfg(test)]
+mod e2e_webview_config_tests {
+    use std::ffi::OsStr;
+
+    use super::{E2E_WEBVIEW_BROWSER_ARGS, configure_e2e_webview};
+    use tauri::utils::config::WindowConfig;
+
+    fn main_window() -> WindowConfig {
+        WindowConfig {
+            label: "main".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn e2e_webview_config_sets_trusted_arguments_and_isolated_data_directory() {
+        let mut windows = [main_window()];
+
+        let configured =
+            configure_e2e_webview(&mut windows, Some(OsStr::new("snotra-e2e-session-1"))).unwrap();
+
+        assert!(configured);
+        assert_eq!(
+            windows[0].additional_browser_args.as_deref(),
+            Some(E2E_WEBVIEW_BROWSER_ARGS)
+        );
+        assert_eq!(
+            windows[0].data_directory.as_deref(),
+            Some(std::path::Path::new("snotra-e2e-session-1"))
+        );
+    }
+
+    #[test]
+    fn e2e_webview_config_without_session_directory_preserves_production_defaults() {
+        let mut windows = [main_window()];
+
+        let configured = configure_e2e_webview(&mut windows, None).unwrap();
+
+        assert!(!configured);
+        assert!(windows[0].additional_browser_args.is_none());
+        assert!(windows[0].data_directory.is_none());
+    }
+
+    #[test]
+    fn e2e_webview_config_rejects_unsafe_session_directories() {
+        for invalid in ["", "..", "../shared", "nested/session", r"C:\absolute"] {
+            let mut windows = [main_window()];
+            assert!(
+                configure_e2e_webview(&mut windows, Some(OsStr::new(invalid))).is_err(),
+                "{invalid} must be rejected"
+            );
+        }
     }
 }


### PR DESCRIPTION
## 対応Issue

- Refs #555（原因訂正・検証結果をコメント済み、Issue は完了としてクローズ済み）

## 変更内容

- E2E 専用 Cargo feature `e2e-webview-automation` を追加
- High IL でも有効な Wry/WebView2 アプリ API 経由で `--remote-debugging-port=0` を設定
- アプリと msedgedriver が同一のセッション隔離 user-data folder を使用するよう E2E ハーネスを変更
- 正常終了・異常終了の両経路で driver と一時 data directory をクリーンアップ
- E2E ビルド手順、`src-tauri` の不変条件、振り返りを更新

## 根本原因

WebView2 150 は、High IL ホストでユーザーが書き換え可能な `WEBVIEW2_*` 環境変数と HKCU policy の browser arguments をセキュリティ上の理由で無視します。従来設定していた `tauri:options.webviewOptions.additionalBrowserArguments` は msedgedriver capability に留まり、アプリ生成時の `CoreWebView2EnvironmentOptions.AdditionalBrowserArguments` へ届いていなかったため、`DevToolsActivePort file doesn't exist` でセッション生成に失敗していました。

通常ビルドでは user-writable な経路から browser argument を有効化せず、E2E 専用 Cargo feature とセッション環境変数が揃った場合だけ trusted app API を使用します。

## 検証

- `cargo test -p snotra` — 73 passed
- `cargo check --workspace`
- `cargo check -p snotra --features e2e-webview-automation`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p snotra --all-targets --features e2e-webview-automation -- -D warnings`
- `npm run typecheck`
- `npm run build`
- `npm test` — 22 files / 424 tests passed
- ローカル `npm run e2e:tauri` — 16/16 passed（2回）
- GitHub Actions `E2E & Smoke` run 29624546469 — startup smoke 5/5、E2E 16/16 passed

CI: https://github.com/finelagusaz/Snotra/actions/runs/29624546469

## 補足

`cargo fmt --check` は今回未変更の既存ファイルにも大量の差分を要求するため一括適用していません。変更差分は `git diff --check` で検証済みです。