### PR TITLE
test(ci): e2e-webview-automation feature の配線を rust-check で被覆

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,13 @@ jobs:
       - name: cargo clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+      # #568: feature 限定の main() 配線（configure_e2e_webview の呼び出し）は
+      # 既定 feature の check/clippy/test では cfg で除外され compile されない
+      # （唯一 compile するのは e2e.yml の feature 付き tauri build）。feature 付き
+      # clippy で compile + lint 被覆し、配線の破損を高速検査で loud に落とす。
+      - name: cargo clippy (e2e-webview-automation feature)
+        run: cargo clippy -p snotra --features e2e-webview-automation --all-targets -- -D warnings
+
       # #509: main 保護 Layer 1（.githooks）と PreToolUse/PostToolUse フック
       # （.claude/hooks）の selftest は、実運用が Windows でのみ起きる安全網。
       # ubuntu の frontend-check と相補的に、Windows 固有の hook 実行機構


### PR DESCRIPTION
## 概要

`e2e-webview-automation` feature 限定の `main()` 配線を CI の高速検査（`rust-check`）へ載せ、compile + lint 被覆する。PR #564 のレビューで判明した被覆ギャップ（#568）の解消。

## 背景

`configure_e2e_webview` の**呼び出し側**は `#[cfg(feature = "e2e-webview-automation")]` ゲートのため、既定 feature の検査（`cargo check --workspace` / `cargo clippy --workspace` / `cargo test -p snotra` / PostToolUse hook）では cfg 除外され compile されない。関数本体は `#[cfg(any(test, feature))]` で test cfg 経由の被覆があるが、feature 限定の配線ブロックは唯一 `e2e.yml` の `tauri build --features` でしか compile されず、clippy はどこでも走っていなかった。将来この配線を壊しても高速検査は沈黙（緑）し、30 分の E2E ビルドまで露見しない false-green の形。

## 変更

`rust-check` ジョブへ一段追加（既存 clippy ステップの直後）:

```
cargo clippy -p snotra --features e2e-webview-automation --all-targets -- -D warnings
```

## 検証（故障注入）

`safety-nets.md`「効いていることは故障注入で一度は実測する」に従い、呼び出し側の関数名を一時的に壊して弁別を実測（実測後に revert・稼働中ガードは弱めていない）:

| チェック | 結果 |
|---|---|
| 新ステップ（feature 付き clippy） | `E0425` で **FAIL**（exit 101）— 破損を捕捉 |
| 既存 `cargo clippy --workspace`（feature 無） | **PASS**（exit 0）— cfg 除外で素通り |

現行コードでは feature ブロックに潜在 clippy 警告なし（初回被覆でクリーン、exit 0）。

## スコープ外

#568 参考欄の 2 nit（`stopTauriDriver` の unref されないタイマー / `C:\absolute` テストの非ポータブル性）は実害なしのため対応しない。

Closes #568
