### PR TITLE
docs(adr): ADR-0002 の (A2) 3 理由の復唱を SSOT ポインタに削る

### DIFF
--- a/docs/adr/0002-squash-merge-issue-autoclose.md
+++ b/docs/adr/0002-squash-merge-issue-autoclose.md
@@ -19,7 +19,7 @@ auto-close の経路は 2 本あり、可視性が非対称である:
 - **`gh pr merge` の `--subject` / `--body-file` で PR 本文の closing keyword を抑止する**: 却下。PR 本文の closing keyword はマージした瞬間に閉じ、`--subject` / `--body-file` では抑止できない（#488 実測）。
 - **`--body-file` に closing keyword を書いて squash 側で制御する**: 却下。squash 本文に書くと `closingIssuesReferences` に現れないまま閉じ、マージ前確認の一覧（＝唯一の制御点）を信頼できなくする。
 - **マージ方式を変えて逃げる（`--merge` / `--rebase`）**: 却下、というより不可。本リポジトリは squash のみ有効（`allow_merge_commit` / `allow_rebase_merge` はいずれも `false`）で GitHub が `--merge` / `--rebase` を拒否する。
-- **hook で merge / close を守る・設定 read-back の検知器を置く**: 却下。理由は `CLAUDE.md`「フック」(A2) が SSOT（merge/close の誤りは人の意図にあり `deny` が書けない・`ask` は fail-closed 骨格と両立せず・hook の視界が Web UI／ユーザー端末のマージを覆わない・「不在を検知する検知器」の無限後退から降りる）。ここでは繰り返さない。
+- **hook で merge / close を守る・設定 read-back の検知器を置く**: 却下。理由は `CLAUDE.md`「フック」(A2) が SSOT。ここでは繰り返さない（3 理由の詳細はそちら）。
 
 ## 帰結
 


### PR DESCRIPTION
## 対応Issue

なし（#624 で生じた DRY の綻びの polish）

## 変更内容

#624 で ADR-0002 を起こした際、rejected 代替案の一項に「理由は `CLAUDE.md`「フック」(A2) が SSOT」と書きながら、その 3 理由を括弧で**復唱**していた。「ここでは繰り返さない」の一文と矛盾する重複だったため、括弧をポインタだけに削り、`CLAUDE.md`「フック」(A2) を唯一の SSOT に戻す。

- 常時ロード・rules 面は不変（ADR は ratchet 非課税・参照 churn なし・行数変化なし）
- `CLAUDE.md`「フック」(A2) への参照は維持、3 理由の実体はそちらのみに一本化

### 背景

「CLAUDE.md の整理」検討サイクルの結論は「3 サイクル（#624/#625）で余剰は抜き切り、残りは load-bearing。無理に動かすのは『やりすぎ』」。唯一の綺麗な微修正として、この既存 DRY の綻びのみを整えた（burn-down ではなく polish）。

### 検証

- `npm run governance:check` 緑（216/216・173/173・G1..G10 passed）
