### PR TITLE
feat(#615): governance:check に G10 恒久規範 行数 ratchet を追加

### DIFF
--- a/docs/build-commands.md
+++ b/docs/build-commands.md
@@ -67,11 +67,11 @@ npm test    # 必須: 使い捨て repo で hook を実測する（.githooks/git
 ### F. ガバナンス文書（`*.md`・`.claude/rules/`・`.claude/skills/`・workflow）を変更した場合
 
 ```bash
-npm run governance:check    # 必須: ガバナンス文書の決定的検査（参照実在・モジュール索引・スキル表・SPEC 番号・rules glob・コマンド写像。#587）
+npm run governance:check    # 必須: ガバナンス文書の決定的検査（参照実在・モジュール索引・スキル表・SPEC 番号・rules glob・コマンド写像・恒久規範の行数 ratchet。#587/#593）
 ```
 
 - PostToolUse フックは `.md` に検査を割り当てない（#497 の受容を維持）ため、**編集時の沈黙は「何も走らなかった」である**。ローカルで本コマンドを実行するか、PR CI の `governance-check` job（skip-ci 非対象・常時実行）に委ねる
-- 検査の実体は `scripts/governance-check.mjs`（G1〜G9）。意味判断（責務の妥当性・npm ラッパー等価・メモリ整合）は `/health-check` に残る
+- 検査の実体は `scripts/governance-check.mjs`（G1〜G10。G10 = 恒久規範の行数 ratchet・#593）。意味判断（責務の妥当性・npm ラッパー等価・メモリ整合）は `/health-check` に残る
 
 ## Windows/macOS/Linux で実行可能
 

--- a/scripts/governance-check.mjs
+++ b/scripts/governance-check.mjs
@@ -483,6 +483,72 @@ export function checkHookCommands(snapshot) {
 }
 
 // ---------------------------------------------------------------------------
+// G10 — 恒久規範の面積 ratchet（二面独立）。#593 §2。
+// 恒久規範（毎セッション/引き金時にロード = コンテキスト予算への課税）の面積を単調非増加に保つ。
+// 「常時ロード」と「rules」を独立の上限で見るのは、常時→rules の面替えだけで数字を下げる回避を
+// 塞ぐため（合計 ratchet なら総額不変で通ってしまう）。基準の引き上げは LINE_BUDGET を理由コメント
+// 付きで更新すること（= 明示的な合意の摩擦）。ADR・spec・issue は履歴側ゆえ対象外。
+// 行数は \r?\n で数える（CRLF checkout で `.` が \r を落とす沈黙経路を #587/#589 で二度踏んだ）。
+// ---------------------------------------------------------------------------
+
+/** 常時ロードされる恒久規範ファイル（ルート直下の 2 文書） */
+export const ALWAYS_LOADED_FILES = ["CLAUDE.md", "AGENTS.md"];
+
+/** 二面独立の行数上限（2026-07-19 実測を基準に設定・#593/#615）。削減したら下げる（#616） */
+export const LINE_BUDGET = { alwaysLoaded: 233, rules: 173 };
+
+/** \r?\n の出現数 = wc -l 相当。読めなければ null（母集団欠落を上位で検知） */
+function countLines(text) {
+  return text == null ? null : (text.match(/\r?\n/g) || []).length;
+}
+
+/** 指定ファイル群の総行数を数える。読めないファイルは finding に積み、行数へは算入しない */
+function sumLines(snapshot, files, gLabel) {
+  let total = 0;
+  const findings = [];
+  for (const f of files) {
+    const c = countLines(snapshot.read(f));
+    if (c == null) findings.push(finding(f, 1, `${f} が読めない（${gLabel} 母集団の欠落）`));
+    else total += c;
+  }
+  return { total, findings };
+}
+
+export function checkNormativeLineBudget(snapshot) {
+  const findings = [];
+
+  const always = sumLines(snapshot, ALWAYS_LOADED_FILES, "G10");
+  findings.push(...always.findings);
+  if (always.total > LINE_BUDGET.alwaysLoaded) {
+    findings.push(
+      finding(
+        "CLAUDE.md",
+        1,
+        `常時ロード規範 ${always.total} 行 > 基準 ${LINE_BUDGET.alwaysLoaded} 行（#593 二面 ratchet）。機構吸収か履歴退去で減らすか、正当なら LINE_BUDGET.alwaysLoaded を理由コメント付きで更新`,
+      ),
+    );
+  }
+
+  const ruleFiles = snapshot.files.filter((f) => /^\.claude\/rules\/[^/]+\.md$/.test(f));
+  if (ruleFiles.length === 0) {
+    findings.push(finding(".claude/rules", 1, "rules が 0 件（G10 母集団の欠落）"));
+  } else {
+    const rules = sumLines(snapshot, ruleFiles, "G10");
+    findings.push(...rules.findings);
+    if (rules.total > LINE_BUDGET.rules) {
+      findings.push(
+        finding(
+          ".claude/rules",
+          1,
+          `rules 合計 ${rules.total} 行 > 基準 ${LINE_BUDGET.rules} 行（#593 二面 ratchet）。ルーター化で減らすか、正当なら LINE_BUDGET.rules を理由コメント付きで更新`,
+        ),
+      );
+    }
+  }
+  return findings;
+}
+
+// ---------------------------------------------------------------------------
 // 実行
 // ---------------------------------------------------------------------------
 
@@ -512,8 +578,13 @@ export function runAll(snapshot) {
     ...checkRulesGlobs(snapshot),
     ...checkSkillTable(snapshot),
     ...checkHookCommands(snapshot),
+    ...checkNormativeLineBudget(snapshot),
   );
-  const evidence = `対象文書 ${docs.length} 件 / rules ${snapshot.files.filter((f) => /^\.claude\/rules\/[^/]+\.md$/.test(f)).length} 件 / skills ${snapshot.files.filter((f) => /^\.claude\/skills\/[^/]+\/SKILL\.md$/.test(f)).length} 件`;
+  const always = ALWAYS_LOADED_FILES.reduce((n, f) => n + (countLines(snapshot.read(f)) ?? 0), 0);
+  const ruleLines = snapshot.files
+    .filter((f) => /^\.claude\/rules\/[^/]+\.md$/.test(f))
+    .reduce((n, f) => n + (countLines(snapshot.read(f)) ?? 0), 0);
+  const evidence = `対象文書 ${docs.length} 件 / rules ${snapshot.files.filter((f) => /^\.claude\/rules\/[^/]+\.md$/.test(f)).length} 件 / skills ${snapshot.files.filter((f) => /^\.claude\/skills\/[^/]+\/SKILL\.md$/.test(f)).length} 件 / 恒久規範 常時ロード ${always}/${LINE_BUDGET.alwaysLoaded} 行・rules ${ruleLines}/${LINE_BUDGET.rules} 行`;
   return { findings, evidence };
 }
 
