### PR TITLE
docs: #488 マージ節の否定の知識を ADR-0002 へ退去し常時ロードを 228→222 に削減

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,11 +36,7 @@
 - **`--no-verify` は人間専用** — `.githooks/` を迂回する。Claude は使用してはならない。迂回しても main への直接 push は GitHub ruleset が拒む（実測）
 - **`gh pr create` は `git push` と `&&` で繋いでよい** — PR 前 push チェック hook（`.claude/hooks/pre-bash.mjs`）は、鎖の中で `git push` が `&&` で先行していれば通す（`&&` が前段の成功を保証するため）。区切りが `;` / `||` / 改行の場合は push 失敗時に PR が作られうるので拒否する。`git -C <別ツリー> push` も安全な鎖とは見なさない（#482 で実測）
 - **main の同期は `git pull --ff-only` を使う** — 非 FF の `git pull` は main にマージコミットを作るため `.githooks/pre-merge-commit` が拒否する。FF ならマージコミットが生じず hook は呼ばれない
-- **マージで閉じる issue を決めるのは PR 本文である。`gh pr merge --body-file` では止まらない**（#488 実測） — auto-close の経路は 2 本あり、制御点が違う。
-  - **PR 本文の closing keyword** → `gh pr view <PR> --json closingIssuesReferences` に現れ、**マージした瞬間に閉じる。`gh pr merge` の `--subject` / `--body-file` では抑止できない**（#488 実測）。PR テンプレートが `Closes` 行を埋めるため、**書いた覚えが無くても残っている**
-  - **squash commit 本文の closing keyword** → main に載った時点で閉じる。本リポジトリは `squash_merge_commit_title=PR_TITLE` / `squash_merge_commit_message=PR_BODY`（#488 で変更。**ブランチのコミット本文は squash 本文へ流入しない**）。ただし `--body-file` に書けば **`closingIssuesReferences` に現れないまま**閉じる
-  - **hook はどちらも見ていない**（→「フック」の (A2) の非対称）。**これは規範であって機構ではない** — 手順を飛ばせば止めるものは無い。**だからこそ下の手順が唯一の防御である**
-  - **マージ方式を変えても逃げられない**: 本リポジトリは squash のみ有効（`allow_merge_commit` / `allow_rebase_merge` はいずれも `false`。`--merge` / `--rebase` は GitHub が拒否する）
+- **マージで閉じる issue を決めるのは PR 本文であり、`gh pr merge` の `--subject` / `--body-file` では抑止できない**（#488 実測）。auto-close は本文の**どこにあっても** `close`/`fix`/`resolve` 系 9 形（大文字小文字問わず・表やチェックリスト内も）でマージ時に走り、PR テンプレートが `Closes` を埋めるため**書いた覚えが無くても残る**。hook も見ていない（→「フック」の (A2)）。**だから下の手順が唯一の防御である**。なぜこの機構になるか（2 経路の可視性の非対称・マージ方式では逃げられない・squash 設定と復元レシピ）は `docs/adr/0002-squash-merge-issue-autoclose.md`
 
   手順（squash マージでは常にこの順。`<PR>` は PR 番号、`<issue>` は issue 番号）:
   1. **マージ直前に** `gh pr view <PR> --json closingIssuesReferences` を**必ず**見る。これが GitHub の計算した「いま閉じる issue」である
@@ -52,9 +48,7 @@
      - `gh issue list --state closed --search "closed:>=<mergedAt>"`（`mergedAt` は `gh pr view <PR> --json mergedAt`）。どちらの一覧にも属さない「知らないうちに閉じた issue」を拾う、唯一の接地した観測点
      誤って閉じていたら `gh issue reopen <issue>`（close イベントは履歴に残り、close を契機に動く下流は巻き戻らない。**reopen は回復であって、事前確認を省く免罪符ではない**）
 
