### PR TITLE
docs(start-issue): 外部ソース根拠の原因説明に最終 maintainer 回答までの確認を追加

### DIFF
--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -70,6 +70,8 @@ git checkout -b <branch-name>
 
 **列挙の事実確認**: 「関連コード」に挙げたファイル・関数が実在し、説明が正確かを grep で確認してから Step 4 へ進む。研究の前提誤りは plan へ伝播する——`/plan-review` Step 2b の独立再導出が伝播後に拾うが、前提はここで正すのが最も安い。
 
+**外部ソースが根拠のときの追加確認**（外部 issue・上流バグ・外部仕様を根本原因の根拠にする場合のみ発火。使わない issue では不要）: issue 本文冒頭の説明を確定事実とせず、timeline を**最終 maintainer 回答**まで辿って現在の結論（fixed / reverted / 未修正）を掴んでから前提として扱う。上流の記述とローカル実装（使用中バージョン・設定者→中間層→実 consumer の実行経路）が食い違うときは、どちらを採用したかを理由付きで `research.md` に記す。上の実在確認が内部前提を、`/plan-review` Step 2b がコードベースを覆うのに対し、**外部の事実だけはどの下流検査も再導出できない**——ここで正さなければ後段で拾えない（#565。内部前提=能力・根本原因診断の裏取りは `docs/development-principles.md`「デバッグ・バグ修正」節）。
+
 ## Step 4 — 実装計画（workspace/plan.md）
 
 `workspace/research.md` の分析結果をもとに、`workspace/plan.md` に実装計画を作成する。


### PR DESCRIPTION
## 概要

`start-issue` Step 3 の「列挙の事実確認」段落に、**外部 issue・上流バグ・外部仕様を根本原因の根拠にする場合のみ発火**する追加確認を足す。#565 の実装。

## 背景

#555 の調査で、上流 WebView2Feedback issue の初期説明を一度は根本原因として扱いかけた。実際は最終 maintainer コメントが別の仕様を説明しており、最終回答まで読み直して是正できた。この「外部ソースの初期説明は後の maintainer コメントで覆されうる」という一点は、既存の三重の網（Step 3 実在確認 / development-principles.md #409 / memory）がどれも視界をコードに閉じているため拾えなかった。下流の `/plan-review` Step 2b もコードベースに対して再導出するため、外部の事実は原理的に再導出できない。

## 変更点

- `.claude/skills/start-issue/SKILL.md` Step 3: 外部ソース根拠のときのみ発火する条件付き追加確認を1段落追加
  - timeline を最終 maintainer 回答まで辿り現在の結論（fixed / reverted / 未修正）を掴む
  - 上流とローカル実装（使用中バージョン・実行経路）の食い違いは採否を理由付きで `research.md` に記す
  - 外部情報を使わない通常 issue では発火しない

## 受け入れ条件（#565）

- [x] Step 3 に外部ソース根拠のときのみ発火する一文が入っている
- [x] 内部前提向けの既存記述（Step 3 実在確認・development-principles.md）と重複していない
- [x] 外部情報を使わない通常 Issue に追加負荷が掛からない（条件付き発火）

## 検証

`.claude/skills/**` は skip-safe（CI テスト対象外）のため skip-ci を付与。挙動変更なし・skill 指示の追加のみ。棲み分け: 内部前提=development-principles.md、外部前提=本 PR、選択肢空間=#409 の三層で重複なし。

Closes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)
