### PR TITLE
docs(rules): snotra-settings.md をルーターへ薄化（#588 横展開 2/4）

### DIFF
--- a/.claude/rules/snotra-settings.md
+++ b/.claude/rules/snotra-settings.md
@@ -3,12 +3,14 @@ paths:
   - "snotra-settings/**/*.rs"
 ---
 
-# snotra-settings ルール
+# snotra-settings ルール（ルーター）
 
-詳細は `snotra-settings/CLAUDE.md` を参照。
+事実の正準は `snotra-settings/CLAUDE.md`。本 rule は「どこを読むか」だけを示す（要約を置かない）。位置はファイル名で断定せず**見出し名・シンボル名で grep** して辿る（#588）。
 
-- **`saved` は「検証を通った config 全体」に差し替わる時だけ更新する**: `draft` は自由に変更可。`saved` が進む契機は save 成功と完全な config のロード（初期化・import 等）で、いずれも部分編集ではなく全体差し替えである。編集中の `draft` を部分的に `saved` へ写す経路を作ると部分保存バグになる。核心は、バリデーション/IO 失敗時に `saved` を進めないこと
-- **egui API 型注意**: `Key::ALL` は `&[Key]`（`for &key in`）、`color_edit_button_srgba` は永続変数の `&mut Color32` を渡す（一時変数だと変更が消える）
-- **フレームごとに重い処理を呼ばない**: `list_system_fonts()` 等は `new()` で一度だけ取得しキャッシュ
-- **PickerState の `active = false` リセット忘れ**: キャンセル・成功の両パスで必ず。忘れるとボタン永久無効化
-- **Opener ターゲット変更は remove → add**: ルールの `target` を直接書き換えると同じルール内の他ツールも巻き込まれる
+## 読む正準（`snotra-settings/CLAUDE.md` の該当節）
+
+- `saved` / `draft` の更新規律（save 成功・完全ロード時のみ `saved` を進める・部分保存禁止）: 「draft / saved 二重状態モデル」+「保存フロー」
+- egui API の型（`Key::ALL` は `&[Key]`・`color_edit_button_srgba` は永続 `&mut Color32`・`Stroke::new` の版差）: 「API の型に注意」
+- フレームごとの重い処理（`list_system_fonts()` 等は `new()` で 1 度キャッシュ）: 「フレームごとの重い処理を避ける」
+- `PickerState.active = false` の戻し（キャンセル・成功の両パス・`poll()` に集約）: 「非同期ファイルピッカーパターン」
+- opener ターゲット変更は remove → add（`OpenerRule.target` を直接書き換えない）: 「開発ルール」


### PR DESCRIPTION
## 概要

#588 横展開 2 本目。`snotra-settings.md` の 5 bullet はすべて `snotra-settings/CLAUDE.md` に正準が実在するため、**孤児なしの純粋なポインタ化**で薄化。

## 変更内容
- 事実コピー（egui `Key::ALL`/`color_edit_button_srgba` の型・`PickerState.active` リセット・opener remove→add 等）を CLAUDE.md 節見出しへのポインタに置換（1,173 bytes・旧 1,225）
- 元が既に簡潔なため byte 減は控えめだが、狙いは**要約コピー除去＝ドリフト耐性**（CLAUDE.md 側が変わってもルーターが腐らない）
- #588 の 2 規範（位置断定せず見出し名で grep）

## 検証
- 参照した 6 見出しの CLAUDE.md 実在を確認
- `governance:check` G1..G9 pass

## 横展開の進捗
- [x] snotra-core.md（#609 merged）
- [x] snotra-settings.md（本 PR）
- [ ] src-tauri.md（一部固有説明の正準実在を要確認）
- [ ] ui.md（latestRun/OwnedTimer 等・正準実在を要確認）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)