@@ -527,6 +598,6 @@ if (isMain) {
     for (const f of findings) console.error(`  ${f.file}:${f.line}  ${f.message}`);
     process.exitCode = 1;
   } else {
-    console.log(`governance:check — G1..G9 passed（${evidence}）`);
+    console.log(`governance:check — G1..G10 passed（${evidence}）`);
   }
 }

--- a/scripts/governance-check.test.mjs
+++ b/scripts/governance-check.test.mjs
@@ -13,6 +13,9 @@ import {
   checkRulesGlobs,
   checkSkillTable,
   globToRegex,
+  checkNormativeLineBudget,
+  LINE_BUDGET,
+  ALWAYS_LOADED_FILES,
   runAll,
 } from "./governance-check.mjs";
 
@@ -348,6 +351,67 @@ describe("runAll（空母集団の明示 fail = 沈黙経路の閉塞）", () =>
     const s = snap({});
     const { findings } = runAll(s);
     expect(findings.length).toBeGreaterThan(0);
+  });
+});
+
+describe("G10 checkNormativeLineBudget（二面独立 ratchet・#593）", () => {
+  const nl = (n) => "\n".repeat(n); // n 本の \n = n 行（wc -l 相当）
+  const rule = (p, n) => ({ [`.claude/rules/${p}`]: nl(n) });
+
+  it("両面とも基準以内なら findings 無し（緑）", () => {
+    const s = snap({
+      "CLAUDE.md": nl(LINE_BUDGET.alwaysLoaded - 10),
+      "AGENTS.md": nl(10),
+      ...rule("a.md", LINE_BUDGET.rules),
+    });
+    expect(checkNormativeLineBudget(s)).toEqual([]);
+  });
+
+  it("常時ロードが基準超過なら finding（赤）", () => {
+    const s = snap({
+      "CLAUDE.md": nl(LINE_BUDGET.alwaysLoaded + 1),
+      "AGENTS.md": nl(0),
+      ...rule("a.md", 1),
+    });
+    const f = checkNormativeLineBudget(s);
+    expect(f.some((x) => x.message.includes("常時ロード規範") && x.message.includes("> 基準"))).toBe(true);
+  });
+
+  it("常時ロードは 2 面替えでは下がらない（rules へ移しても rules 側が超過する）", () => {
+    // 常時ロードは基準内だが rules を超過させる = 面替え回避を塞ぐことの検算
+    const s = snap({
+      "CLAUDE.md": nl(10),
+      "AGENTS.md": nl(10),
+      ...rule("a.md", LINE_BUDGET.rules + 1),
+    });
+    const f = checkNormativeLineBudget(s);
+    expect(f.some((x) => x.message.includes("rules 合計") && x.message.includes("> 基準"))).toBe(true);
+  });
+
+  it("CRLF でも \\r?\\n で数える（CRLF checkout 沈黙経路の閉塞）", () => {
+    const s = snap({
+      "CLAUDE.md": "x\r\n".repeat(LINE_BUDGET.alwaysLoaded + 1),
+      "AGENTS.md": "",
+      ...rule("a.md", 1),
+    });
+    const f = checkNormativeLineBudget(s);
+    expect(f.some((x) => x.message.includes("常時ロード規範"))).toBe(true);
+  });
+
+  it("常時ロード文書が読めなければ母集団欠落 finding（沈黙経路の閉塞）", () => {
+    const s = snap({ "AGENTS.md": nl(1), ...rule("a.md", 1) }); // CLAUDE.md 欠落
+    const f = checkNormativeLineBudget(s);
+    expect(f.some((x) => x.file === "CLAUDE.md" && x.message.includes("母集団の欠落"))).toBe(true);
+  });
+
+  it("rules が 0 件なら母集団欠落 finding（グロブ破損の沈黙経路の閉塞）", () => {
+    const s = snap({ "CLAUDE.md": nl(1), "AGENTS.md": nl(1) }); // rule ファイル無し
+    const f = checkNormativeLineBudget(s);
+    expect(f.some((x) => x.file === ".claude/rules" && x.message.includes("母集団の欠落"))).toBe(true);
+  });
+
+  it("ALWAYS_LOADED_FILES はルート直下の 2 文書", () => {
+    expect(ALWAYS_LOADED_FILES).toEqual(["CLAUDE.md", "AGENTS.md"]);
   });
 });
 