-  **手順 1 の一覧が「閉じる issue のすべて」になるのは、手順 3 を守り、かつ確認からマージまで PR 本文が変わらなかったときだけである。** 本文を凍結する機構は無く、`gh pr merge --auto` は確認とマージを引き離すため**使わない**（残余の詳細は #488）。
-
-  設定の組み合わせは GitHub が制限する（実測 422・#488）。**元に戻す**なら `gh api -X PATCH repos/:owner/:repo -f squash_merge_commit_title=COMMIT_OR_PR_TITLE -f squash_merge_commit_message=COMMIT_MESSAGES`
+  **手順 1 の一覧が「閉じる issue のすべて」になるのは、手順 3 を守り、かつ確認からマージまで PR 本文が変わらなかったときだけである。** 本文を凍結する機構は無く、`gh pr merge --auto` は確認とマージを引き離すため**使わない**。
 
 ## フック（.claude/settings.json）
 

--- a/docs/adr/0002-squash-merge-issue-autoclose.md
+++ b/docs/adr/0002-squash-merge-issue-autoclose.md
@@ -1,0 +1,32 @@
+# ADR-0002: squash マージでの issue 意図せぬ auto-close を、Layer 0 遮断＋手順で防ぐ
+
+## 文脈
+
+GitHub の auto-close は、PR 本文・squash commit 本文の**どこにあっても** `close/closes/closed` `fix/fixes/fixed` `resolve/resolves/resolved` の 9 形（大文字小文字問わず・表やチェックリスト内・1 行同居も可）でマージ時に走る。PR テンプレートが `Closes` 行を埋めるため、**書いた覚えの無い close が残る**。本リポジトリは squash のみ有効で、意図せぬ issue クローズ事故が起きた（#488）。制御点をどこに置くかを決める必要があった。
+
+auto-close の経路は 2 本あり、可視性が非対称である:
+
+- **PR 本文の closing keyword** → `gh pr view <PR> --json closingIssuesReferences` に**現れ**、マージした瞬間に閉じる。`gh pr merge` の `--subject` / `--body-file` では抑止できない（#488 実測）。
+- **squash commit 本文の closing keyword** → main に載った時点で閉じる。ただし `--body-file` に書くと `closingIssuesReferences` に**現れないまま**閉じる。
+
+## 決定
+
+1. **Layer 0 で断つ** — `squash_merge_commit_message=PR_BODY` にし、ブランチのコミット本文が squash 本文へ流入する経路を全マージ経路から消した（#488 で設定変更）。詳細と、なぜ hook では守らないかは `CLAUDE.md`「フック」(A2) が SSOT。
+2. **残余（PR 本文の closing keyword）は手順で守る** — マージ前に `closingIssuesReferences` を見て意図どおりになるまで PR 本文を編集し、マージ後に接地した観測点で確認する。**手順の実体は `CLAUDE.md`「Git/GitHub 運用」に常時ロードで置く** — 手順が視界に無いと #488 保護を失うため（マージ手順の skill 化＝常時視界からの退去は `RETROSPECTIVE.md` で却下済み）。ADR は「なぜ」だけを持つ。
+
+## 検討した代替案と却下理由
+
+- **`gh pr merge` の `--subject` / `--body-file` で PR 本文の closing keyword を抑止する**: 却下。PR 本文の closing keyword はマージした瞬間に閉じ、`--subject` / `--body-file` では抑止できない（#488 実測）。
+- **`--body-file` に closing keyword を書いて squash 側で制御する**: 却下。squash 本文に書くと `closingIssuesReferences` に現れないまま閉じ、マージ前確認の一覧（＝唯一の制御点）を信頼できなくする。
+- **マージ方式を変えて逃げる（`--merge` / `--rebase`）**: 却下、というより不可。本リポジトリは squash のみ有効（`allow_merge_commit` / `allow_rebase_merge` はいずれも `false`）で GitHub が `--merge` / `--rebase` を拒否する。
+- **hook で merge / close を守る・設定 read-back の検知器を置く**: 却下。理由は `CLAUDE.md`「フック」(A2) が SSOT（merge/close の誤りは人の意図にあり `deny` が書けない・`ask` は fail-closed 骨格と両立せず・hook の視界が Web UI／ユーザー端末のマージを覆わない・「不在を検知する検知器」の無限後退から降りる）。ここでは繰り返さない。
+
+## 帰結
+
+- 母集団は**派生した参照集合ではなく起きた事実**から取る — 2 経路の可視性が非対称ゆえ、確認は `closingIssuesReferences` だけでなく `gh issue list --search "closed:>=<mergedAt>"` で裏取りする（この一般形は `.claude/rules/safety-nets.md` が持つ）。手順の全文は `CLAUDE.md`「Git/GitHub 運用」。
+- squash 設定は `squash_merge_commit_title=PR_TITLE` / `squash_merge_commit_message=PR_BODY`。設定の組み合わせは GitHub が制限する（実測 422）。**元に戻す**なら `gh api -X PATCH repos/:owner/:repo -f squash_merge_commit_title=COMMIT_OR_PR_TITLE -f squash_merge_commit_message=COMMIT_MESSAGES`。
+
+---
+
+status: Accepted
+関連: #488 ・`CLAUDE.md`「Git/GitHub 運用」「フック」(A2) ・`.claude/rules/safety-nets.md`

