### PR TITLE
refactor(core): incremental search キャッシュ状態を IncrementalCache 型へ集約 (#601)

### DIFF
--- a/.claude/rules/snotra-core-search.md
+++ b/.claude/rules/snotra-core-search.md
@@ -10,14 +10,14 @@ paths:
 ## 読む正準
 
 - 責務・スコア階層・全順序の強制: `search.rs` の `//!`、`SearchEngine` の struct doc、`mod score_tier` の doc（直後の `const _` 全順序アサーション含む。位置は下の注記参照）
-- incremental 述語と `prev_*` の規律: `decide_incremental` / `score_one_entry` / `heap_into_results` の doc と `search_with_options` 本体のコメント
+- incremental 述語と前回状態の規律: `IncrementalCache`（`can_reuse` の read / `update` の write を対に持つ・#601）・`score_one_entry` / `heap_into_results` の doc と `search_with_options` 本体のコメント
 
 > **位置はファイル名で断定せず、シンボル名で grep して現在地を確認する。** search.rs は責務単位で `search/{build,query_plan,scoring}.rs` へ分割済み（#598〜#600）で、上記シンボルは移動しうる（例: `mod score_tier` / `score_one_entry` / `heap_into_results` は `search/scoring.rs`、`compute_wave1/2` は `search/build.rs`、`prepare_query_plan` は `search/query_plan.rs`）。名前参照は refactor を生き延びるが、`<file> の X` という位置断定は腐る（#600 実測）。
 - 横断不変条件（並列 Vec レイアウト・ビットマスク一元化・has_path_sep 非互換）: `snotra-core/CLAUDE.md` の search.rs 節・「文字ビットマスク」節・「incremental cache とパスクエリの非互換」節
 
 ## 引き金 → 検査
 
-- **incremental・キャッシュ再利用・`prev_*`・`has_dot`/`has_path_sep` に触れたら**: 正準（`decide_incremental` の doc）を読み、`/cache-check` で単調性を検証する
+- **incremental・キャッシュ再利用・前回状態（`IncrementalCache`）・`has_dot`/`has_path_sep` に触れたら**: 正準（`IncrementalCache::can_reuse` の doc）を読み、`/cache-check` で単調性を検証する。述語や状態を足すときは `can_reuse`（read）と `update`（write）を対で変更する
 - **新しいマッチ種別を追加するなら**: bitmask pre-filter との整合を `compute_wave2` の doc（false-negative 不変条件）で確認する
 - **Wave 1/2・kana 構築に触れたら**: `compute_wave1` / `new_with_cached_masks` の doc（#337）を読む
 - **`Ord` / `BinaryHeap` / top-k に触れたら**: `snotra-core/CLAUDE.md` 実装前チェックの規律（先頭が最良/最悪の明記・入力順不変テスト）に従う

--- a/snotra-core/CLAUDE.md
+++ b/snotra-core/CLAUDE.md
@@ -63,7 +63,7 @@
   - `kana_lower_names[i]` / `kana_char_masks[i]` へアクセスする全箇所は `is_empty()` ガードを通す（`kana_char_masks` は `kana_lower_names` から `compute_kana_char_masks` で導出し、3 コンストラクタ全経路で `assemble` 直前に構築する）
   - 条件分岐は `compute_wave1(.., migemo_enabled)` と `new_with_cached_masks` の v4/v3 両パスに**同時に**入れる（片方だけだと migemo ON でも空になる）
   - migemo は index 構築入力なので、engine の `IndexInputs`（`config_watcher` の kick 判定と `complete_index_drain` の re-diff が共有する**単一定義**）に含める（#347 Phase 2 で `needs_reindex` / in-flight `needs_rebuild` を `IndexInputs` に統合・削除済み）
-- `search.rs` の incremental search キャッシュ（`prev_*` フィールド群）に新しい述語を追加するとき: `use_incremental` の条件式と `prev_*` の更新箇所を同時に変更し、`/cache-check` で単調性を検証する
+- incremental search キャッシュに述語や状態を追加するとき: 状態は `IncrementalCache` 型に集約済み（#601。`prev_query` / `prev_candidates` / `prev_mode` / `prev_kana_query`）。read（`can_reuse`）と write（`update`）を**対で**変更し、`/cache-check` で単調性を検証する。read が参照する全フィールドを `update` が書くこと（型に閉じたので対称更新漏れは起きにくいが、フィールド追加時は両メソッドを同時に触る）
 - `query.rs` の正規化を変更する場合は、タブ・全角スペース・NBSP を `' '` に統一するテストと冪等性テストを追加または更新する
 - `folder.rs` のソート順変更時: ソート順は「`is_folder` 降順 → `exp_count` 降順 → `lower_name` 昇順」で、先頭要素が最良（最優先）。`select_nth_unstable_by`（O(N) 平均の top-k 選択）＋ `sort_by`（安定ソートで確定順）の2段階を崩さない。入力順に依存しないことを確認するテスト（`score_entries_top_k_order_independent_of_input_order`）を通す
 

--- a/snotra-core/src/search.rs
+++ b/snotra-core/src/search.rs
@@ -130,18 +130,78 @@ pub struct SearchEngine {
     /// kana_lower_names 用の損失あり文字存在マスク。migemo 有効時のみ構築し、kana
     /// pre-filter の false positive は許すが false negative は起こさない。
     kana_char_masks: Vec<u64>,
-    /// Incremental search cache: normalized query string from the previous call.
+    /// incremental search の再利用状態（前回クエリ・候補・mode・kana query）。
+    /// read（再利用判定）と write（検索後更新）を [`IncrementalCache`] のメソッドに閉じ、
+    /// 述語や状態を足したときの read/write 対称更新漏れを防ぐ（#601）。
+    incremental_cache: IncrementalCache,
+}
+
+/// incremental search（前回候補の再利用）の状態を集約する private 型（#601）。
+/// ホットパスの並列 `Vec` とは別の小さな状態であり、専用型に閉じても cache locality は不変。
+/// 再利用判定（read）と検索完了後の状態更新（write）を対にしてメソッド化し、述語追加時の
+/// 対称更新漏れを型で防ぐ。全 4 フィールドは `Default`（空 query / 空候補 / mode 未設定 /
+/// kana なし）で初期化し、初回検索は必ず full scan になる。
+#[derive(Default)]
+struct IncrementalCache {
+    /// 正規化済み前回クエリ。
     prev_query: String,
-    /// Incremental search cache: entry indices that matched on the previous call,
-    /// stored BEFORE truncation to `max_results` so every match is captured.
+    /// 前回一致した entry index 群。`max_results` truncation の**前**に全件保存する
+    /// （top-k から落ちた一致も次回の再利用候補に残し、候補集合の縮小を防ぐ）。
     prev_candidates: Vec<usize>,
-    /// Incremental search cache: search mode of the previous call.
+    /// 前回の SearchMode。
     prev_mode: Option<SearchMode>,
-    /// Incremental search cache: 前回の kana_query 文字列。
-    /// incremental を使えるのは今回の kana_query が前回の prefix 拡張のときだけ。
-    /// ローマ字→かな変換は文字列伸長に対して非単調（"kan"→"かん", "kana"→"かな"）なため、
-    /// bool フラグでは不十分で、実際の kana 文字列を比較する必要がある。
+    /// 前回の kana_query 文字列。ローマ字→かな変換は非単調（"kan"→"かん", "kana"→"かな"）
+    /// なため bool では不十分で、実値の prefix 比較が要る。
     prev_kana_query: Option<String>,
+}
+
+impl IncrementalCache {
+    /// incremental search（前回候補の再利用）の可否を判定する（read のみ）。
+    ///
+    /// 全述語は「今回の候補集合 ⊆ 前回の候補集合」を保証する単調条件。
+    ///
+    /// - `!has_dot || prev_query.contains('.')`: "no-dot → dot" 遷移は full scan にフォールバック。
+    ///   prev_candidates が file_name スコアリングなしで構築されており、file_name のみで
+    ///   マッチするエントリが欠落して false negative になるのを防ぐ。
+    /// - kana_monotonic: kana_query の単調性。(None,_)→OK / (Some curr, Some prev) は
+    ///   `curr.starts_with(prev)` のとき候補が狭まる / (Some,None) は新規出現ゆえ full scan。
+    ///   ローマ字→かな変換は非単調（"kan"→"かん", "kana"→"かな"）ゆえ実値比較が必要。
+    /// - `!has_path_sep`: パスクエリは norm_query と path_query で正規化が異なり単調性を
+    ///   保証できないため無条件で無効化する（稀ゆえ性能影響は無視できる）。
+    fn can_reuse(&self, plan: &QueryPlan, mode: SearchMode) -> bool {
+        let kana_monotonic = match (&plan.kana_query, &self.prev_kana_query) {
+            (None, _) => true,
+            (Some(curr), Some(prev)) => curr.starts_with(prev.as_str()),
+            (Some(_), None) => false,
+        };
+        self.prev_mode == Some(mode)
+            && !self.prev_candidates.is_empty()
+            && !self.prev_query.is_empty()
+            && plan.norm_query.starts_with(self.prev_query.as_str())
+            && (!plan.has_dot || self.prev_query.contains('.'))
+            && !plan.has_path_sep
+            && kana_monotonic
+    }
+
+    /// 再利用時に前回候補の所有権を取り出す（`std::mem::take` で `self` から移す）。
+    fn take_candidates(&mut self) -> Vec<usize> {
+        std::mem::take(&mut self.prev_candidates)
+    }
+
+    /// 検索完了後に状態を更新する（write）。`candidates` は truncation 前の全一致 index。
+    /// `can_reuse` が read する全フィールドをここで対にして書き、対称更新漏れを構造で防ぐ。
+    fn update(
+        &mut self,
+        norm_query: String,
+        candidates: Vec<usize>,
+        mode: SearchMode,
+        kana_query: Option<String>,
+    ) {
+        self.prev_query = norm_query;
+        self.prev_candidates = candidates;
+        self.prev_mode = Some(mode);
+        self.prev_kana_query = kana_query;
+    }
 }
 
 /// kana の Unicode scalar value を 64 bit に写す損失あり存在マスク。
@@ -153,7 +213,6 @@ fn kana_char_mask(kana: &str) -> u64 {
 }
 
 impl SearchEngine {
-
     /// 履歴ブーストとデフォルト設定（migemo 無効）で検索する便宜 API。
     /// migemo（ローマ字→かな変換マッチ）を有効にするには
     /// [`Self::search_with_options`] に `migemo_enabled = true` の
@@ -194,12 +253,12 @@ impl SearchEngine {
 
         // Phase 4: incremental search — クエリが前回クエリの単調拡張でモードが不変の
         // とき、前回のマッチ候補を再利用する。
-        // 述語（no-dot→dot / kana 単調性 / !has_path_sep）と prev_* の read は
-        // decide_incremental に集約する。ここでは write のみを fold 後に行う。
-        let use_incremental = self.decide_incremental(&plan, mode);
+        // 述語（no-dot→dot / kana 単調性 / !has_path_sep）と前回状態の read は
+        // IncrementalCache::can_reuse に集約する。ここでは write のみを fold 後に行う。
+        let use_incremental = self.incremental_cache.can_reuse(&plan, mode);
 
         let candidate_indices: Vec<usize> = if use_incremental {
-            std::mem::take(&mut self.prev_candidates)
+            self.incremental_cache.take_candidates()
         } else {
             (0..self.entries.len()).collect()
         };
@@ -275,40 +334,16 @@ impl SearchEngine {
         // write 順序の入れ替えに意味論上の影響はない）。
         let results = heap_into_results(&self.entries, top_k);
 
-        self.prev_query = plan.norm_query.into_owned();
-        self.prev_candidates = all_match_indices;
-        self.prev_mode = Some(mode);
-        self.prev_kana_query = plan.kana_query;
+        // write: can_reuse が read する全状態を IncrementalCache::update で対にして更新する。
+        // all_match_indices は top-k から落ちた一致も含む全件。
+        self.incremental_cache.update(
+            plan.norm_query.into_owned(),
+            all_match_indices,
+            mode,
+            plan.kana_query,
+        );
 
         results
-    }
-
-    /// incremental search（前回候補の再利用）の可否を判定する。
-    ///
-    /// 全述語は「今回の候補集合 ⊆ 前回の候補集合」を保証する単調条件。
-    /// `self.prev_*` を **read のみ**で参照する（write は `search_with_options` が fold 後に行う）。
-    ///
-    /// - `!has_dot || prev_query.contains('.')`: "no-dot → dot" 遷移は full scan にフォールバック。
-    ///   prev_candidates が file_name スコアリングなしで構築されており、file_name のみで
-    ///   マッチするエントリが欠落して false negative になるのを防ぐ。
-    /// - kana_monotonic: kana_query の単調性。(None,_)→OK / (Some curr, Some prev) は
-    ///   `curr.starts_with(prev)` のとき候補が狭まる / (Some,None) は新規出現ゆえ full scan。
-    ///   ローマ字→かな変換は非単調（"kan"→"かん", "kana"→"かな"）ゆえ実値比較が必要。
-    /// - `!has_path_sep`: パスクエリは norm_query と path_query で正規化が異なり単調性を
-    ///   保証できないため無条件で無効化する（稀ゆえ性能影響は無視できる）。
-    fn decide_incremental(&self, plan: &QueryPlan, mode: SearchMode) -> bool {
-        let kana_monotonic = match (&plan.kana_query, &self.prev_kana_query) {
-            (None, _) => true,
-            (Some(curr), Some(prev)) => curr.starts_with(prev.as_str()),
-            (Some(_), None) => false,
-        };
-        self.prev_mode == Some(mode)
-            && !self.prev_candidates.is_empty()
-            && !self.prev_query.is_empty()
-            && plan.norm_query.starts_with(self.prev_query.as_str())
-            && (!plan.has_dot || self.prev_query.contains('.'))
-            && !plan.has_path_sep
-            && kana_monotonic
     }
 
     pub fn recent_history(&self, history: &HistoryStore, max_results: usize) -> Vec<SearchResult> {

--- a/snotra-core/src/search/build.rs
+++ b/snotra-core/src/search/build.rs
@@ -10,7 +10,7 @@ use rayon::prelude::*;
 use crate::indexer::{AppEntry, normalize_entry_key};
 use crate::query::{file_char_mask, lower_file_name, name_char_mask, to_kana, to_lower_folded};
 
-use super::{SearchEngine, kana_char_mask};
+use super::{IncrementalCache, SearchEngine, kana_char_mask};
 
 /// Wave 1 の出力: `(lower_names, lower_file_names, normalized_keys, kana_lower_names)`。
 /// いずれも構築後に伸長しないため `Box<str>` で保持する（容量ワード 8B/要素を節約）。
@@ -127,10 +127,9 @@ impl SearchEngine {
             file_name_char_masks,
             kana_lower_names,
             kana_char_masks,
-            prev_query: String::new(),
-            prev_candidates: Vec::new(),
-            prev_mode: None,
-            prev_kana_query: None,
+            // incremental cache は Default（空 query / 空候補 / mode 未設定）で初期化し、
+            // 構築直後の初回検索は必ず full scan になる（#601）。
+            incremental_cache: IncrementalCache::default(),
         }
     }
 


### PR DESCRIPTION
## 概要

`#596` ロードマップ Phase 2 の第 1 段。incremental search の状態（`prev_query` / `prev_candidates` / `prev_mode` / `prev_kana_query`）を `SearchEngine` の 4 フィールドから private `IncrementalCache` 型へ集約する。read（再利用判定）と write（検索後更新）を型のメソッドに閉じ、対称更新漏れを構造で防ぐ。**製品挙動・再利用条件は不変**。

Closes #601

## 変更内容

- private `IncrementalCache` 型を導入（4 状態を集約・`#[derive(Default)]`）
  - `can_reuse(&self, plan, mode) -> bool`（read・旧 `decide_incremental` をバイト等価で移設）
  - `take_candidates(&mut self) -> Vec<usize>`（`std::mem::take` で候補の所有権を取り出す）
  - `update(&mut self, norm_query, candidates, mode, kana_query)`（write・read する全フィールドを対で書く）
- `SearchEngine` は `incremental_cache` 1 フィールドを所有。`assemble`（build.rs）は `IncrementalCache::default()`（初回検索は必ず full scan）
- `search_with_options`: `decide_incremental` → `can_reuse`、`mem::take(prev_candidates)` → `take_candidates`、末尾 4 代入 → `update`

## 維持した不変条件（受け入れ条件）

再利用可の 7 条件は不変: mode 一致 / 前回候補非空 / 前回 query 非空 / `norm_query` が `prev_query` の prefix / no-dot→dot 除外 / `!has_path_sep` / kana 単調。`std::mem::take` 再利用・top-k から落ちた全一致の保存も不変。

- [x] `incremental_search_gives_correct_results_on_extension` / `_fallback_on_backspace` / `_fallback_on_mode_change`
- [x] dot 遷移の再利用/フォールバック（`dot_to_dot` / `no_dot_to_dot`）
- [x] kana 境界（min_chars 跨ぎ・ASCII 残留解消・非単調・単調拡張・kana→kana）
- [x] `path_match_incremental_disabled_avoids_accent_false_negative` / `path_match_incremental_cache_monotonic`
- [x] **`/cache-check`**: 全述語で単調性保証・`can_reuse` の read 集合と `update` の write 集合が単一型で co-located・対称・early-return 経路は旧挙動と同一 → キャッシュ再利用は安全（対称性を型で強制し安全性を向上）
- [x] カテゴリ A（clippy / `cargo test -p snotra-core` 466 passed, 9 ignored・property テスト incremental==fresh 全通過）/ rustdoc(`-D warnings`) / `cargo check -p snotra`（下流）/ governance G1..G9

## 非目的

- 再利用条件の緩和・拡張 / `prev_path_query` 追加 / キャッシュ永続化 / スコア・top-k 変更

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