### PR DESCRIPTION
## 概要

設計書 `2026-07-19-doc-minimization-design.md` §2 の**行数 ratchet を機構化**。#593 の burn-down（恒久規範の面積の単調非増加）を governance:check で担保する。

## G10 の中身

- **二面独立の ratchet**: 常時ロード（`CLAUDE.md` + `AGENTS.md`）と rules（`.claude/rules/*.md`）を**別々の上限**で監視。合計 ratchet だと常時→rules の面替えだけで数字を下げられるため、独立にして「真の削減（機構吸収 or 履歴退去）だけが両面を下げる」構造にした
- **基準** = 2026-07-19 実測 `233` / `173` 行。引き上げは `LINE_BUDGET` を理由コメント付きで更新（= 明示的合意の摩擦）
- **行数は `\r?\n` で数える** — CRLF checkout で `.` が `\r` を落とす沈黙経路を #587/#589 で二度踏んだ
- **母集団欠落の検知**: 常時ロード文書が読めない / rules が 0 件なら finding（グロブ破損の沈黙経路を塞ぐ）
- **burn-down の可視化**: 毎回 evidence に `常時ロード 233/233 行・rules 173/173 行` を出力
- ADR・spec・issue は履歴側ゆえ対象外

## 検証

- 故障注入テスト 7 件（両面超過・面替え・CRLF・常時ロード欠落・rules 0 件）で両方向を実測
- dogfood スモーク: 実リポジトリで G1..G10 緑（233/173 が基準内）
- `npm run governance:check` → `G1..G10 passed`

Refs #593
Closes #615