--- a/scripts/governance-check.mjs
+++ b/scripts/governance-check.mjs
@@ -494,8 +494,8 @@ export function checkHookCommands(snapshot) {
 /** 常時ロードされる恒久規範ファイル（ルート直下の 2 文書） */
 export const ALWAYS_LOADED_FILES = ["CLAUDE.md", "AGENTS.md"];
 
-/** 二面独立の行数上限。削減したら下げる（ratchet）。#616 で常時ロードを写し除去で 233→228 に削減 */
-export const LINE_BUDGET = { alwaysLoaded: 228, rules: 173 };
+/** 二面独立の行数上限。削減したら下げる（ratchet）。#616 で常時ロードを写し除去で 233→228、その後 #488 マージ節の否定の知識を ADR-0002 へ退去し 228→222 に削減 */
+export const LINE_BUDGET = { alwaysLoaded: 222, rules: 173 };
 
 /** \r?\n の出現数 = wc -l 相当。読めなければ null（母集団欠落を上位で検知） */
 function countLines(text) {


### PR DESCRIPTION
## 対応Issue

なし（クローズする issue はない。ガバナンス文書の整理）

## 変更内容

CLAUDE.md「Git/GitHub 運用」のマージ時 issue auto-close 節（#488）は、大半が「なぜこの機構がこうなのか」という**否定の知識**で占められ、毎セッション課税される常時ロード面を圧迫していた。ADR 機構（否定の知識専用・履歴側で行数 ratchet 非課税）へ退去する。

- **新規 `docs/adr/0002-squash-merge-issue-autoclose.md`**: 2 経路の可視性非対称・マージ方式で逃げられない理由・squash 設定値/422/復元レシピを収容。hook で守れない (A2) 非対称は `CLAUDE.md:71` を SSOT として**参照のみ**（写しを増やさない）
- **`CLAUDE.md`**: 見出しに命令（`--subject`/`--body-file` 抑止不能・9 形が本文のどこでも効く・テンプレ `Closes` 潜伏・**唯一の防御**）と ADR ポインタを集約。**手順 1〜4 は逐語・番号不変**、`--auto` 禁止と一覧完全性条件も残置
- **`scripts/governance-check.mjs`**: `LINE_BUDGET.alwaysLoaded` 228→222（削減を ratchet で固定）

### 不変条件

- **ADR を開かずに、常時ロードのテキストだけで安全にマージできる** — 命令はすべて CLAUDE.md 側に残し、ADR は「なぜ」だけを持つ
- 操作そのものは不変（platform 仕様上より確実・単純な手順は無く、手順は据え置き）
- 33〜38 行と `CLAUDE.md:71`（(A2) SSOT・「手順 3」参照元）は無傷

### 検証

- 常時ロード 228→222 行（#593 burn-down 前進）
- `npm run governance:check` 緑（222/222・G1..G10 passed）
