### PR TITLE
docs(rules): src-tauri.md をルーターへ薄化（#588 横展開 3/4）

### DIFF
--- a/.claude/rules/src-tauri.md
+++ b/.claude/rules/src-tauri.md
@@ -3,18 +3,26 @@ paths:
   - "src-tauri/**/*.rs"
 ---
 
-# src-tauri ルール
+# src-tauri ルール（ルーター）
 
-詳細は `src-tauri/CLAUDE.md` を参照。
+事実の正準は `src-tauri/CLAUDE.md` とコード。要約コピーは置かず正準へ指す。ただし CLAUDE.md に正準の無い src-tauri 固有の不変条件は「この rule が正準」節に残す。位置はファイル名・行で断定せず**見出し名・シンボル名で grep**（#588）。
 
-- **engine ロックを async/blocking 境界またぎで保持しない**: データ抽出 → 即解放 → 処理の順
-- **index-build フラグは `AppState::try_begin_index_build` / `finish_index_build` 経由**: `indexing` / `index_build_started` を直接 `store()` しない（外部からの force-reset は走行中ビルドのガードを踏み倒す）
-- **子プロセス spawn → exit handler kill はペア**: `main.rs` の exit ハンドラに `.kill()` を忘れない
-- **ウィンドウの生成は setup フェーズに限り、ランタイムは取得と表示制御だけ**: ランタイム（イベントループ中・IPC ハンドラ）では既存ウィンドウを取得して show/hide するに留める。ウィンドウ生成（`WebviewWindowBuilder::build()`）は WebView2 初期化がメッセージポンプの進行を要求するため、そこで呼ぶとデッドロックする。現状ランタイムに生成経路は無く、これは再び生成を持ち込む時のための予防規範
-- **Win32 API は PlatformBridge 経由**: IPC ハンドラから直接呼ばない。platform スレッドのメッセージループで実行する
-- **`windows` クレート（v0.62）の API を使う前に**: 型・シグネチャの一致と feature フラグの宣言を確認する
-- **ShellExecuteW + シェル拡張 → COM STA 必須**: `std::thread::spawn` + `CoInitializeEx` パターン。EXE は不要
-- **イベント順序**: `language-changed` → `hotkey-registration-failed` の順（フロントエンドが正しい言語でメッセージを組み立てるため）
-- **状態フラグを `true` にしたら `false` に戻す経路とセットで設計する**: 戻す責務を持つ関数は `#[must_use]` を付けて `let _ =` による無視をコンパイル時に検出する（実例 `window.rs::launch_settings_process`。index-build フラグは上記 `try_begin_index_build`/`finish_index_build` 経由）
-- **Win32 依存モジュール（`ime.rs`・`platform/` 内の `hotkey.rs` 等）はユニットテスト前提にしない**
-- **ホットキー・ウィンドウ生成/表示順・スラッシュコマンド経路を変更したら、カテゴリ A に加え `docs/build-commands.md` カテゴリ C（`smoke:startup` / `e2e:tauri`）も該当する**: post-edit hook が撃つのはカテゴリ A（clippy/test）だけで、「沈黙 = 合格」は C を含まない。C は手元で回すか、PR で `e2e.yml`（対象 paths で自動起動）に委ねるかを明示的に選ぶ。検証カテゴリは拡張子（`.rs`→A）でなく、変更が触れるコードパスの意味で決める（#558 でこの写像を早合点し C を見落とした）
+## 読む正準（`src-tauri/CLAUDE.md` の該当節）
+
+- index-build フラグは `try_begin_index_build` / `finish_index_build` 経由（`indexing` / `index_build_started` を直接 store しない）: 「実装パターン」
+- ランタイムでウィンドウ生成しない（`WebviewWindowBuilder::build()` はメッセージポンプ進行を要求しデッドロック・生成は setup 限定）: 「WebView2 ウィンドウ生成の制約」
+- `windows` クレート（v0.62）の API 型・feature フラグを使用前に確認: 「Win32 / Tauri 注意事項」
+- `ShellExecuteW` + シェル拡張は COM STA 必須（`std::thread::spawn` + `CoInitializeEx`・EXE は不要）: 「Win32 / Tauri 注意事項」
+- イベント順序 `language-changed` → `hotkey-registration-failed`: 「モジュール構成」の不変条件
+- engine ロックは async/blocking 境界またぎで保持しない（抽出 → 即解放 → 処理）: `snotra-core/CLAUDE.md`「engine.rs のロック最小化パターン」
+
+## この rule が正準（CLAUDE.md に無い src-tauri 固有）
+
+- **子プロセス spawn → exit ハンドラ kill はペア**: `snotra-settings.exe` 等を spawn したら `main.rs` の exit ハンドラで `child.kill()` する（生成/破棄のペア）
+- **Win32 API は `PlatformBridge` 経由**: IPC ハンドラから直接呼ばず `platform::{PlatformBridge, PlatformCommand}` で platform スレッドのメッセージループに実行を委ねる
+- **状態フラグを true にしたら false に戻す経路とセットで設計する**: 戻す責務の関数に `#[must_use]` を付け `let _ =` 無視を compile-fail 検出（実例 `launch_settings_process`）。一般則は `AGENTS.md`「事前調査」
+- **Win32 依存モジュール（`ime.rs`・`platform/` の `hotkey.rs` 等）はユニットテスト前提にしない**
+
+## 引き金 → 検査
+
+- ホットキー・ウィンドウ生成/表示順・スラッシュコマンド経路を変更したら: カテゴリ A に加え `docs/build-commands.md` カテゴリ C（`smoke:startup` / `e2e:tauri`）も該当。post-edit hook は A（clippy/test）だけで「沈黙 = 合格」は C を含まない。検証カテゴリは拡張子でなく変更が触れるコードパスの意味で決める（#558）


### PR DESCRIPTION
## 概要

#588 横展開 3 本目。src-tauri.md は 1・2 本目と違い**約半分が正準の無い「原本」**だった（PlatformBridge 経由・子プロセス kill・#[must_use]・Win32 非 unit-test）。コピーはポインタ化、原本は温存する **honest な部分薄化**。

## 変更内容
- **コピー 6 件をポインタ化**: try_begin_index_build / WebView2 生成制約 / windows crate / ShellExecuteW COM STA / イベント順序 →「該当節」、engine ロック最小化は `snotra-core/CLAUDE.md` へ cross-ref
- **原本 4 件は「この rule が正準」節に集約**（CLAUDE.md に正準が無いため）。全てコード実在を裏取り（`PlatformBridge` / `launch_settings_process` の `#[must_use]` / `main.rs` exit の `child.kill`）
- #588 規範どおり**行番号を書かず**シンボル名で指す（旧 rule の line 参照癖を排除）

## 検証
- 参照見出しの実在確認（src-tauri/CLAUDE.md 4 + snotra-core/CLAUDE.md 1）
- `governance:check` G1..G9 pass
- 2,719 bytes（旧 2,845）。半分が原本のため byte 減は小さいが、コピー 6 件のドリフト源を断った

## 横展開で見えた知見
薄化の byte 効果は「元がどれだけコピーを持つか」に比例: snotra-core 29% / snotra-settings 4% / src-tauri 4%（半分原本）。**ドリフト耐性はコピー除去分だけ等しく得られる**。全ルールが純コピーとは限らず、原本は温存するのが正しい。

## 進捗
- [x] snotra-core.md (#609)
- [x] snotra-settings.md (#610)
- [x] src-tauri.md（本 PR）
- [ ] ui.md（latestRun/OwnedTimer の正準実在を要確認）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)