### PR TITLE
fix: 起動時 bootstrap が先着 config 変更 event を上書きする race を塞ぐ (#578)

### DIFF
--- a/ui/src/MainApp.test.tsx
+++ b/ui/src/MainApp.test.tsx
@@ -305,3 +305,67 @@ describe("MainApp auto_hide_on_focus_lost（#576: 常時リスニング + シグ
     }
   });
 });
+
+describe("MainApp 起動ハイドレーションガード（#578: bootstrap は先着 event を上書きしない）", () => {
+  // bootstrap を deferred にして onMount を await getBootstrapPayload で停止させ、
+  // その隙に config 変更 event を先着させてから stale な bootstrap を解決する。
+  // ハイドレーションガードが無いと bootstrap が event 値を上書きしてしまう（RED）。
+  function deferBootstrap(): (payload: BootstrapPayload) => void {
+    let resolve!: (payload: BootstrapPayload) => void;
+    mockGetBootstrapPayload.mockReturnValue(
+      new Promise<BootstrapPayload>((r) => {
+        resolve = r;
+      }),
+    );
+    return resolve;
+  }
+
+  it("show_icons: bootstrap 解決前に来た event 値が保持される（bootstrap が轢かない）", async () => {
+    const resolveBootstrap = deferBootstrap(); // BOOTSTRAP.show_icons = true
+    render(() => <MainApp />);
+    await tick(); // listener 登録まで進み bootstrap await で停止
+
+    // より新しい event（show_icons=false）が bootstrap 解決前に到着
+    listenHandlers["show-icons-changed"]({ payload: false });
+    expect(capturedProps!.showIcons).toBe(false);
+
+    // 起動時に読んだ stale な bootstrap（show_icons=true）が後から解決
+    resolveBootstrap(BOOTSTRAP);
+    await tick();
+    await tick();
+
+    expect(capturedProps!.showIcons).toBe(false);
+  });
+
+  it("visible_rows: bootstrap 解決前に来た event 値が保持される（bootstrap が轢かない）", async () => {
+    const resolveBootstrap = deferBootstrap(); // BOOTSTRAP.visible_rows = 8
+    render(() => <MainApp />);
+    await tick();
+
+    listenHandlers["max-results-changed"]({ payload: 3 });
+    expect(capturedProps!.maxResults).toBe(3);
+
+    resolveBootstrap(BOOTSTRAP);
+    await tick();
+    await tick();
+
+    expect(capturedProps!.maxResults).toBe(3);
+  });
+
+  it("event 未着なら bootstrap 値が通常どおり適用される（ガードの副作用なし）", async () => {
+    const resolveBootstrap = deferBootstrap();
+    render(() => <MainApp />);
+    await tick();
+
+    // event を発火せずに bootstrap を解決
+    resolveBootstrap({
+      ...BOOTSTRAP,
+      appearance: { show_icons: false, visible_rows: 5 },
+    });
+    await tick();
+    await tick();
+
+    expect(capturedProps!.showIcons).toBe(false);
+    expect(capturedProps!.maxResults).toBe(5);
+  });
+});

--- a/ui/src/MainApp.tsx
+++ b/ui/src/MainApp.tsx
@@ -166,31 +166,60 @@ const MainApp: Component = () => {
       console.warn("auto-hide focus listener registration failed:", e);
     }
 
+    // 起動ハイドレーションガード（#578）。config 変更 event（購読済み）と bootstrap
+    // （後から解決する起動時スナップショット）は同じ signal を書く二重の書き手だが、
+    // bootstrap には世代刻印が無く「どちらが新しいか」を判別できない。snapshot 撮影〜
+    // bootstrap 適用の窓（IPC 境界をまたぐため JS 側でアトミック化できない）に config が
+    // 外部変更されると、後着の stale な bootstrap が先着 event 値を轢きうる。
+    // このガードは「起動中に一度でも event が来たキーは bootstrap より勝つ」という
+    // 初期化専用の調停で、一般の順序保証ではない（純粋な順序解が無いことの受容として
+    // この窓だけを塞ぐ）。受容残余は 2 つ: (1) 1 変更が複数の per-field event を撒くため
+    // 生じるフィールド間の一瞬の世代混在、(2) 起動窓で同一フィールドが二度変わり
+    // e(A)→bootstrap が新しい B を解決→e(B) と届く場合、guard が B を skip して A を
+    // 一瞬見せる（次 event で自己修復。単一変更が支配的なため net では改善）。
+    type ConfigField =
+      | "language"
+      | "visual"
+      | "visible_rows"
+      | "show_icons"
+      | "instant_command_prefix"
+      | "result_limit"
+      | "auto_hide_on_focus_lost";
+    const eventWon = new Set<ConfigField>();
+    const applyBootstrap = (field: ConfigField, apply: () => void) => {
+      if (!eventWon.has(field)) apply();
+    };
+
     // Listen for auto_hide_on_focus_lost config changes (#576)
     const unlistenAutoHideConfig = await listen<boolean>("auto-hide-focus-lost-changed", (event) => {
+      eventWon.add("auto_hide_on_focus_lost");
       setAutoHideOnFocusLost(event.payload);
     });
     unlistenFns.push(unlistenAutoHideConfig);
 
     // Listen for visual config changes
     const unlistenVisual = await listen<VisualConfig>("visual-config-changed", (event) => {
+      eventWon.add("visual");
       applyTheme(event.payload);
     });
     unlistenFns.push(unlistenVisual);
 
     // Listen for visible_rows config changes (event name kept as "max-results-changed" for IPC stability, #388)
     const unlistenMaxResults = await listen<number>("max-results-changed", (event) => {
+      eventWon.add("visible_rows");
       setMaxResults(event.payload);
     });
     unlistenFns.push(unlistenMaxResults);
 
     // Listen for show_icons config changes
     const unlistenShowIcons = await listen<boolean>("show-icons-changed", (event) => {
+      eventWon.add("show_icons");
       setShowIcons(event.payload);
     });
     unlistenFns.push(unlistenShowIcons);
 
-    // Listen for hotkey registration failure (config change case)
+    // Listen for hotkey registration failure (config change case).
+    // 一時通知であって config 値 signal ではないため、ハイドレーションガードの対象外。
     const unlistenHotkeyFailed = await listen<string>("hotkey-registration-failed", (event) => {
       setHotkeyFailureNotice(t("notice.hotkey.change_failed", { hotkey: event.payload }));
     });
@@ -198,18 +227,21 @@ const MainApp: Component = () => {
 
     // Listen for language changes
     const unlistenLang = await listen<string>("language-changed", (event) => {
+      eventWon.add("language");
       setLanguage(event.payload as Lang);
     });
     unlistenFns.push(unlistenLang);
 
     // Listen for instant command prefix changes
     const unlistenInstantPrefix = await listen<string>("instant-prefix-changed", (event) => {
+      eventWon.add("instant_command_prefix");
       setInstantCommandPrefix(event.payload);
     });
     unlistenFns.push(unlistenInstantPrefix);
 
     // Listen for result_limit changes (event name kept as "top-n-history-changed" for IPC stability, #388)
     const unlistenTopN = await listen<number>("top-n-history-changed", (event) => {
+      eventWon.add("result_limit");
       setIconCacheSize(event.payload);
     });
     unlistenFns.push(unlistenTopN);
@@ -218,16 +250,21 @@ const MainApp: Component = () => {
     let bootstrap: BootstrapPayload | null = null;
     try {
       bootstrap = await api.getBootstrapPayload();
-      setLanguage(bootstrap.language as Lang);
-      applyTheme(bootstrap.visual);
-      setMaxResults(bootstrap.appearance.visible_rows);
-      setShowIcons(bootstrap.appearance.show_icons);
-      setInstantCommandPrefix(bootstrap.instant_command_prefix);
-      setIconCacheSize(bootstrap.result_limit);
+      // 各適用は applyBootstrap 経由（#578）。await 中に config 変更 event が先着した
+      // キーは skip し、event の新しい値を stale な bootstrap で轢かない。
+      const b = bootstrap;
+      applyBootstrap("language", () => setLanguage(b.language as Lang));
+      applyBootstrap("visual", () => applyTheme(b.visual));
+      applyBootstrap("visible_rows", () => setMaxResults(b.appearance.visible_rows));
+      applyBootstrap("show_icons", () => setShowIcons(b.appearance.show_icons));
+      applyBootstrap("instant_command_prefix", () => setInstantCommandPrefix(b.instant_command_prefix));
+      applyBootstrap("result_limit", () => setIconCacheSize(b.result_limit));
       // フォーカス喪失時自動非表示の初期値（#576）。以後の変更は
       // "auto-hide-focus-lost-changed" イベントが追従する。bootstrap 失敗時は
       // 既定 false のままとし、非表示を走らせない。
-      setAutoHideOnFocusLost(bootstrap.general.auto_hide_on_focus_lost);
+      applyBootstrap("auto_hide_on_focus_lost", () =>
+        setAutoHideOnFocusLost(b.general.auto_hide_on_focus_lost),
+      );
     } catch (e) {
       console.error("Failed to load bootstrap payload:", e);
     }


### PR DESCRIPTION
## 対応Issue
- Closes #578

## 変更内容

`MainApp.tsx` の `onMount` は config 変更 event を購読後、後から解決する `getBootstrapPayload()` スナップショットを無条件で signal に代入していた。snapshot 撮影〜適用の窓（IPC 境界をまたぐため JS 側でアトミック化不可）に config が外部変更されると、後着の stale な bootstrap が先着 event 値を轢きうる（全 config signal 横断のレース）。

### 修正: 起動ハイドレーションガード
- `eventWon: Set<ConfigField>` + `applyBootstrap(field, apply)` helper を追加
- 7 config 項目の listener が先頭で該当キーを刻み、bootstrap 適用は全て helper 経由に統一
- 「起動中に一度でも event が来たキーは bootstrap より勝つ」初期化専用の調停（一般の順序保証ではない）
- `hotkey-registration-failed` は値 signal でなく一時通知のため対象外
- bootstrap 失敗時は helper 未到達で既定値維持（挙動不変）

### 設計判断
- 案1（購読/適用の順序入替）は race が IPC 境界をまたぐため原理的に無効で、むしろ脆弱窓が広がりうる（advisor / Codex 非対話モードと相互確認）——不採用
- 案3（Rust 側 config 世代機構）は自己修復する極稀レースに過剰——不採用
- 案2 を helper 1 個に畳む形（本 PR）を採用

### テスト（`MainApp.test.tsx`・3 件追加）
- bootstrap を deferred にして onMount を `await` で停止させ、その隙に config 変更 event を先着させてから stale bootstrap を解決する race を `show_icons` / `visible_rows` で再現（ガード無しでは RED を実測）
- 不変条件: 「先着 event 値が bootstrap に轢かれない」＋「event 未着なら bootstrap が通常どおり適用される（ガードの副作用なし）」

### 検証
- `npm run typecheck` クリーン / ui 全 269 件緑
- `/simplify`（reuse・simplification・efficiency・altitude の 4 レンズ）通過・無変更

### 関連
- #576（`auto_hide_on_focus_lost` を既存パターンに整合させて追加した際に検出。本 issue の対象に含む）
- イベント名 `max-results-changed` / `top-n-history-changed` は IPC 安定のため旧名を維持（#388）
