### PR TITLE
SU2: ウィンドウシェル + 状態機械（egui 専用フォーク・#532 Phase 2）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4708,6 +4708,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snotra-core",
+ "snotra-egui-runtime",
  "tauri",
  "tauri-build",
  "tauri-plugin-single-instance",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4701,6 +4701,7 @@ name = "snotra"
 version = "0.1.0"
 dependencies = [
  "arboard",
+ "egui",
  "indexmap 2.14.0",
  "notify",
  "png 0.18.1",

--- a/docs/superpowers/plans/2026-07-22-su2-window-shell.md
+++ b/docs/superpowers/plans/2026-07-22-su2-window-shell.md
@@ -179,12 +179,12 @@ pub(crate) struct SearchWindowView {
     app_handle: tauri::AppHandle,
     was_focused: bool,
     unfocus_at: Option<Instant>,
-    hide_sent: bool,
+    // emit dedup は共有 EguiShellState.hide_pending（show がクリア・codex #8）。view-local には持たない。
 }
 
 impl SearchWindowView {
     pub(crate) fn new(app_handle: tauri::AppHandle) -> Self {
-        Self { app_handle, was_focused: false, unfocus_at: None, hide_sent: false }
+        Self { app_handle, was_focused: false, unfocus_at: None }
     }
 }
 
@@ -223,7 +223,7 @@ mod tests {
 - [ ] **Step 2: テスト実行**
 
 Run: `cargo test -p snotra egui_shell::view`
-Expected: `jp_font_is_registered_at_index_zero_for_both_families` PASS。`was_focused`/`unfocus_at`/`hide_sent` は Task 5 まで未使用ゆえ dead-code 警告が出る場合は `#[allow(dead_code)]` を struct に付け Task 5 で除去。
+Expected: `jp_font_is_registered_at_index_zero_for_both_families` PASS。`was_focused`/`unfocus_at` は Task 5 まで未使用ゆえ dead-code 警告が出る場合は `#[allow(dead_code)]` を struct に付け Task 5 で除去。
 
 - [ ] **Step 3: コミット**
 
@@ -270,37 +270,45 @@ use snotra_egui_runtime::EguiRuntime;
 use crate::egui_shell::view::SearchWindowView;
 
 /// フラグ ON の窓生成。EguiRuntime を install し webview 無しの "main" 窓を生成して attach。setup 限定。
-pub(crate) fn create(app: &mut tauri::App) -> Result<(), snotra_egui_runtime::RuntimeError> {
+/// 宣言窓の全プロパティ（600×52 は既定・width は config の window_width・skipTaskbar・
+/// alwaysOnTop・decorations:false・resizable:false・visible:false）を再現する（codex #11・(B)#1）。
+pub(crate) fn create(app: &mut tauri::App, window_width: f64) -> Result<(), snotra_egui_runtime::RuntimeError> {
     let runtime = EguiRuntime::new();
     runtime.install(app); // &mut App を要求（runtime.rs:77）
     let app_handle = app.handle().clone();
     let window = tauri::Window::builder(app, "main")
         .title("Snotra")
-        .inner_size(600.0, 52.0)
+        .inner_size(window_width, 52.0) // 保存幅を尊重（codex #11）
         .decorations(false)
         .resizable(false)
+        .skip_taskbar(true)   // 宣言窓 skipTaskbar:true の再現（(B)#1）
+        .always_on_top(true)  // 宣言窓 alwaysOnTop:true の再現（(B)#1）
         .visible(false)
         .build()
         .map_err(snotra_egui_runtime::RuntimeError::from)?;
-    // skip_taskbar/always_on_top は Window::builder に無ければ setup 後 setter で（mini-gate）。
     runtime.attach(window, SearchWindowView::new(app_handle))
 }
 ```
 
-mini-gate: `Window::builder` の `skip_taskbar`/`always_on_top` メソッド有無、`tauri::Error` → `RuntimeError` の `From`（`RuntimeError::Tauri(#[from] tauri::Error)`＝`runtime.rs:45`）を `cargo build` で確認。無いビルダーメソッドは `build()` 後に `window.set_skip_taskbar(true)`/`window.set_always_on_top(true)`。
+mini-gate: `Window::builder` に `skip_taskbar`/`always_on_top` が無ければ `build()` 後に `window.set_skip_taskbar(true)`/`window.set_always_on_top(true)` で補う（**未確定のままにしない**＝(B)#1）。`tauri::Error` → `RuntimeError` の `From`（`RuntimeError::Tauri(#[from] tauri::Error)`＝`runtime.rs:45`）を `cargo build` で確認。`window_width` は `main()` の既存 `config.appearance.window_width`（`main.rs:572`）を渡す。
 
-- [ ] **Step 3: setup で窓生成を flag 分岐**
+- [ ] **Step 3: setup で窓生成を flag 分岐（platform thread の後・codex #12）**
 
-`src-tauri/src/main.rs` の `.setup(move |app| {` 内、`let app_handle = app.handle().clone();`（`main.rs:633`）の**直後**に:
+`src-tauri/src/main.rs` の setup 内、**`setup_platform_thread(&app_handle, ...)`（`main.rs:652`）の後**に置く。SPEC §8.5「platform thread を窓生成より前に spawn し Win32 初期化と窓生成を並列実行」を満たすため、egui 生成も platform thread の後にする（codex #12）:
 
 ```rust
-    // 窓生成: フラグ ON は egui、OFF は宣言窓が Tauri により既に生成済み（何もしない）。
+    // 窓生成: フラグ ON は egui（platform thread spawn 後・SPEC §8.5 並列化）、
+    // OFF は宣言窓が Tauri により既に生成済み（何もしない）。
     if crate::trace::env_flag("SNOTRA_EGUI_MAIN") {
-        egui_shell::create(app)?; // app: &mut App
+        // show/hide を跨ぐ共有状態（世代・emit dedup）。view/hotkey/hide が参照するので窓生成前に管理下へ。
+        app.manage(egui_shell::EguiShellState::default());
+        egui_shell::create(app, window_width as f64)?; // app: &mut App・保存幅を渡す（codex #11）
     }
 ```
 
-（`?` は setup の戻り `Result<(), Box<dyn Error>>` へ。`RuntimeError` は `thiserror::Error` 派生ゆえ `Box<dyn Error>` に乗る。乗らなければ `.map_err(|e| e.to_string())?`。`cargo build` で確認。）
+（`EguiShellState` は Task 4 Step 2 で定義。`app.manage` は setup の `&mut App`／`&App` どちらでも可＝`Manager` トレイト。`SearchWindowView` は `app_handle` 経由で `try_state::<EguiShellState>()` を読む。）
+
+（`window_width` は既存の `config.appearance.window_width`＝`main.rs:572`。`?` は setup の戻り `Result<(), Box<dyn Error>>` へ。`RuntimeError` は `thiserror::Error` 派生ゆえ乗る。乗らなければ `.map_err(|e| e.to_string())?`。`cargo build` で確認。`setup_first_run`（`main.rs:656`）より前後どちらでもよいが、`setup_hotkey_listener` より前に窓が在ること。）
 
 - [ ] **Step 4: フラグ OFF 不変（G1）とフラグ ON 子孫 0（G4）を確認**
 
@@ -354,8 +362,17 @@ Expected: コンパイル成功。失敗＝呼び出し元で `&WebviewWindow �
 
 ```rust
 use std::time::Instant;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tauri::Manager;
+
+/// egui 経路の show/hide を跨ぐ共有状態（managed state）。
+/// - hotkey_generation: alt 解放待ち show の世代。hide が bump して保留 show を無効化する（codex #5/(B)#2）。
+/// - hide_pending: view の emit dedup。show がクリアして「hide 後に Focused(true) が来ず抑止が残る」を断つ（codex #8）。
+#[derive(Default)]
+pub(crate) struct EguiShellState {
+    pub(crate) hotkey_generation: AtomicU64,
+    pub(crate) hide_pending: AtomicBool,
+}
 
 /// egui 経路の show。共有するのは position_on_target_monitor のみ。全 hide は外部化ゆえ
 /// runtime.visible は false にならず、show は Focused(true) に依存せず確実に描ける（codex #4）。
@@ -363,6 +380,10 @@ pub(crate) fn show_egui_main(app: &tauri::AppHandle, _t0: Instant) {
     let Some(window) = app.get_window("main") else { return };
     if let Some(state) = app.try_state::<crate::AppState>() {
         state.main_visible.store(true, Ordering::SeqCst);
+    }
+    // show のたびに view の emit dedup をリセット（Focused(true) 非依存・codex #8）。
+    if let Some(sh) = app.try_state::<EguiShellState>() {
+        sh.hide_pending.store(false, Ordering::SeqCst);
     }
     #[cfg(windows)]
     crate::position_on_target_monitor(app, &window);
@@ -387,6 +408,11 @@ pub(crate) fn show_egui_main(app: &tauri::AppHandle, _t0: Instant) {
 
 /// egui 経路の hide。全 hide の唯一の副作用所有点（codex #7）。外部 window.hide() のみ。
 pub(crate) fn hide_egui_main(app: &tauri::AppHandle) {
+    // 保留中の alt 解放待ち show を無効化（codex #5/(B)#2）: 世代を bump し、
+    // spawn 済み show スレッドの gen 一致チェックを外して再表示を防ぐ。
+    if let Some(sh) = app.try_state::<EguiShellState>() {
+        sh.hotkey_generation.fetch_add(1, Ordering::SeqCst);
+    }
     if let Some(window) = app.get_window("main") {
         save_placement_relative(app, &window); // save-on-hide
         let _ = window.hide();
@@ -429,6 +455,10 @@ fn setup_startup_display(app_handle: &AppHandle, show_on_startup: bool) {
 
 ```rust
         if crate::trace::env_flag("SNOTRA_EGUI_MAIN") {
+            // 世代は共有の EguiShellState を使う（hide が bump して保留 show を無効化・codex #5/(B)#2）。
+            let current_gen = handle_for_hotkey.try_state::<egui_shell::EguiShellState>()
+                .map(|sh| sh.hotkey_generation.fetch_add(1, Ordering::SeqCst) + 1)
+                .unwrap_or(0);
             let visible = handle_for_hotkey.try_state::<AppState>()
                 .map(|s| s.main_visible.load(Ordering::SeqCst)).unwrap_or(false);
             let hotkey_toggle = handle_for_hotkey.try_state::<AppState>()
@@ -440,10 +470,12 @@ fn setup_startup_display(app_handle: &AppHandle, show_on_startup: bool) {
                 HotkeyPlan::ShowNow => egui_shell::show_egui_main(&handle_for_hotkey, t0),
                 HotkeyPlan::ShowAfterAltRelease => {
                     let h = handle_for_hotkey.clone();
-                    let gen_for_wait = hotkey_generation_for_listener.clone();
                     std::thread::spawn(move || {
                         wait_alt_release_or_timeout();
-                        if gen_for_wait.load(Ordering::SeqCst) != current_gen { return; }
+                        // 共有世代が変わっていたら（別の press や hide が bump）show を諦める。
+                        let gen_now = h.try_state::<egui_shell::EguiShellState>()
+                            .map(|sh| sh.hotkey_generation.load(Ordering::SeqCst)).unwrap_or(0);
+                        if gen_now != current_gen { return; }
                         egui_shell::show_egui_main(&h, Instant::now());
                     });
                 }
@@ -452,7 +484,7 @@ fn setup_startup_display(app_handle: &AppHandle, show_on_startup: bool) {
         }
 ```
 
-（`HotkeyPlan` は `egui_shell::HotkeyPlan`。`t0`/`current_gen`/`hotkey_generation_for_listener` は listener の既存変数＝`main.rs:786,795,784`。Task 1 で dead-code allow を付けていれば除去。）
+（`HotkeyPlan` は `egui_shell::HotkeyPlan`。`t0` は listener 冒頭の `Instant::now()`＝`main.rs:786`。**egui 分岐は WebView2 の既存 `hotkey_generation_for_listener` を使わず共有 `EguiShellState.hotkey_generation` を使う**——hide 経路（`hide_egui_main`）からも bump できるようにするため。Task 1 で dead-code allow を付けていれば除去。）
 
 - [ ] **Step 5: Alt+Q show/hide/toggle と hide→show 反復（空白窓不在）を確認（G2/G3）**
 
@@ -522,10 +554,10 @@ pub(crate) fn register_hide_listener(app: &tauri::AppHandle) {
         let focused = ctx.input(|i| i.focused);
         let escape = ctx.input(|i| i.key_pressed(egui::Key::Escape));
 
-        // 再表示直後の stale 猶予をリセット（codex #8）: focused に戻ったら pending 破棄。
+        // 再表示直後の stale 猶予をリセット: focused に戻ったら pending 破棄。
+        // emit dedup（hide_pending）は show_egui_main がクリアするので view では触らない（codex #8）。
         if focused {
             self.unfocus_at = None;
-            self.hide_sent = false;
         }
         // Escape → 即 hide 要求（内側モード優先は SU3）。
         if escape {
@@ -555,8 +587,12 @@ pub(crate) fn register_hide_listener(app: &tauri::AppHandle) {
 
 ```rust
     fn emit_hide(&mut self) {
-        if self.hide_sent { return; } // 多重防止
-        self.hide_sent = true;
+        // 多重防止は共有 EguiShellState.hide_pending（show_egui_main がクリア・codex #8）。
+        // view-local フラグだと hide 後 Focused(true) 非着信で永久 true 化し以後の hide を抑止する。
+        let already = self.app_handle.try_state::<crate::egui_shell::EguiShellState>()
+            .map(|sh| sh.hide_pending.swap(true, std::sync::atomic::Ordering::SeqCst))
+            .unwrap_or(false);
+        if already { return; }
         let _ = self.app_handle.emit("egui-hide-requested", ());
     }
     fn auto_hide_enabled(&self) -> bool {
@@ -650,8 +686,16 @@ git push -u origin HEAD && gh pr create --fill
 - **spec §受け入れ条件 1-6** → 全 Task。flag OFF 完全不変=G1、plan_hotkey 純関数=Task 1、blur policy が view=Task 5、font-first=Task 2、子孫 0=G4。✓
 - **spec 否定の知識（seam/controller/静的空化/RuntimeFrame 直 hide の却下）** → 本計画は簡素化版で seam を持たない。✓
 
+**codex 再レビュー（2026-07-22）で追加修正した箇所:**
+- #12: egui `create` を `setup_platform_thread` の後へ（SPEC §8.5 並列化順序）。Task 3 Step 3。
+- #11: `create` が config の `window_width` を使う（固定 600px でなく保存幅）。Task 3。
+- (B)#1: `create` が `skip_taskbar(true)`/`always_on_top(true)` を明示（宣言窓プロパティ再現・未確定にしない）。Task 3 Step 2。
+- #8: emit dedup を view-local `hide_sent` から共有 `EguiShellState.hide_pending` へ移し `show_egui_main` がクリア（hide 後 Focused(true) 非着信で抑止が残る問題を断つ）。Task 4/5。
+- #5/(B)#2: `hide_egui_main` が共有 `EguiShellState.hotkey_generation` を bump し、保留中の alt 解放待ち show を無効化（hide 後の再表示を防ぐ）。Task 4。
+- #10: デバウンス保存欠落は残余として spec §位置永続に記録（受容）。
+
 **実装時 mini-gate（fabrication を避けた箇所）:**
-- Task 3: `Window::builder` の `skip_taskbar`/`always_on_top` 有無・`RuntimeError` From・`config_mut().app.windows` の label フィールド名。
+- Task 3: `Window::builder` の `skip_taskbar`/`always_on_top` 有無（無ければ setter・未確定にしない）・`RuntimeError` From・`config_mut().app.windows` の label フィールド名。
 - Task 4: `position_on_target_monitor` 一般化での呼び出し元互換（`&WebviewWindow→&Window`）・`save_search_placement` シグネチャ・`get_window("main")` が egui 窓を返す（Task 3 で確認）。
 - Task 5: `auto_hide_on_focus_lost` の config.rs 既定値・`Emitter`/`Manager` トレイト import。
 - Task 6: 既存 alwaysOnTop 制御の実型（WebviewWindow）と egui 分岐の最小差分。

--- a/docs/superpowers/plans/2026-07-22-su2-window-shell.md
+++ b/docs/superpowers/plans/2026-07-22-su2-window-shell.md
@@ -436,25 +436,30 @@ show/hide の Win32 骨格を共有関数へ集約し、WebView2 の renderer/fr
 - Consumes: `crate::{resume_webview, suspend_and_trim_after_hide, apply_ime_control, position_on_target_monitor, show_and_focus_window}`（`show_and_focus_window` は本タスクで一般化）。
 - Produces: `enum MainBackend { WebView2, Egui }`・`fn show_main(app: &AppHandle, backend: MainBackend, t0: Instant)`・`fn hide_main(app: &AppHandle, backend: MainBackend)`。Task 5/6 が消費。
 
-- [ ] **Step 1: WebviewWindow から &tauri::Window を得る手段を 1 行で確定（mini-gate）**
+- [ ] **Step 1: `app.get_window("main")` が WebView2 窓を返すことを実行時に確定（mini-gate・G1 の要）**
 
-共有 show 列は `&tauri::Window` で回す（egui/WebView2 両対応）。WebView2 側で `WebviewWindow` から `Window` を得る手段を確定する。`src-tauri/src/main.rs` の任意関数内に一時的に置いてコンパイル確認:
+共有 `show_main`/`hide_main` は実行時に **`app.get_window("main")`** で `tauri::Window` を取る（egui/WebView2 両対応の想定）。だが Tauri v2 では `get_window` と `get_webview_window` は**別レジストリ**で、`WebviewWindowBuilder` 生成窓を `get_window("main")` が返すかは**実行時の事実**（コンパイルでは分からない）。返さなければ flag OFF の `show_main` が早期 return し **G1 が壊れる**。ゆえにコンパイルでなく実行で確認する。
+
+`main.rs` の setup 末尾に一時ログを置く:
 
 ```rust
-// 確認用（このあと削除）: WebviewWindow -> &Window
-if let Some(wv) = app_handle.get_webview_window("main") {
-    let _w: &tauri::Window = wv.as_ref().window();
-}
+// 確認用（このあと削除）: get_window が programmatic WebView2 窓を返すか
+eprintln!("SNOTRA_GET_WINDOW_MAIN some={}", app_handle.get_window("main").is_some());
 ```
 
-Run: `cargo build -p snotra`
-Expected: コンパイル成功。**失敗したら** `wv.as_ref()` / `wv.window()` / `app.get_window("main")` の別手段を試し、通る 1 行を採用してから次へ（確認コードは削除）。以降のステップはこの確定手段を `webview_window_as_window(&wv)` 相当として使う。
+Run（`SNOTRA_EGUI_MAIN` 未設定）: `cargo run -p snotra 2>&1 | Select-String SNOTRA_GET_WINDOW_MAIN`
+Expected: `some=true`。**`some=false` なら** `show_main`/`hide_main` は単一 `get_window` でなく **backend 別取得**にする——`MainBackend` に `fn window(self, app: &AppHandle) -> Option<tauri::Window>`（WV2: `get_webview_window("main").map(|w| w.as_ref().window().clone())`、Egui: `get_window("main")`）を足し、共有列はそれを使う（「共有ハンドル」の物語がわずかに凹むが、アーキは不変）。**この分岐を決めてから Step 2 以降を書く**（確認ログは削除）。
 
-- [ ] **Step 2: `show_and_focus_main` を `&tauri::Window` へ一般化**
+補足: `wv.as_ref().window()` が `WebviewWindow → &Window` の手段として通るかも同時に確認（fallback の window() で使う）。通らなければ `wv.window()` / deref を試す。
 
-`src-tauri/src/main.rs:397` の `show_and_focus_main(app_handle, main: &tauri::WebviewWindow, t0)` を `show_and_focus_window(app_handle: &AppHandle, window: &tauri::Window, t0: Instant)` へ改名し、引数型を `&tauri::Window` に変える。本体（`show()`/`main_visible=true`/`set_focus()`/WM_NULL 同期/残留 Alt: `is_alt_pressed()` skip or `send_alt_key_up()`）はそのまま（すべて `&tauri::Window` で動く）。`.hwnd()` は両型にある。
+- [ ] **Step 2: 共有 Win32 列を `&tauri::Window` へ一般化（2 関数）**
 
-呼び出し元 `show_main_and_emit`（`main.rs:499`）は Step 4 で `show_main` へ移すため一旦保留。
+`src-tauri/src/main.rs` の 2 関数を `&tauri::WebviewWindow` → `&tauri::Window` へ一般化する（両型が持つ `show()`/`set_focus()`/`hwnd()`/`outer_size()`/`set_position()` だけを使うため素直に通る）:
+
+1. `show_and_focus_main(app_handle, main: &tauri::WebviewWindow, t0)`（`main.rs:397`）→ `show_and_focus_window(app_handle: &AppHandle, window: &tauri::Window, t0: Instant)`。本体（`show()`/`main_visible=true`/`set_focus()`/WM_NULL 同期/残留 Alt: `is_alt_pressed()` skip or `send_alt_key_up()`）はそのまま。
+2. `position_on_target_monitor(app_handle, main: &tauri::WebviewWindow)`（`main.rs:329`）→ 引数型を `&tauri::Window` に変える。本体（`main.outer_size()` でクランプ・`window_data::load_search_placement()` で相対座標・`main.set_position()`）はそのまま——`.outer_size()`/`.set_position()` は `tauri::Window` にある。
+
+呼び出し元 `show_main_and_emit`（`main.rs:497,499`）は Step 4 で `show_main` 経由へ移すため一旦保留（一般化した 2 関数は Step 3 の `show_main` が呼ぶ）。`reset_search_height`（`main.rs:379`）は WebView2 専用（高さ折りたたみ）ゆえ一般化せず、WV2 フック内に留める（Step 4）。
 
 - [ ] **Step 3: `MainBackend` とフックを書く**
 
@@ -549,7 +554,20 @@ fn show_main_and_emit(app_handle: &AppHandle) {
 }
 ```
 
-`reset_search_height`（`main.rs:379`）は WebView2 の高さ折りたたみ。SU2 placeholder は固定サイズゆえ egui では不要。WebView2 経路では `show_main` の `pre_show` 前に呼ぶ必要があるため、`MainBackend::WebView2::pre_show` の先頭で `reset_search_height` を呼ぶ（順序: height reset → resume → 位置 → show を温存。`src-tauri/CLAUDE.md`「操作順序制約」）。
+`reset_search_height`（`main.rs:379`）は WebView2 の高さ折りたたみ。SU2 placeholder は固定サイズゆえ egui では不要。**原本 `show_main_and_emit` の順序は resume(486) → reset_height(491) → position(497) → show(499)**。共有 `show_main` は position → show を担うので、WebView2 の `pre_show` は **resume → reset_height の順**にする（原本の前半を逐語温存＝G1 byte-identical）。`MainBackend::WebView2::pre_show` を次にする:
+
+```rust
+    fn pre_show(self, app: &AppHandle) {
+        if self == MainBackend::WebView2
+            && let Some(wv) = app.get_webview_window("main")
+        {
+            crate::resume_webview(&wv);      // 原本 486
+            crate::reset_search_height(&wv); // 原本 491（position より前＝clamp が折りたたみ高さを使う・CLAUDE.md 操作順序制約）
+        }
+    }
+```
+
+（Step 3 に書いた `pre_show` の骨子を、この resume→reset_height 版へ差し替える。egui の `pre_show` は空のまま。）
 
 - [ ] **Step 5: フラグ OFF で回帰が無いことを確認する（G1）**
 
@@ -687,15 +705,15 @@ use std::sync::Mutex;
 use lifecycle::{HostCommand, LifecycleEvent, LifecycleState, UiAction, plan_ui_action, transition};
 
 /// show/hide の合流点。hotkey・Escape・focus-lost の全 Show/Hide 要求がここを通り、
-/// 冪等性と show 進行中 Hide の Defer を一元化する。egui 経路専用（WV2 は従来の直接呼び）。
+/// 冪等性（表示中+Show→Refocus / 非表示中+Hide→Ignore）を一元化する。
+/// egui 経路専用（WV2 は従来の直接呼び）。
 pub(crate) struct LifecycleController {
     state: Mutex<LifecycleState>,
-    deferred_hide: Mutex<bool>,
 }
 
 impl LifecycleController {
     pub(crate) fn new() -> Self {
-        Self { state: Mutex::new(LifecycleState::Suspended), deferred_hide: Mutex::new(false) }
+        Self { state: Mutex::new(LifecycleState::Suspended) }
     }
 
     pub(crate) fn apply(&self, app: &AppHandle, command: HostCommand) {
@@ -705,18 +723,26 @@ impl LifecycleController {
                 if let HostCommand::Show { hotkey_started } = command {
                     show_main(app, MainBackend::Egui, hotkey_started);
                 }
-                self.advance(LifecycleEvent::Show);
-                // FramePresented は runtime の初回 present 後に別途通知（Step 3 注）。
+                // egui 経路は show が同期（window.show() は即・SU1 runtime は surface を
+                // 再生成せず Focused 観測で repaint）。ゆえに「最初のフレーム提示を待つ」
+                // mid-flight race が無い。Show→FramePresented を即座に畳んで Visible へ進め、
+                // 後続の Hide（hotkey トグル / focus-lost）が Recreating で Defer に吸われて
+                // 無限待ちになるデッドロックを断つ。
+                self.advance(LifecycleEvent::Show);          // Suspended → Recreating
+                self.advance(LifecycleEvent::FramePresented); // Recreating → Visible（即畳み）
             }
             UiAction::Hide => {
                 hide_main(app, MainBackend::Egui);
-                self.advance(LifecycleEvent::Hide);
+                self.advance(LifecycleEvent::Hide);           // Visible → Suspended
             }
             UiAction::Refocus => {
                 if let Some(w) = app.get_window("main") { let _ = w.set_focus(); }
             }
-            UiAction::Defer => { *self.deferred_hide.lock().unwrap() = true; }
-            UiAction::Ignore => {}
+            // Defer/Ignore は egui 経路では runtime 到達しない（apply 後の state は常に
+            // Visible|Suspended・Recreating は transient）。plan_ui_action の Defer 純粋契約は
+            // Task 1 のテストで固定するが、live では走らない（roadmap の「Defer をテストで
+            // 固定」＝純粋関数の契約テストで満たす。将来 async show を入れるなら再活性化）。
+            UiAction::Defer | UiAction::Ignore => {}
         }
     }
 
@@ -727,7 +753,7 @@ impl LifecycleController {
 }
 ```
 
-controller を `AppState` の managed state か `egui_shell` の `OnceLock<LifecycleController>` として保持する（threading: hotkey listener はメインスレッド、view は event loop スレッドから `apply` を呼ぶため `Mutex` で保護）。
+controller を `AppState` の managed state か `egui_shell` の `OnceLock<LifecycleController>` として保持する（threading: hotkey listener はメインスレッド、view は event loop スレッドから `apply` を呼ぶため `Mutex` で保護）。**`transition`/`LifecycleEvent` は Show/Hide/FramePresented の 3 event を `advance` が使うため非テストコードで消費される**（dead-code にならない）。
 
 - [ ] **Step 2: `setup_hotkey_listener` を flag 分岐する**
 
@@ -799,6 +825,8 @@ git commit -F <tmpfile>   # "feat(#532): SU2 ホットキー配線 + controller�
 ### Task 7: blur 自動非表示 + Escape（focus 観測 + policy）
 
 view が focus 喪失を観測し、100ms 猶予・`auto_hide_on_focus_lost` ゲート・サイドカーガードを満たすとき controller へ `HostCommand::Hide` を送る。Escape も Hide。policy は view（src-tauri）側に置き runtime API を拡張しない。
+
+**境界注記（黙って落とさない）**: SPEC §8.5 の「`snotra-settings` 起動中はメインの `alwaysOnTop` を一時 `false` にし終了検知で復元」は、現在 `get_webview_window("main")` にキーされた**設定サイドカー共存**の挙動で、ロードマップの **SU6（設定サイドカー共存）** に属す。SU2 が持つのは focus-lost の**非 hide ガード**だけ（設定が focus を奪っても本体を消さない）。egui 窓の `alwaysOnTop` トグルは SU6 で `get_window("main")` 対応にする。SU2 では触らない。
 
 **Files:**
 - Modify: `src-tauri/src/egui_shell/view.rs`（focus 観測 + Escape + policy 判定）
@@ -898,11 +926,11 @@ egui window の位置を SPEC §8.2 どおり復元・保存する。復元は `
 - Consumes: `position_on_target_monitor`（復元・共有列内）・既存の位置保存経路（`commands::save_search_placement` が使う `window.bin` 書き込み。相対座標算出は `monitor.rs`）。
 - Produces: なし（副作用）。
 
-- [ ] **Step 1: 位置保存経路を確認する**
+- [ ] **Step 1: 位置保存経路を確認しヘルパーを作る**
 
-`commands::save_search_placement`（`get_webview_window("main")` を使う・`commands/window.rs`）が呼ぶ `window.bin` 書き込み関数（`snotra-core` 側の placement 保存 or `monitor.rs`）を特定する。egui window（`get_window("main")`）の物理位置 + ターゲットモニター作業領域原点から**相対座標**を出して同じ形式で保存する共有ヘルパー `save_placement_relative(app, &window)` を `egui_shell` に用意する（WebView2 の保存ロジックを `&tauri::Window` で一般化・`monitor.rs` の相対座標算出を再利用）。
+復元と対称の保存経路を確認する。復元は `snotra_core::window_data::load_search_placement()`（`position_on_target_monitor:355` で使用）。保存は対の `window_data::save_search_placement(placement)`（`commands/window.rs` の `commands::save_search_placement` が現在 `get_webview_window("main")` から相対座標を出して呼ぶ）。その相対座標算出（現在の物理位置 − ターゲットモニター作業領域原点。`monitor.rs` のモニター決定 + 原点）を **`&tauri::Window` で一般化**し、`egui_shell` に `pub(crate) fn save_placement_relative(app: &AppHandle, window: &tauri::Window)` を作る（`window.outer_position()`/`monitor.rs` の作業領域原点 → `window_data::save_search_placement` へ）。既存 `commands::save_search_placement` のロジックを共有できるなら関数抽出で DRY 化（`/dry-check`）。
 
-Run: `cargo build -p snotra`（型が合うこと）
+Run: `cargo build -p snotra`（型が合うこと）。`window_data::save_search_placement` のシグネチャ（引数の placement 型）を `commands/window.rs` で確認してから呼ぶ。
 
 - [ ] **Step 2: `hide_main` に save-on-hide を足す**
 

--- a/docs/superpowers/plans/2026-07-22-su2-window-shell.md
+++ b/docs/superpowers/plans/2026-07-22-su2-window-shell.md
@@ -1,87 +1,75 @@
-# SU2: ウィンドウシェル + 状態機械 実装計画
+# SU2: ウィンドウシェル + 状態機械 実装計画（簡素化版）
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** 製品 `src-tauri` のメインウィンドウに、WebView2 と並行して egui/softbuffer 経路を env フラグ選択で立ち上げる外殻を作る。Alt+Q 表示/非表示・blur 自動非表示・フォーカス列・残留 Alt 解除・位置永続・起動時/初回フローを SPEC §8 と一致させ、フラグ OFF で WebView2 挙動を不変に保つ。
+**Goal:** 製品 `src-tauri` のメインウィンドウに、WebView2 と並行して egui/softbuffer 経路を env フラグで立ち上げる外殻を作る。Alt+Q 表示/非表示・blur 自動非表示・フォーカス列・残留 Alt 解除・位置永続・起動時/初回フローを SPEC §8 と一致させ、**フラグ OFF で WebView2 経路・E2E 注入を完全に不変**に保つ。
 
-**Architecture:** 両ウィンドウが同じ `tauri::Window` 抽象（`.show()`/`.hide()`/`.set_focus()`/`.hwnd()`）を共有するため、show/hide の Win32 骨格を 1 本の共有オーケストレーション（`show_main`/`hide_main`）に集約し、renderer(resume/suspend)+frontend(emit) の副作用だけを `MainBackend::{WebView2, Egui}` の薄い 3 フック（`pre_show`/`post_show`/`post_hide`）へ逃がす。ホットキー分岐と UI コマンド適用は純関数 `plan_hotkey`/`plan_ui_action` として `egui_shell/lifecycle.rs` に置き、冪等性と show 進行中 Hide の Defer をユニットテストで固定する。宣言窓（`tauri.conf.json`）を廃し両経路とも setup で programmatic 生成へ寄せ、フラグ ON で egui が WebView2 を真に置き換える（子孫 0）。
+**Architecture:** codex 敵対的レビューを受けた簡素化版。egui 専用の `show_egui_main`/`hide_egui_main` を WebView2 経路（無改変）と分離し、共有は `position_on_target_monitor` の `&tauri::Window` 一般化のみ。状態は `AppState.main_visible`(bool) + 純粋核 `plan_hotkey`。controller/4 状態機械/`plan_ui_action`/`Defer` は持たない（egui 同期 show で live 到達不能・spec「否定の知識」）。フラグは `tauri.conf.json` を空にせず、`main()` で `config_mut().app.windows` からフラグ ON のときだけ "main" を除去（E2E 注入が宣言窓に依存するため・codex #2）。全 hide は外部 `window.hide()`（runtime.visible を false にせず空白窓を避ける・codex #4/#7）。
 
-**Tech Stack:** Rust 2024 / egui 0.35 / `snotra-egui-runtime`（SU1・softbuffer）/ tauri v2・tauri-runtime-wry（unstable）/ windows 0.62 / Windows・PowerShell。
+**Tech Stack:** Rust 2024 / egui 0.35 / `snotra-egui-runtime`（SU1） / tauri v2・tauri-runtime-wry（unstable） / windows 0.62 / Windows・PowerShell。
 
 ## Global Constraints
 
-- **`main` へ直接コミットしない**（現在ブランチ `docs/532-su2-window-shell-spec`。実装用に `feat/532-su2-window-shell` を切る）。コミットメッセージは一時ファイル `git commit -F <tmpfile>`。bash HEREDOC 不可。パス区切りは `/`。
-- **フラグ**: `SNOTRA_EGUI_MAIN=1`（env・setup で 1 回読む）。判定は既存 `crate::trace::env_flag("SNOTRA_EGUI_MAIN")`（`src-tauri/src/trace.rs:20`）を使う。
-- **窓生成**: `tauri.conf.json` の `app.windows` を `[]` にする。両経路とも setup で programmatic 生成。ラベルは両方 `"main"`。生成は **setup フェーズ限定**（`WebviewWindowBuilder::build()` はメッセージポンプ進行を要求・`src-tauri/CLAUDE.md`）。
-- **2 つの visible を混同しない**: `AppState.main_visible: AtomicBool`（`state.rs:17`・policy＝`plan_hotkey` 入力・Standby/SearchVisible 判定）と runtime 内 `visible`（SU1 の描画ゲート・不変条件⑥）は別物。
-- **backend seam**: WebView2 の `resume_webview`/`suspend_and_trim_after_hide`/`emit(window-shown|hidden)` を `MainBackend::WebView2` フックへ**逐語移動**。順序制約（resume を show の前後 2 回・emit を suspend より先・FIFO 直列化＝`src-tauri/CLAUDE.md`「TrySuspend / Resume パターン」）を温存。egui フックは `pre_show`/`post_hide` 空・`post_show` は ime_control のみ。
-- **純粋核**: `plan_hotkey`/`plan_ui_action` は Win32 非依存・ユニットテスト。冪等性（`Visible+Show→Refocus`・`Suspended+Hide→Ignore`）と Defer（`Recreating+Hide→Defer`）を固定。
-- **focus 観測**: view が `ctx.input(|i| i.focused)` で観測（`snotra-egui-mvp/src/main.rs:174` で実証）。blur policy（100ms 猶予・`auto_hide_on_focus_lost` ゲート・`SettingsProcessState` 非起動ガード）は **src-tauri の view 側**に置く。`snotra-egui-runtime` の公開 API を拡張しない。
-- **フォント**: `SearchWindowView::setup` は `jp_font` を Proportional/Monospace の **index 0**（`insert(0, ...)`）。`FONT_PATH` 候補は `C:/Windows/Fonts/YuGothM.ttc` 他。`push`（末尾）にすると #399/#579 のベースラインずれ再発。
-- **位置永続**: 復元は show 経路で `position_on_target_monitor`（順序: サイズ確定 → 位置 → show）。保存は save-on-hide + 可視時終了保存。SPEC §8.2 の相対物理座標・`follow_cursor_monitor`・クランプ・中央フォールバックを踏襲。
-- **Win32 ヘルパー再利用**: `is_alt_pressed()`（`main.rs:90`）・`wait_alt_release_or_timeout()`（`main.rs:106`）・`send_alt_key_up()`（`main.rs:131`）。残留 Alt 解除は **focus 確定後かつ物理 Alt 解放後にのみ**注入（#558）。
-- **子孫 0**: フラグ ON で `msedgewebview2.exe` が 0 件（egui が置き換え）。
-- **各タスク境界で** `cargo clippy -p snotra --all-targets` と `cargo test -p snotra` が緑。PostToolUse hook が `*.rs` 編集時に自動実行する（沈黙=合格・失敗時のみ会話に届く）が、各タスクの Step でも明示実行する。
+- **`main` へ直接コミットしない**（実装用に `feat/532-su2-window-shell` を切る）。コミットは一時ファイル `git commit -F`。bash HEREDOC 不可。パス区切り `/`。
+- **フラグ**: `SNOTRA_EGUI_MAIN=1`。判定は `crate::trace::env_flag("SNOTRA_EGUI_MAIN")`。
+- **窓生成**: `tauri.conf.json` は不変（宣言窓 "main" を残す）。`main()` でフラグ ON のとき `app_context.config_mut().app.windows.retain(|w| w.label != "main")`。setup フェーズで `egui_shell::create`。両生成とも setup 限定（`WebviewWindowBuilder`/`Window::builder` はメッセージポンプ進行を要求）。
+- **WebView2 経路（フラグ OFF）は変更しない**。`show_main_and_emit`・resume/suspend/emit・hooks 化はしない。触るのは `position_on_target_monitor` の型一般化のみ（呼び出し元 1 箇所の互換は mini-gate で確認）。
+- **状態**: `AppState.main_visible: AtomicBool`（`state.rs:17`・既存）。egui は controller/4 状態を持たず、`plan_hotkey(main_visible, is_alt_pressed())` で分岐。
+- **`EguiRuntime::install(&self, app: &mut tauri::App<Wry>)`**（`runtime.rs:77`）: `create` は setup の `&mut App` を受ける（codex #1）。
+- **全 hide は外部 `window.hide()`**（codex #4/#7）: `RuntimeFrame::hide_window`（runtime.visible=false）を使わない。view 起点 hide は `emit("egui-hide-requested")` → listener → `hide_egui_main`。
+- **focus 観測**: view 内 `ctx.input(|i| i.focused)`（probe `main.rs:174`）。blur policy（100ms 猶予・`auto_hide_on_focus_lost` live-read・`SettingsProcessState` ガード・stale リセット）は view（src-tauri）側。runtime API を拡張しない。
+- **フォント**: `SearchWindowView::setup` は `jp_font` を Proportional/Monospace の **index 0**（`insert(0, ...)`）。`push` は #399/#579 再発。
+- **Win32 ヘルパー再利用**: `is_alt_pressed()`（`main.rs:90`）・`wait_alt_release_or_timeout()`（`main.rs:106`）・`send_alt_key_up()`（`main.rs:131`）。残留 Alt は focus 確定後かつ物理 Alt 解放後にのみ注入（#558）。
+- **各タスク境界で** `cargo clippy -p snotra --all-targets` + `cargo test -p snotra` 緑。PostToolUse hook が `*.rs` 編集で自動実行（沈黙=合格）。
 
 ## File Structure
 
-- `src-tauri/src/egui_shell/mod.rs`（新規）: `MainBackend` enum・`create()`（`Window::builder`+`install`+`attach`）・`show_main`/`hide_main` 共有オーケストレーション・3 フック・controller（合流点）。
-- `src-tauri/src/egui_shell/lifecycle.rs`（新規・純粋核）: `HotkeyPlan`/`plan_hotkey`・`LifecycleState`/`LifecycleEvent`/`transition`・`HostCommand`/`UiAction`/`plan_ui_action`。Win32 非依存。
-- `src-tauri/src/egui_shell/view.rs`（新規）: `SearchWindowView: EguiView`（placeholder）。`setup` で font-first・`update` で focus 観測（自動非表示の起点）。
-- `src-tauri/src/main.rs`（改修）: setup 本体に窓生成 flag 分岐 + `build_webview2_window`（新規）。`show_and_focus_main` を `&tauri::Window` へ一般化。WebView2 leaf をフックへ移動。`setup_hotkey_listener`/`setup_startup_display` に flag 分岐。
-- `src-tauri/tauri.conf.json`（改修）: `app.windows = []`。
+- `src-tauri/src/egui_shell/mod.rs`（新規）: `create(&mut App)`・`show_egui_main`/`hide_egui_main`・`save_placement_relative`・`egui-hide-requested` listener・`plan_hotkey` re-export。
+- `src-tauri/src/egui_shell/lifecycle.rs`（新規・純粋核）: `HotkeyPlan`/`plan_hotkey` のみ。
+- `src-tauri/src/egui_shell/view.rs`（新規）: `SearchWindowView`（placeholder・font-first・focus 観測 → emit）。
+- `src-tauri/src/main.rs`（改修）: `config_mut` 除去・窓生成 flag 分岐・`setup_hotkey_listener`/`setup_startup_display`/`setup_exit_listener`/設定 launch-exit(§8.5) の flag 分岐・`position_on_target_monitor` の `&Window` 一般化。**WebView2 経路本体は不変**。
 - `src-tauri/Cargo.toml`（改修）: `snotra-egui-runtime` path-dep 追加。
+- `src-tauri/tauri.conf.json`: **不変**。
 
 ---
 
-### Task 1: 依存追加 + egui_shell モジュール骨格 + 純粋核 lifecycle.rs
-
-撤去済み spike（`soft_host_main.rs:130-207` / テスト `1597-1649`・commit 7558cc8）から純粋核を移植する。Win32 非依存ゆえ単独でコンパイル・ユニットテストできる。
+### Task 1: 依存追加 + 純粋核 lifecycle.rs（plan_hotkey）+ モジュール骨格
 
 **Files:**
-- Modify: `src-tauri/Cargo.toml`（`[dependencies]` に 1 行）
-- Modify: `src-tauri/src/main.rs`（`mod egui_shell;` を 1 行追加）
-- Create: `src-tauri/src/egui_shell/mod.rs`
-- Create: `src-tauri/src/egui_shell/lifecycle.rs`
+- Modify: `src-tauri/Cargo.toml`（`[dependencies]` 1 行）
+- Modify: `src-tauri/src/main.rs`（`mod egui_shell;` 1 行）
+- Create: `src-tauri/src/egui_shell/mod.rs`・`src-tauri/src/egui_shell/lifecycle.rs`
 
 **Interfaces:**
-- Consumes: なし（純粋・std のみ）。
-- Produces: `plan_hotkey(visible: bool, alt_pressed: bool) -> HotkeyPlan`／`plan_ui_action(state: LifecycleState, command: &HostCommand) -> UiAction`／`transition(state: LifecycleState, event: LifecycleEvent) -> Result<LifecycleState, String>`／enum `HotkeyPlan{HideNow,ShowAfterAltRelease,ShowNow}`・`LifecycleState{Visible,Suspended,Recreating,Exiting}`・`LifecycleEvent{Hide,Show,FramePresented,Exit}`・`HostCommand{Show{hotkey_started:Instant},Hide}`・`UiAction{Show,Hide,Refocus,Defer,Ignore}`。Task 5/6 の controller が消費。
+- Produces: `pub(crate) fn plan_hotkey(visible: bool, alt_pressed: bool) -> HotkeyPlan`・`pub(crate) enum HotkeyPlan { HideNow, ShowAfterAltRelease, ShowNow }`。Task 4 の hotkey listener が消費。
 
 - [ ] **Step 1: Cargo 依存を追加**
 
-`src-tauri/Cargo.toml` の `[dependencies]` に追加:
+`src-tauri/Cargo.toml` の `[dependencies]` に:
 
 ```toml
 snotra-egui-runtime = { path = "../snotra-egui-runtime" }
 ```
 
-- [ ] **Step 2: モジュールを登録**
+- [ ] **Step 2: モジュール登録 + mod.rs 骨格**
 
-`src-tauri/src/main.rs` の他の `mod` 宣言群（`mod trace;` 等の近く）に追加:
-
-```rust
-mod egui_shell;
-```
-
-`src-tauri/src/egui_shell/mod.rs` を作成（Task 4 以降で拡張。今は純粋核の入れ物）:
+`src-tauri/src/main.rs` の `mod` 群に `mod egui_shell;` を追加。`src-tauri/src/egui_shell/mod.rs`:
 
 ```rust
-//! egui/softbuffer メインウィンドウの外殻。WebView2 と並行する window 生成・
-//! show/hide 状態機械・blur 自動非表示・位置永続を持つ（#532 SU2）。
+//! egui/softbuffer メインウィンドウの外殻（#532 SU2）。WebView2 と並行する
+//! egui 専用 window 生成・show/hide・blur 自動非表示・位置永続。WebView2 経路は触らない。
 mod lifecycle;
+mod view;
+
+pub(crate) use lifecycle::{HotkeyPlan, plan_hotkey};
 ```
 
-- [ ] **Step 3: 失敗するテストを書く（純粋核 + テスト）**
+- [ ] **Step 3: 失敗するテストを書く（plan_hotkey + テスト）**
 
-`src-tauri/src/egui_shell/lifecycle.rs` を作成（spike から逐語移植・製品用にコメント調整）:
+`src-tauri/src/egui_shell/lifecycle.rs`（spike `soft_host_main.rs:131-147` から移植）:
 
 ```rust
-//! Alt+Q ホットキー分岐と UI コマンド適用の純粋な決定核（Win32 非依存）。
-//! 冪等性（表示中+Show / 非表示中+Hide）と show 進行中に届いた Hide の繰り延べを
-//! ここに一元化する。SU1 spike（soft_host_main.rs）で実証済み・#532 SU2 で製品へ移植。
-
-use std::time::Instant;
+//! Alt+Q ホットキー分岐の純粋な決定核（Win32 非依存）。SU1 spike で実証済み・#532 SU2 で移植。
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum HotkeyPlan {
@@ -102,78 +90,9 @@ pub(crate) fn plan_hotkey(visible: bool, alt_pressed: bool) -> HotkeyPlan {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum LifecycleState {
-    Visible,
-    Suspended,
-    /// show 済みで最初のフレーム提示を待っている。
-    Recreating,
-    Exiting,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum LifecycleEvent {
-    Hide,
-    Show,
-    FramePresented,
-    Exit,
-}
-
-pub(crate) fn transition(
-    state: LifecycleState,
-    event: LifecycleEvent,
-) -> Result<LifecycleState, String> {
-    match (state, event) {
-        (LifecycleState::Visible, LifecycleEvent::Hide) => Ok(LifecycleState::Suspended),
-        (LifecycleState::Suspended, LifecycleEvent::Show) => Ok(LifecycleState::Recreating),
-        (LifecycleState::Recreating, LifecycleEvent::FramePresented) => Ok(LifecycleState::Visible),
-        (LifecycleState::Visible, LifecycleEvent::Exit)
-        | (LifecycleState::Suspended, LifecycleEvent::Exit) => Ok(LifecycleState::Exiting),
-        _ => Err(format!("invalid lifecycle transition: {state:?} + {event:?}")),
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub(crate) enum HostCommand {
-    Show { hotkey_started: Instant },
-    Hide,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum UiAction {
-    Show,
-    Hide,
-    Refocus,
-    /// show 完了（FramePresented）後まで Hide を繰り延べる。
-    Defer,
-    Ignore,
-}
-
-/// ホストコマンドを現在の lifecycle 状態へ適用する計画。冪等性
-/// （Visible+Show / Suspended+Hide）と、show 進行中に届いた Hide の繰り延べを決める。
-pub(crate) fn plan_ui_action(state: LifecycleState, command: &HostCommand) -> UiAction {
-    match (state, command) {
-        (LifecycleState::Visible, HostCommand::Show { .. }) => UiAction::Refocus,
-        (LifecycleState::Visible, HostCommand::Hide) => UiAction::Hide,
-        (LifecycleState::Suspended, HostCommand::Show { .. }) => UiAction::Show,
-        (LifecycleState::Suspended, HostCommand::Hide) => UiAction::Ignore,
-        (LifecycleState::Recreating, HostCommand::Show { .. }) => UiAction::Ignore,
-        (LifecycleState::Recreating, HostCommand::Hide) => UiAction::Defer,
-        (LifecycleState::Exiting, _) => UiAction::Ignore,
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{
-        HostCommand, HotkeyPlan, LifecycleEvent, LifecycleState, UiAction, plan_hotkey,
-        plan_ui_action, transition,
-    };
-    use std::time::Instant;
-
-    fn show_command() -> HostCommand {
-        HostCommand::Show { hotkey_started: Instant::now() }
-    }
+    use super::{HotkeyPlan, plan_hotkey};
 
     #[test]
     fn hotkey_branches_match_product_semantics() {
@@ -182,150 +101,48 @@ mod tests {
         assert_eq!(plan_hotkey(false, true), HotkeyPlan::ShowAfterAltRelease);
         assert_eq!(plan_hotkey(false, false), HotkeyPlan::ShowNow);
     }
-
-    #[test]
-    fn ui_commands_are_idempotent_and_defer_hide_while_showing() {
-        assert_eq!(plan_ui_action(LifecycleState::Visible, &show_command()), UiAction::Refocus);
-        assert_eq!(plan_ui_action(LifecycleState::Suspended, &HostCommand::Hide), UiAction::Ignore);
-        assert_eq!(plan_ui_action(LifecycleState::Suspended, &show_command()), UiAction::Show);
-        assert_eq!(plan_ui_action(LifecycleState::Visible, &HostCommand::Hide), UiAction::Hide);
-        assert_eq!(plan_ui_action(LifecycleState::Recreating, &HostCommand::Hide), UiAction::Defer);
-        assert_eq!(plan_ui_action(LifecycleState::Recreating, &show_command()), UiAction::Ignore);
-        assert_eq!(plan_ui_action(LifecycleState::Exiting, &show_command()), UiAction::Ignore);
-    }
-
-    #[test]
-    fn lifecycle_requires_frame_before_visible_and_allows_hidden_exit() {
-        let showing = transition(LifecycleState::Suspended, LifecycleEvent::Show).unwrap();
-        assert_eq!(showing, LifecycleState::Recreating);
-        let visible = transition(showing, LifecycleEvent::FramePresented).unwrap();
-        assert_eq!(visible, LifecycleState::Visible);
-        assert!(transition(LifecycleState::Suspended, LifecycleEvent::Hide).is_err());
-    }
 }
 ```
 
-- [ ] **Step 4: テストが通ることを確認する**
+注: `HotkeyPlan`/`plan_hotkey` は Task 4 で消費されるまで dead-code。mod.rs の `pub(crate) use` 直前に一時的に `#[allow(dead_code)]` は付けない——`pub(crate) use` の re-export があれば警告は出ない想定。出る場合のみ `#[allow(dead_code)]` を lifecycle.rs 先頭に付け Task 4 完了時に除去。
+
+- [ ] **Step 4: テスト実行**
 
 Run: `cargo test -p snotra egui_shell::lifecycle`
-Expected: 3 tests（`hotkey_branches_match_product_semantics` / `ui_commands_are_idempotent_and_defer_hide_while_showing` / `lifecycle_requires_frame_before_visible_and_allows_hidden_exit`）PASS。
-
-注: `pub(crate)` の未使用シンボルは Task 5/6 で消費されるまで dead-code 警告が出る。clippy を止めないため、`mod.rs` の `mod lifecycle;` 直後にこの時点だけ `#[allow(dead_code)]` を付け、**Task 6 完了時に除去する**（除去を Task 6 Step の最後に明記済み）。
+Expected: `hotkey_branches_match_product_semantics` PASS。
 
 - [ ] **Step 5: コミット**
 
 ```
 git add src-tauri/Cargo.toml src-tauri/src/main.rs src-tauri/src/egui_shell/
-git commit -F <tmpfile>   # "feat(#532): SU2 純粋核 plan_hotkey/plan_ui_action を src-tauri へ移植"
+git commit -F <tmpfile>   # "feat(#532): SU2 純粋核 plan_hotkey を src-tauri へ移植"
 ```
 
 ---
 
-### Task 2: G0 — 宣言窓を programmatic 生成へ変換（flag OFF byte-identical）
-
-`tauri.conf.json` の宣言窓を廃し、setup で `WebviewWindowBuilder` により逐語再現する。**このタスクではまだ flag 分岐を入れない**（純粋に宣言→programmatic の等価変換だけを接地し、回帰が無いことを確定する = G0）。
-
-**Files:**
-- Modify: `src-tauri/tauri.conf.json:14-28`（`windows` 配列を空に）
-- Modify: `src-tauri/src/main.rs`（`build_webview2_window` 新規 + setup 本体で呼ぶ）
-
-**Interfaces:**
-- Consumes: なし。
-- Produces: `fn build_webview2_window(app: &tauri::AppHandle) -> tauri::Result<()>`。Task 5 で flag 分岐の else 側に置かれる。
-
-- [ ] **Step 1: 宣言窓を空にする**
-
-`src-tauri/tauri.conf.json` の `app.windows` を空配列にする（`app.security` / `bundle` / `plugins` は不変）:
-
-```json
-  "app": {
-    "windows": [],
-    "security": {
-      "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:"
-    }
-  },
-```
-
-- [ ] **Step 2: `build_webview2_window` を書く（宣言窓 10 フィールドを逐語再現）**
-
-`src-tauri/src/main.rs` に追加（`use tauri::{WebviewUrl, WebviewWindowBuilder};` を先頭 use 群へ）:
-
-```rust
-/// 旧 tauri.conf.json の宣言窓（label "main"）を programmatic に再現する。
-/// フラグ OFF（WebView2 経路）の窓生成。宣言時と挙動一致（G0）。
-fn build_webview2_window(app: &tauri::AppHandle) -> tauri::Result<()> {
-    WebviewWindowBuilder::new(app, "main", WebviewUrl::App("main.html".into()))
-        .title("Snotra")
-        .inner_size(600.0, 52.0)
-        .visible(false)
-        .decorations(false)
-        .skip_taskbar(true)
-        .always_on_top(true)
-        .resizable(false)
-        .center()
-        .build()?;
-    Ok(())
-}
-```
-
-- [ ] **Step 3: setup 本体の先頭で窓を生成する**
-
-`src-tauri/src/main.rs` の `.setup(move |app| {` 直後、`let app_handle = app.handle().clone();`（現 633 行）の**直後**に追加（`setup_window_geometry` 等の既存呼び出しより前・宣言窓が消えた分をここで作る）:
-
-```rust
-    // 宣言窓を廃し programmatic 生成へ変換（#532 SU2 G0）。フラグ分岐は Task 5。
-    build_webview2_window(&app_handle)?;
-```
-
-- [ ] **Step 4: フラグ OFF で回帰が無いことを確認する（G0）**
-
-Run（PowerShell・`SNOTRA_EGUI_MAIN` 未設定）:
-```
-npm run smoke:startup
-npm run e2e:tauri
-```
-Expected: 両方 PASS（宣言時と同じ起動・ウィンドウ挙動）。`app.get_webview_window("main")` が従来どおり取れ、`main.html` がロードされる。**FAIL したら STOP** — programmatic 再現が宣言窓と非等価。10 フィールドの差分（特に `center`/`skip_taskbar`/`always_on_top`）を洗い直す。
-
-- [ ] **Step 5: コミット**
-
-```
-git add src-tauri/tauri.conf.json src-tauri/src/main.rs
-git commit -F <tmpfile>   # "feat(#532): SU2 G0 宣言窓を programmatic 生成へ変換（flag OFF 不変）"
-```
-
----
-
-### Task 3: placeholder view（SearchWindowView）+ font-first カナリア
-
-egui window に描く最小 view を作る。SU1 申し送りの font-first（`insert(0, jp_font)`）を機構化し、実 `setup` を駆動するテストで固定する。本体（検索・結果・モード）は SU3。
+### Task 2: placeholder view（SearchWindowView）+ font-first カナリア
 
 **Files:**
 - Create: `src-tauri/src/egui_shell/view.rs`
-- Modify: `src-tauri/src/egui_shell/mod.rs`（`mod view;`）
 
 **Interfaces:**
-- Consumes: `snotra_egui_runtime::{EguiView, RuntimeFrame}`・`egui`。
-- Produces: `struct SearchWindowView`（`SearchWindowView::new() -> Self`・`impl EguiView`）。`fn japanese_font_definitions(bytes: &'static [u8]) -> egui::FontDefinitions`（テスト対象）。Task 5 の `create()` が `attach` に渡す。
+- Produces: `struct SearchWindowView`（`SearchWindowView::new(app_handle: tauri::AppHandle) -> Self`・`impl EguiView`）。`fn japanese_font_definitions(bytes: &'static [u8]) -> egui::FontDefinitions`（テスト対象）。Task 3 の `create` が `attach` に渡す。
 
-- [ ] **Step 1: 失敗するテストを書く（view + font-first テスト）**
+- [ ] **Step 1: 失敗するテストを書く（view + font-first）**
 
-`src-tauri/src/egui_shell/view.rs` を作成（`japanese_font_definitions` は probe `snotra-egui-mvp/src/main.rs:635-653` から移植・テストは `:798-811` から移植）:
+`src-tauri/src/egui_shell/view.rs`（`japanese_font_definitions` は probe `snotra-egui-mvp/src/main.rs:635-670` から移植・テストは `:798-811` から）。**focus 観測フィールドは置くが emit 配線は Task 5**:
 
 ```rust
-//! egui メインウィンドウの placeholder view（#532 SU2）。show/hide/focus/位置を
-//! 視覚検証できる最小 chrome を描く。検索本体は SU3。font-first（jp_font を index 0）は
-//! SU1 申し送りの義務——push（末尾）だと softbuffer で #399/#579 のベースラインずれ再発。
+//! egui メインウィンドウの placeholder view（#532 SU2）。show/hide/focus/位置を視覚検証できる
+//! 最小 chrome を描く。検索本体は SU3。font-first（jp_font を index 0）は SU1 申し送りの義務。
 
 use std::sync::OnceLock;
+use std::time::Instant;
 
 use snotra_egui_runtime::{EguiView, RuntimeFrame};
 
 static JP_FONT_BYTES: OnceLock<Box<[u8]>> = OnceLock::new();
 
-/// `jp_font` を Proportional/Monospace の先頭（`insert(0, ...)`）へ差し込んだ
-/// `FontDefinitions` を組む純粋部分。`push`（末尾）だと Latin=egui既定/CJK=Yu Gothic の
-/// 2フォントに分かれ、softbuffer の被覆AA無しラスタが vertical metrics 差を整数pxへ
-/// 丸めて混在行のベースラインをずらす（#399/#579）。
 fn japanese_font_definitions(bytes: &'static [u8]) -> egui::FontDefinitions {
     let mut fonts = egui::FontDefinitions::default();
     let mut font = egui::FontData::from_static(bytes);
@@ -353,20 +170,21 @@ fn configure_japanese_font(context: &egui::Context) {
         }
     }
     if let Some(bytes) = JP_FONT_BYTES.get() {
-        // OnceLock はプロセス寿命ゆえ &'static へ延命できる（再表示ごとのリークを作らない）。
         let static_bytes: &'static [u8] = unsafe { std::mem::transmute::<&[u8], &'static [u8]>(bytes) };
         context.set_fonts(japanese_font_definitions(static_bytes));
     }
 }
 
-/// SU2 の placeholder view。検索バー枠と最小テキストだけを描く。
 pub(crate) struct SearchWindowView {
-    // Task 7 で focus 観測 + blur policy 用の状態（was_focused / unfocus_at）を足す。
+    app_handle: tauri::AppHandle,
+    was_focused: bool,
+    unfocus_at: Option<Instant>,
+    hide_sent: bool,
 }
 
 impl SearchWindowView {
-    pub(crate) fn new() -> Self {
-        Self {}
+    pub(crate) fn new(app_handle: tauri::AppHandle) -> Self {
+        Self { app_handle, was_focused: false, unfocus_at: None, hide_sent: false }
     }
 }
 
@@ -376,8 +194,8 @@ impl EguiView for SearchWindowView {
     }
 
     fn update(&mut self, ui: &mut egui::Ui, _frame: &mut RuntimeFrame) {
-        // placeholder: SU3 が検索 UI で置き換える。混在行（Latin+CJK）を出して
-        // font-first の視覚検証を可能にする。
+        // placeholder: SU3 が検索 UI で置き換える。混在行（Latin+CJK）で font-first を視覚検証。
+        // focus 観測 + blur emit は Task 5 で本体を実装する。
         ui.label("Snotra — 検索ウィンドウ（C:/Program Files/example）");
     }
 }
@@ -402,18 +220,10 @@ mod tests {
 }
 ```
 
-`src-tauri/src/egui_shell/mod.rs` に追加:
-
-```rust
-mod view;
-```
-
-- [ ] **Step 2: テストが通ることを確認する**
+- [ ] **Step 2: テスト実行**
 
 Run: `cargo test -p snotra egui_shell::view`
-Expected: `jp_font_is_registered_at_index_zero_for_both_families` PASS。
-
-注: `SearchWindowView` は Task 5 で `attach` に渡るまで未使用ゆえ、Task 1 で付けた `#[allow(dead_code)]` の傘に入れる（`view` mod も同様）。
+Expected: `jp_font_is_registered_at_index_zero_for_both_families` PASS。`was_focused`/`unfocus_at`/`hide_sent` は Task 5 まで未使用ゆえ dead-code 警告が出る場合は `#[allow(dead_code)]` を struct に付け Task 5 で除去。
 
 - [ ] **Step 3: コミット**
 
@@ -424,152 +234,75 @@ git commit -F <tmpfile>   # "feat(#532): SU2 placeholder SearchWindowView + font
 
 ---
 
-### Task 4: MainBackend seam + 共有 show_main/hide_main（WebView2 leaf 抽出・G1）
+### Task 3: フラグで宣言窓を除去 + egui window 生成（子孫 0・G1/G4）
 
-show/hide の Win32 骨格を共有関数へ集約し、WebView2 の renderer/frontend 副作用をフックへ逐語移動する。**このタスクは WebView2 側だけを触り**（`Egui` variant は定義するが未使用）、フラグ OFF が不変であることを接地する（G1）。
+`main()` でフラグ ON のとき `config_mut().app.windows` から "main" を除去し、setup で egui window を生成する。フラグ OFF は一切変えない。
 
 **Files:**
-- Modify: `src-tauri/src/egui_shell/mod.rs`（`MainBackend`・フック・`show_main`/`hide_main`）
-- Modify: `src-tauri/src/main.rs`（`show_and_focus_main` を `&tauri::Window` へ一般化 → `show_and_focus_window`。`show_main_and_emit` を `show_main` 経由へ。`resume_webview`/`suspend_and_trim_after_hide`/`emit` をフックから呼ぶ）
+- Modify: `src-tauri/src/main.rs`（`config_mut` 除去・setup 窓生成分岐）
+- Modify: `src-tauri/src/egui_shell/mod.rs`（`create`）
 
 **Interfaces:**
-- Consumes: `crate::{resume_webview, suspend_and_trim_after_hide, apply_ime_control, position_on_target_monitor, show_and_focus_window}`（`show_and_focus_window` は本タスクで一般化）。
-- Produces: `enum MainBackend { WebView2, Egui }`・`fn show_main(app: &AppHandle, backend: MainBackend, t0: Instant)`・`fn hide_main(app: &AppHandle, backend: MainBackend)`。Task 5/6 が消費。
+- Produces: `pub(crate) fn create(app: &mut tauri::App) -> Result<(), snotra_egui_runtime::RuntimeError>`。
 
-- [ ] **Step 1: `app.get_window("main")` が WebView2 窓を返すことを実行時に確定（mini-gate・G1 の要）**
+- [ ] **Step 1: `main()` でフラグ ON のとき宣言窓を除去**
 
-共有 `show_main`/`hide_main` は実行時に **`app.get_window("main")`** で `tauri::Window` を取る（egui/WebView2 両対応の想定）。だが Tauri v2 では `get_window` と `get_webview_window` は**別レジストリ**で、`WebviewWindowBuilder` 生成窓を `get_window("main")` が返すかは**実行時の事実**（コンパイルでは分からない）。返さなければ flag OFF の `show_main` が早期 return し **G1 が壊れる**。ゆえにコンパイルでなく実行で確認する。
-
-`main.rs` の setup 末尾に一時ログを置く:
+`src-tauri/src/main.rs` の `let app_context = tauri::generate_context!();` と E2E 注入ブロック（`main.rs:588-599`）の**後**に:
 
 ```rust
-// 確認用（このあと削除）: get_window が programmatic WebView2 窓を返すか
-eprintln!("SNOTRA_GET_WINDOW_MAIN some={}", app_handle.get_window("main").is_some());
-```
-
-Run（`SNOTRA_EGUI_MAIN` 未設定）: `cargo run -p snotra 2>&1 | Select-String SNOTRA_GET_WINDOW_MAIN`
-Expected: `some=true`。**`some=false` なら** `show_main`/`hide_main` は単一 `get_window` でなく **backend 別取得**にする——`MainBackend` に `fn window(self, app: &AppHandle) -> Option<tauri::Window>`（WV2: `get_webview_window("main").map(|w| w.as_ref().window().clone())`、Egui: `get_window("main")`）を足し、共有列はそれを使う（「共有ハンドル」の物語がわずかに凹むが、アーキは不変）。**この分岐を決めてから Step 2 以降を書く**（確認ログは削除）。
-
-補足: `wv.as_ref().window()` が `WebviewWindow → &Window` の手段として通るかも同時に確認（fallback の window() で使う）。通らなければ `wv.window()` / deref を試す。
-
-- [ ] **Step 2: 共有 Win32 列を `&tauri::Window` へ一般化（2 関数）**
-
-`src-tauri/src/main.rs` の 2 関数を `&tauri::WebviewWindow` → `&tauri::Window` へ一般化する（両型が持つ `show()`/`set_focus()`/`hwnd()`/`outer_size()`/`set_position()` だけを使うため素直に通る）:
-
-1. `show_and_focus_main(app_handle, main: &tauri::WebviewWindow, t0)`（`main.rs:397`）→ `show_and_focus_window(app_handle: &AppHandle, window: &tauri::Window, t0: Instant)`。本体（`show()`/`main_visible=true`/`set_focus()`/WM_NULL 同期/残留 Alt: `is_alt_pressed()` skip or `send_alt_key_up()`）はそのまま。
-2. `position_on_target_monitor(app_handle, main: &tauri::WebviewWindow)`（`main.rs:329`）→ 引数型を `&tauri::Window` に変える。本体（`main.outer_size()` でクランプ・`window_data::load_search_placement()` で相対座標・`main.set_position()`）はそのまま——`.outer_size()`/`.set_position()` は `tauri::Window` にある。
-
-呼び出し元 `show_main_and_emit`（`main.rs:497,499`）は Step 4 で `show_main` 経由へ移すため一旦保留（一般化した 2 関数は Step 3 の `show_main` が呼ぶ）。`reset_search_height`（`main.rs:379`）は WebView2 専用（高さ折りたたみ）ゆえ一般化せず、WV2 フック内に留める（Step 4）。
-
-- [ ] **Step 3: `MainBackend` とフックを書く**
-
-`src-tauri/src/egui_shell/mod.rs` に追加:
-
-```rust
-use std::time::Instant;
-use tauri::{AppHandle, Manager};
-
-/// メインウィンドウの renderer+frontend backend。show/hide の Win32 骨格は共有し、
-/// backend 固有の副作用（WV2: resume/suspend/emit、egui: なし）だけをフックへ逃がす。
-/// SU7 で WebView2 variant を削除すれば egui が素で残る。
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum MainBackend {
-    WebView2,
-    Egui,
-}
-
-impl MainBackend {
-    /// show の Win32 列（show/focus/位置）より前。WV2 はレンダラー resume。
-    fn pre_show(self, app: &AppHandle) {
-        if self == MainBackend::WebView2
-            && let Some(wv) = app.get_webview_window("main")
-        {
-            crate::resume_webview(&wv);
-        }
-    }
-
-    /// show の Win32 列の後。WV2 は resume 再適用 + ime_control + emit("window-shown")。
-    /// egui は ime_control のみ（repaint は runtime が Focused 観測で運ぶ）。
-    fn post_show(self, app: &AppHandle, t0: Instant) {
-        match self {
-            MainBackend::WebView2 => {
-                if let Some(wv) = app.get_webview_window("main") {
-                    crate::resume_webview(&wv); // 冒頭 resume 後〜可視反映前の残余窓を是正（#576）
-                    crate::apply_ime_control_if_enabled(app, &wv, t0);
-                }
-                crate::emit_window_shown(app, t0);
-            }
-            MainBackend::Egui => {
-                crate::apply_ime_control_egui(app, t0);
-            }
-        }
-    }
-
-    /// hide の後。WV2 は emit("window-hidden") + suspend + trim。egui は何もしない。
-    fn post_hide(self, app: &AppHandle) {
-        if self == MainBackend::WebView2 {
-            let _ = app.emit("window-hidden", ());
-            crate::suspend_and_trim_after_hide(app, "egui_shell_hide");
-        }
-    }
-}
-
-/// 両経路が通る唯一の show 経路。順序: pre_show → 位置 → Win32 show 列 → post_show。
-pub(crate) fn show_main(app: &AppHandle, backend: MainBackend, t0: Instant) {
-    let Some(window) = app.get_window("main") else { return };
-    backend.pre_show(app);
-    #[cfg(windows)]
-    crate::position_on_target_monitor(app, &window);
-    crate::show_and_focus_window(app, &window, t0);
-    backend.post_show(app, t0);
-}
-
-/// 両経路が通る唯一の hide 経路。window.hide → main_visible=false → post_hide。
-pub(crate) fn hide_main(app: &AppHandle, backend: MainBackend) {
-    if let Some(window) = app.get_window("main") {
-        let _ = window.hide();
-    }
-    if let Some(state) = app.try_state::<crate::AppState>() {
-        state.main_visible.store(false, std::sync::atomic::Ordering::SeqCst);
-    }
-    backend.post_hide(app);
-}
-```
-
-注: `app.get_window("main")` が programmatic WebView2 窓と egui 窓の両方を `tauri::Window` として返せることを Step 1 の確認で担保する（返せない場合は Step 1 の確定手段に合わせ `show_main`/`hide_main` の window 取得を差し替える）。
-
-- [ ] **Step 4: 既存の WebView2 side-effect を helper 化してフックから呼ぶ**
-
-`show_main_and_emit`（`main.rs:475`）内の以下を `egui_shell` から呼べるよう整理する:
-- `resume_webview`（`main.rs:266`・既存 `pub` 化が要れば `pub(crate)`）
-- `emit_window_shown`（`main.rs:463`）→ `pub(crate)`
-- `apply_ime_control`（`main.rs:447`）を `apply_ime_control_if_enabled(app, &wv, t0)`（`ime_off_on_show` の live-read 判定込み・現 `show_main_and_emit:511-517` のロジックを移設）と、egui 版 `apply_ime_control_egui(app, t0)`（`get_window("main").hwnd()` に `PlatformCommand::TurnOffIme`）へ切り出す。
-- `suspend_and_trim_after_hide`（`main.rs:305`・既に `pub(crate)`）。
-
-そのうえで `show_main_and_emit(app)` を **薄いラッパー**にする（既存の全呼び出し元＝`single_instance` プラグイン `main.rs:607`・`setup_startup_display`・hotkey listener の互換を保つ）:
-
-```rust
-fn show_main_and_emit(app_handle: &AppHandle) {
-    egui_shell::show_main(app_handle, egui_shell::MainBackend::WebView2, Instant::now());
-}
-```
-
-`reset_search_height`（`main.rs:379`）は WebView2 の高さ折りたたみ。SU2 placeholder は固定サイズゆえ egui では不要。**原本 `show_main_and_emit` の順序は resume(486) → reset_height(491) → position(497) → show(499)**。共有 `show_main` は position → show を担うので、WebView2 の `pre_show` は **resume → reset_height の順**にする（原本の前半を逐語温存＝G1 byte-identical）。`MainBackend::WebView2::pre_show` を次にする:
-
-```rust
-    fn pre_show(self, app: &AppHandle) {
-        if self == MainBackend::WebView2
-            && let Some(wv) = app.get_webview_window("main")
-        {
-            crate::resume_webview(&wv);      // 原本 486
-            crate::reset_search_height(&wv); // 原本 491（position より前＝clamp が折りたたみ高さを使う・CLAUDE.md 操作順序制約）
-        }
+    // フラグ ON: 宣言窓 "main"（WebView2）を除去して egui が置き換える（#532 SU2・codex #2）。
+    // tauri.conf.json は変えず config を実行時ミューテート（E2E 注入と同じ経路）。flag OFF は不変。
+    #[allow(unused_mut)]
+    let mut app_context = app_context;
+    if crate::trace::env_flag("SNOTRA_EGUI_MAIN") {
+        app_context.config_mut().app.windows.retain(|w| w.label != "main");
     }
 ```
 
-（Step 3 に書いた `pre_show` の骨子を、この resume→reset_height 版へ差し替える。egui の `pre_show` は空のまま。）
+（E2E ブロックが既に `let app_context = { ... };` で shadow している場合は、その後に置く。`config_mut()` は `&mut Config` を返す＝E2E ブロックが `config_mut().app.windows` を触っているので同 API で可。）
 
-- [ ] **Step 5: フラグ OFF で回帰が無いことを確認する（G1）**
+- [ ] **Step 2: `create()` を書く**
+
+`src-tauri/src/egui_shell/mod.rs` に（probe `snotra-egui-mvp/src/main.rs:691-756` の install/builder/attach を移植・`install` は `&mut App`＝codex #1）:
+
+```rust
+use snotra_egui_runtime::EguiRuntime;
+use crate::egui_shell::view::SearchWindowView;
+
+/// フラグ ON の窓生成。EguiRuntime を install し webview 無しの "main" 窓を生成して attach。setup 限定。
+pub(crate) fn create(app: &mut tauri::App) -> Result<(), snotra_egui_runtime::RuntimeError> {
+    let runtime = EguiRuntime::new();
+    runtime.install(app); // &mut App を要求（runtime.rs:77）
+    let app_handle = app.handle().clone();
+    let window = tauri::Window::builder(app, "main")
+        .title("Snotra")
+        .inner_size(600.0, 52.0)
+        .decorations(false)
+        .resizable(false)
+        .visible(false)
+        .build()
+        .map_err(snotra_egui_runtime::RuntimeError::from)?;
+    // skip_taskbar/always_on_top は Window::builder に無ければ setup 後 setter で（mini-gate）。
+    runtime.attach(window, SearchWindowView::new(app_handle))
+}
+```
+
+mini-gate: `Window::builder` の `skip_taskbar`/`always_on_top` メソッド有無、`tauri::Error` → `RuntimeError` の `From`（`RuntimeError::Tauri(#[from] tauri::Error)`＝`runtime.rs:45`）を `cargo build` で確認。無いビルダーメソッドは `build()` 後に `window.set_skip_taskbar(true)`/`window.set_always_on_top(true)`。
+
+- [ ] **Step 3: setup で窓生成を flag 分岐**
+
+`src-tauri/src/main.rs` の `.setup(move |app| {` 内、`let app_handle = app.handle().clone();`（`main.rs:633`）の**直後**に:
+
+```rust
+    // 窓生成: フラグ ON は egui、OFF は宣言窓が Tauri により既に生成済み（何もしない）。
+    if crate::trace::env_flag("SNOTRA_EGUI_MAIN") {
+        egui_shell::create(app)?; // app: &mut App
+    }
+```
+
+（`?` は setup の戻り `Result<(), Box<dyn Error>>` へ。`RuntimeError` は `thiserror::Error` 派生ゆえ `Box<dyn Error>` に乗る。乗らなければ `.map_err(|e| e.to_string())?`。`cargo build` で確認。）
+
+- [ ] **Step 4: フラグ OFF 不変（G1）とフラグ ON 子孫 0（G4）を確認**
 
 Run（`SNOTRA_EGUI_MAIN` 未設定）:
 ```
@@ -578,215 +311,140 @@ cargo test -p snotra
 npm run smoke:startup
 npm run e2e:tauri
 ```
-Expected: すべて PASS。hotkey show/hide・focus 喪失・`/s`・二重起動が従来どおり。**FAIL したら STOP** — leaf 移動が順序（resume 2 回・emit を suspend より先・height reset の位置）を壊した。`SNOTRA_TRACE=1` で `show_main:*` / `suspend:*` の順序を従来ログと比較。
+Expected: 全 PASS（宣言窓・E2E 注入とも無改変）。**FAIL したら STOP** — `config_mut` 除去がフラグ OFF で走っていないか、他を触った。
 
-- [ ] **Step 6: コミット**
-
+Run（フラグ ON）:
 ```
-git add src-tauri/src/
-git commit -F <tmpfile>   # "feat(#532): SU2 MainBackend seam + 共有 show_main/hide_main（WV2 leaf 抽出・G1）"
+$env:SNOTRA_EGUI_MAIN="1"; cargo run -p snotra
 ```
-
----
-
-### Task 5: egui window 生成 + Egui backend + 起動時表示（子孫 0）
-
-フラグ ON で egui window を setup 生成し、`EguiRuntime` を install/attach する。`show_main` は Task 4 で在るため起動時表示はそれを使う。
-
-**Files:**
-- Modify: `src-tauri/src/egui_shell/mod.rs`（`create()`・`EguiRuntime` 保持）
-- Modify: `src-tauri/src/main.rs`（setup 窓生成 flag 分岐・`setup_startup_display` 分岐）
-
-**Interfaces:**
-- Consumes: `snotra_egui_runtime::EguiRuntime`・`crate::egui_shell::{show_main, MainBackend}`・`SearchWindowView`。
-- Produces: `fn create(app: &tauri::App) -> Result<(), snotra_egui_runtime::RuntimeError>`（install + Window::builder("main") + attach）。
-
-- [ ] **Step 1: `create()` を書く**
-
-`src-tauri/src/egui_shell/mod.rs` に追加（probe `snotra-egui-mvp/src/main.rs:691-756` の install/builder/attach 構造を移植・window は `visible(false)`）:
-
-```rust
-use snotra_egui_runtime::EguiRuntime;
-use crate::egui_shell::view::SearchWindowView;
-
-/// フラグ ON の窓生成。EguiRuntime を install し、webview 無しの "main" 窓を
-/// programmatic 生成して SearchWindowView を attach する。生成は setup 限定。
-pub(crate) fn create(app: &tauri::App) -> Result<(), snotra_egui_runtime::RuntimeError> {
-    let runtime = EguiRuntime::new();
-    runtime.install(app);
-    let window = tauri::Window::builder(app, "main")
-        .title("Snotra")
-        .inner_size(600.0, 52.0)
-        .decorations(false)
-        .skip_taskbar(true)
-        .always_on_top(true)
-        .resizable(false)
-        .visible(false)
-        .build()?;
-    runtime.attach(window, SearchWindowView::new())?;
-    Ok(())
-}
-```
-
-注: `Window::builder` の利用可能メソッド（`skip_taskbar`/`always_on_top` 等）が `WebviewWindowBuilder` と同名かは Tauri v2 API 依存。`cargo build` で確認し、無いメソッドは setup 後 `window.set_skip_taskbar(true)` 等で補う。
-
-- [ ] **Step 2: setup 本体で flag 分岐する**
-
-`src-tauri/src/main.rs` の Task 2 Step 3 で入れた `build_webview2_window(&app_handle)?;` を flag 分岐に置き換える:
-
-```rust
-    // 窓生成: フラグで egui / WebView2 を選ぶ（#532 SU2）。生成は setup 限定。
-    if crate::trace::env_flag("SNOTRA_EGUI_MAIN") {
-        egui_shell::create(app)?;
-    } else {
-        build_webview2_window(&app_handle)?;
-    }
-```
-
-（`app` は `&tauri::App`・`create` が要求。`app_handle` は既存。**エラー変換の確定（mini-gate）**: setup クロージャの戻りは `Result<(), Box<dyn std::error::Error>>`。`create` の `RuntimeError` が `std::error::Error` を実装していれば `?` がそのまま通る（`RuntimeError` は `thiserror::Error` 派生＝`runtime.rs:43`・実装済み）。`build_webview2_window` の `tauri::Result` も同様に `?`。通らなければ `.map_err(|e| e.to_string())?` で `String`（`Box<dyn Error>` へ変換可）にする。`cargo build` で確認。）
-
-- [ ] **Step 3: `setup_startup_display` を flag 分岐する**
-
-`src-tauri/src/main.rs:952` の `setup_startup_display` を、egui のとき `show_main(app, MainBackend::Egui, Instant::now())` を呼ぶよう分岐:
-
-```rust
-fn setup_startup_display(app_handle: &AppHandle, show_on_startup: bool) {
-    if show_on_startup {
-        let backend = if crate::trace::env_flag("SNOTRA_EGUI_MAIN") {
-            egui_shell::MainBackend::Egui
-        } else {
-            egui_shell::MainBackend::WebView2
-        };
-        egui_shell::show_main(app_handle, backend, Instant::now());
-    }
-}
-```
-
-- [ ] **Step 4: フラグ ON で egui window が上がり子孫 0 を確認する（G2-partial）**
-
-Run（PowerShell）:
-```
-$env:SNOTRA_EGUI_MAIN="1"; $env:SNOTRA_TRACE="1"; cargo run -p snotra 2>&1 | Select-String "SNOTRA_EGUI|show_main"
-```
-（`show_on_startup=true` の config で起動、または起動後にウィンドウが出ることを確認）
-別ターミナルで:
-```
-Get-Process msedgewebview2 -ErrorAction SilentlyContinue
-```
-Expected: egui window が可視・日本語 + 長パスが正しいベースラインで描画。`Get-Process msedgewebview2` が **0 件**。**msedgewebview2 が spawn していたら STOP** — 宣言窓が残存（Task 2 の `windows:[]` を確認）か WebView2 経路へ誤分岐。
+別ターミナル: `Get-Process msedgewebview2 -ErrorAction SilentlyContinue`
+Expected: egui window が生成される（この時点では非表示＝`visible(false)`。表示は Task 4）。`msedgewebview2` **0 件**。**spawn していたら STOP** — `config_mut` 除去が効いていない（`retain` の label 比較を確認）。
 
 - [ ] **Step 5: コミット**
 
 ```
 git add src-tauri/src/
-git commit -F <tmpfile>   # "feat(#532): SU2 egui window 生成 + 起動時表示（子孫 0・G2-partial）"
+git commit -F <tmpfile>   # "feat(#532): SU2 フラグで宣言窓除去 + egui window 生成（子孫 0・G1/G4）"
 ```
 
 ---
 
-### Task 6: ホットキー配線（controller + plan_hotkey/plan_ui_action 適用）
+### Task 4: show_egui_main / hide_egui_main + 位置一般化 + ホットキー配線 + 起動時表示（G2/G3）
 
-製品ホットキー（`emit("hotkey-pressed")` → `setup_hotkey_listener`）を egui 経路の show/hide へ配線する。controller が全 Show/Hide 要求を `plan_ui_action` に通し、冪等性と Defer を一元化する。
+egui 専用の show/hide を書き、`position_on_target_monitor` を `&tauri::Window` へ一般化して共有し、ホットキーと起動時表示を配線する。
 
 **Files:**
-- Modify: `src-tauri/src/egui_shell/mod.rs`（controller: `LifecycleState` 保持 + `apply_command`）
-- Modify: `src-tauri/src/main.rs`（`setup_hotkey_listener` の flag 分岐）
+- Modify: `src-tauri/src/main.rs`（`position_on_target_monitor` 一般化・`setup_hotkey_listener`/`setup_startup_display` の flag 分岐）
+- Modify: `src-tauri/src/egui_shell/mod.rs`（`show_egui_main`/`hide_egui_main`/`save_placement_relative`）
 
 **Interfaces:**
-- Consumes: `lifecycle::{plan_hotkey, plan_ui_action, transition, HotkeyPlan, HostCommand, LifecycleState, LifecycleEvent, UiAction}`・`show_main`/`hide_main`。
-- Produces: controller 状態（`AppState` へ `Mutex<LifecycleState>` を足すか、`egui_shell` 内 `static`）。`fn on_hotkey(app: &AppHandle, generation: ...)`（egui 経路の Alt+Q 処理）。
+- Consumes: `crate::{position_on_target_monitor, is_alt_pressed, wait_alt_release_or_timeout, send_alt_key_up}`・`snotra_core::window_data`。
+- Produces: `pub(crate) fn show_egui_main(app: &AppHandle, t0: Instant)`・`pub(crate) fn hide_egui_main(app: &AppHandle)`・`pub(crate) fn save_placement_relative(app: &AppHandle, window: &tauri::Window)`。
 
-- [ ] **Step 1: controller を書く（合流点）**
+- [ ] **Step 1: `position_on_target_monitor` を `&tauri::Window` へ一般化**
 
-`src-tauri/src/egui_shell/mod.rs` に追加。lifecycle 状態を保持し、`HostCommand` を受けて `plan_ui_action` → 適用 → `transition` する:
+`src-tauri/src/main.rs:329` の引数 `main: &tauri::WebviewWindow` を `main: &tauri::Window` に変える。本体（`main.outer_size()`・`window_data::load_search_placement()`・`main.set_position()`）は不変。**呼び出し元 `show_main_and_emit:497`（WebView2・`&main` は `WebviewWindow`）の互換を確認**（mini-gate）: `&WebviewWindow` が `&Window` に deref 強制されるか、`main.as_ref()` 等が要るか。`pub(crate)` へ可視性調整。
+
+Run: `cargo build -p snotra`
+Expected: コンパイル成功。失敗＝呼び出し元で `&WebviewWindow → &Window` の変換を 1 行足す（WebView2 の**挙動**は不変ゆえ G1 スモークで裏取り）。
+
+- [ ] **Step 2: `show_egui_main`/`hide_egui_main`/`save_placement_relative` を書く**
+
+`src-tauri/src/egui_shell/mod.rs` に（show 列は WebView2 の `show_and_focus_main:397-443` を egui 用に自前複製＝WebView2 本体を触らないため。残留 Alt・WM_NULL は逐語）:
 
 ```rust
-use std::sync::Mutex;
-use lifecycle::{HostCommand, LifecycleEvent, LifecycleState, UiAction, plan_ui_action, transition};
+use std::time::Instant;
+use std::sync::atomic::Ordering;
+use tauri::Manager;
 
-/// show/hide の合流点。hotkey・Escape・focus-lost の全 Show/Hide 要求がここを通り、
-/// 冪等性（表示中+Show→Refocus / 非表示中+Hide→Ignore）を一元化する。
-/// egui 経路専用（WV2 は従来の直接呼び）。
-pub(crate) struct LifecycleController {
-    state: Mutex<LifecycleState>,
-}
-
-impl LifecycleController {
-    pub(crate) fn new() -> Self {
-        Self { state: Mutex::new(LifecycleState::Suspended) }
+/// egui 経路の show。共有するのは position_on_target_monitor のみ。全 hide は外部化ゆえ
+/// runtime.visible は false にならず、show は Focused(true) に依存せず確実に描ける（codex #4）。
+pub(crate) fn show_egui_main(app: &tauri::AppHandle, _t0: Instant) {
+    let Some(window) = app.get_window("main") else { return };
+    if let Some(state) = app.try_state::<crate::AppState>() {
+        state.main_visible.store(true, Ordering::SeqCst);
     }
-
-    pub(crate) fn apply(&self, app: &AppHandle, command: HostCommand) {
-        let state = *self.state.lock().unwrap();
-        match plan_ui_action(state, &command) {
-            UiAction::Show => {
-                if let HostCommand::Show { hotkey_started } = command {
-                    show_main(app, MainBackend::Egui, hotkey_started);
-                }
-                // egui 経路は show が同期（window.show() は即・SU1 runtime は surface を
-                // 再生成せず Focused 観測で repaint）。ゆえに「最初のフレーム提示を待つ」
-                // mid-flight race が無い。Show→FramePresented を即座に畳んで Visible へ進め、
-                // 後続の Hide（hotkey トグル / focus-lost）が Recreating で Defer に吸われて
-                // 無限待ちになるデッドロックを断つ。
-                self.advance(LifecycleEvent::Show);          // Suspended → Recreating
-                self.advance(LifecycleEvent::FramePresented); // Recreating → Visible（即畳み）
-            }
-            UiAction::Hide => {
-                hide_main(app, MainBackend::Egui);
-                self.advance(LifecycleEvent::Hide);           // Visible → Suspended
-            }
-            UiAction::Refocus => {
-                if let Some(w) = app.get_window("main") { let _ = w.set_focus(); }
-            }
-            // Defer/Ignore は egui 経路では runtime 到達しない（apply 後の state は常に
-            // Visible|Suspended・Recreating は transient）。plan_ui_action の Defer 純粋契約は
-            // Task 1 のテストで固定するが、live では走らない（roadmap の「Defer をテストで
-            // 固定」＝純粋関数の契約テストで満たす。将来 async show を入れるなら再活性化）。
-            UiAction::Defer | UiAction::Ignore => {}
+    #[cfg(windows)]
+    crate::position_on_target_monitor(app, &window);
+    let _ = window.show();
+    let _ = window.set_focus();
+    #[cfg(windows)]
+    if let Ok(hwnd) = window.hwnd() {
+        use windows::Win32::Foundation::{HWND, LPARAM, WPARAM};
+        use windows::Win32::UI::WindowsAndMessaging::{SendMessageTimeoutW, SMTO_NORMAL, WM_NULL};
+        let hwnd = HWND(hwnd.0);
+        let mut result = 0usize;
+        unsafe {
+            let _ = SendMessageTimeoutW(hwnd, WM_NULL, WPARAM(0), LPARAM(0), SMTO_NORMAL, 100, Some(&mut result));
         }
     }
+    // 残留 Alt 解除: focus 確定後かつ物理 Alt 解放後のみ（#558）。
+    if !crate::is_alt_pressed() {
+        crate::send_alt_key_up();
+    }
+    // ime_off_on_show は SU2 では省略可（IME off は SU5/SU6 で config 反映と合わせる。要判断）。
+}
 
-    fn advance(&self, event: LifecycleEvent) {
-        let mut state = self.state.lock().unwrap();
-        if let Ok(next) = transition(*state, event) { *state = next; }
+/// egui 経路の hide。全 hide の唯一の副作用所有点（codex #7）。外部 window.hide() のみ。
+pub(crate) fn hide_egui_main(app: &tauri::AppHandle) {
+    if let Some(window) = app.get_window("main") {
+        save_placement_relative(app, &window); // save-on-hide
+        let _ = window.hide();
+    }
+    if let Some(state) = app.try_state::<crate::AppState>() {
+        state.main_visible.store(false, Ordering::SeqCst);
+    }
+}
+
+/// 現在の物理位置をターゲットモニター作業領域原点からの相対座標で window.bin に保存。
+pub(crate) fn save_placement_relative(app: &tauri::AppHandle, window: &tauri::Window) {
+    // WebView2 の commands::save_search_placement（commands/window.rs）の相対座標算出を
+    // &tauri::Window で行う。monitor.rs の作業領域原点 + window.outer_position()。
+    // 具体は Step の mini-gate で window_data::save_search_placement のシグネチャに合わせる。
+    let _ = (app, window); // 実装は下記 mini-gate
+}
+```
+
+mini-gate: `commands/window.rs` の `save_search_placement` を読み、`window_data::save_search_placement(placement)` の placement 型と相対座標算出（`monitor.rs` の原点 + `window.outer_position()`）を `save_placement_relative` に写す。`get_window("main")` が egui 窓を返すことは Task 3 で確認済み。
+
+- [ ] **Step 3: 起動時表示を flag 分岐**
+
+`src-tauri/src/main.rs:952` の `setup_startup_display`:
+
+```rust
+fn setup_startup_display(app_handle: &AppHandle, show_on_startup: bool) {
+    if show_on_startup {
+        if crate::trace::env_flag("SNOTRA_EGUI_MAIN") {
+            egui_shell::show_egui_main(app_handle, Instant::now());
+        } else {
+            show_main_and_emit(app_handle);
+        }
     }
 }
 ```
 
-controller を `AppState` の managed state か `egui_shell` の `OnceLock<LifecycleController>` として保持する（threading: hotkey listener はメインスレッド、view は event loop スレッドから `apply` を呼ぶため `Mutex` で保護）。**`transition`/`LifecycleEvent` は Show/Hide/FramePresented の 3 event を `advance` が使うため非テストコードで消費される**（dead-code にならない）。
+- [ ] **Step 4: ホットキーを flag 分岐**
 
-- [ ] **Step 2: `setup_hotkey_listener` を flag 分岐する**
-
-`src-tauri/src/main.rs:781` の `setup_hotkey_listener` 内、`hotkey-pressed` クロージャで egui のとき `plan_hotkey` → `HostCommand` → `controller.apply` へ分岐する。WebView2 側は既存ロジック不変。サイドカーガード（`SettingsProcessState`・`main.rs:790`）と generation ガード（`main.rs:795`）と `ShowAfterAltRelease` の alt 解放待ちスレッド（`main.rs:830`）は共有構造で、egui では:
+`src-tauri/src/main.rs:781` の `setup_hotkey_listener` の `hotkey-pressed` クロージャ冒頭（サイドカーガード `main.rs:790` の後、generation ガード `main.rs:795` の付近）で egui 分岐。既存の generation/alt-wait 構造を egui 用に流用:
 
 ```rust
-        // egui 経路: 純粋核で分岐を決め、controller へ HostCommand を送る。
-        // current_gen / hotkey_generation_for_listener は既存 listener の変数（main.rs:784,795）。
         if crate::trace::env_flag("SNOTRA_EGUI_MAIN") {
             let visible = handle_for_hotkey.try_state::<AppState>()
                 .map(|s| s.main_visible.load(Ordering::SeqCst)).unwrap_or(false);
-            // hotkey_toggle の live-read は WebView2 経路（main.rs:808-812）と同じ。
             let hotkey_toggle = handle_for_hotkey.try_state::<AppState>()
                 .map(|s| s.engine.lock().unwrap().config().general.hotkey_toggle)
-                .unwrap_or(true);
+                .unwrap_or(true); // main.rs:808-812 と同じ live-read
             match egui_shell::plan_hotkey(visible, is_alt_pressed()) {
-                HotkeyPlan::HideNow if hotkey_toggle => {
-                    egui_shell::controller(&handle_for_hotkey)
-                        .apply(&handle_for_hotkey, HostCommand::Hide);
-                }
-                HotkeyPlan::HideNow => {} // hotkey_toggle=false は可視のまま（hide しない）
-                HotkeyPlan::ShowNow => {
-                    egui_shell::controller(&handle_for_hotkey)
-                        .apply(&handle_for_hotkey, HostCommand::Show { hotkey_started: t0 });
-                }
+                HotkeyPlan::HideNow if hotkey_toggle => egui_shell::hide_egui_main(&handle_for_hotkey),
+                HotkeyPlan::HideNow => {} // hotkey_toggle=false は可視のまま
+                HotkeyPlan::ShowNow => egui_shell::show_egui_main(&handle_for_hotkey, t0),
                 HotkeyPlan::ShowAfterAltRelease => {
                     let h = handle_for_hotkey.clone();
                     let gen_for_wait = hotkey_generation_for_listener.clone();
                     std::thread::spawn(move || {
                         wait_alt_release_or_timeout();
                         if gen_for_wait.load(Ordering::SeqCst) != current_gen { return; }
-                        egui_shell::controller(&h)
-                            .apply(&h, HostCommand::Show { hotkey_started: Instant::now() });
+                        egui_shell::show_egui_main(&h, Instant::now());
                     });
                 }
             }
@@ -794,78 +452,98 @@ controller を `AppState` の managed state か `egui_shell` の `OnceLock<Lifec
         }
 ```
 
-（`plan_hotkey`/`HotkeyPlan`/`HostCommand` は `lifecycle` の `pub(crate)`。`main.rs` から使うため `egui_shell/mod.rs` で `pub(crate) use lifecycle::{plan_hotkey, HotkeyPlan, HostCommand};` を re-export。`egui_shell::controller(app) -> &LifecycleController` は Task 6 Step 1 の managed state を返す薄いヘルパー。`t0` は listener 冒頭の `Instant::now()`＝`main.rs:786`。）
+（`HotkeyPlan` は `egui_shell::HotkeyPlan`。`t0`/`current_gen`/`hotkey_generation_for_listener` は listener の既存変数＝`main.rs:786,795,784`。Task 1 で dead-code allow を付けていれば除去。）
 
-- [ ] **Step 3: dead-code allow を除去し、Alt+Q show/hide/toggle を確認する（G2-full・G4）**
+- [ ] **Step 5: Alt+Q show/hide/toggle と hide→show 反復（空白窓不在）を確認（G2/G3）**
 
-Task 1 で付けた `#[allow(dead_code)]` を除去する（全シンボルが消費された）。
+Run: `cargo clippy -p snotra --all-targets`（dead-code なし）
 
-Run: `cargo clippy -p snotra --all-targets`（dead-code 警告が出ないこと）
-
-Run（PowerShell・トレース）:
+Run（フラグ ON・トレース）:
 ```
 $env:SNOTRA_EGUI_MAIN="1"; $env:SNOTRA_TRACE="1"; cargo run -p snotra
 ```
-手動で Alt+Q を押下:
-- 非表示 → 表示（`ShowNow` / Alt 押しっぱなしなら `ShowAfterAltRelease` 後）
-- 表示中に Alt+Q（`hotkey_toggle=true`）→ 非表示
-- 表示中に focus を奪わず連打 → 冪等（多重 show/hide しない）
+- Alt+Q で 非表示→表示（`ShowNow` / Alt 押しっぱなしは `ShowAfterAltRelease`）
+- 表示中 Alt+Q（`hotkey_toggle=true`）→ 非表示
+- **hide→show を 10 回反復 → 毎回ちゃんと描画される（空白窓が出ない・G3）**
+- 位置がドラッグ後も復元される
 
-Expected: show/hide が対称に動く。**hide 後アイドルで present 失敗リトライが繰り返されない**（G4: 隠れ窓に RedrawRequested が来ないので runtime は描かない）。`SNOTRA_TRACE` に `SNOTRA_EGUI_RENDER_ERROR` の連発が無い。**あれば STOP** — 外部 hide と runtime.visible の不整合。
+Expected: 上記どおり。`SNOTRA_EGUI_RENDER_ERROR` 連発なし。**空白窓が出たら STOP** — codex #4 が現実化（runtime.visible が false のまま）。全 hide が外部 `window.hide()` か、`RuntimeFrame::hide_window` を誤用していないか確認。破れるなら runtime に最小の可視化フックを足す設計へ戻る（要相談）。
 
-- [ ] **Step 4: コミット**
+- [ ] **Step 6: コミット**
 
 ```
 git add src-tauri/src/
-git commit -F <tmpfile>   # "feat(#532): SU2 ホットキー配線 + controller（plan_ui_action 合流・G2/G4）"
+git commit -F <tmpfile>   # "feat(#532): SU2 show_egui_main/hide_egui_main + 位置一般化 + hotkey（G2/G3）"
 ```
 
 ---
 
-### Task 7: blur 自動非表示 + Escape（focus 観測 + policy）
+### Task 5: blur 自動非表示 + Escape（view→emit→listener）
 
-view が focus 喪失を観測し、100ms 猶予・`auto_hide_on_focus_lost` ゲート・サイドカーガードを満たすとき controller へ `HostCommand::Hide` を送る。Escape も Hide。policy は view（src-tauri）側に置き runtime API を拡張しない。
-
-**境界注記（黙って落とさない）**: SPEC §8.5 の「`snotra-settings` 起動中はメインの `alwaysOnTop` を一時 `false` にし終了検知で復元」は、現在 `get_webview_window("main")` にキーされた**設定サイドカー共存**の挙動で、ロードマップの **SU6（設定サイドカー共存）** に属す。SU2 が持つのは focus-lost の**非 hide ガード**だけ（設定が focus を奪っても本体を消さない）。egui 窓の `alwaysOnTop` トグルは SU6 で `get_window("main")` 対応にする。SU2 では触らない。
+view が focus 喪失/Escape を観測し `emit("egui-hide-requested")`、src-tauri listener が `hide_egui_main` を呼ぶ。全 hide を 1 経路に集約（codex #7）。
 
 **Files:**
-- Modify: `src-tauri/src/egui_shell/view.rs`（focus 観測 + Escape + policy 判定）
+- Modify: `src-tauri/src/egui_shell/view.rs`（focus/Escape 観測 + policy + emit）
+- Modify: `src-tauri/src/egui_shell/mod.rs`（`egui-hide-requested` listener 登録）
+- Modify: `src-tauri/src/main.rs`（setup で listener 登録の flag 分岐）
 
 **Interfaces:**
-- Consumes: `ctx.input(|i| i.focused)`・`ctx.input(|i| i.key_pressed(egui::Key::Escape))`・`app_handle`（config/`SettingsProcessState` 読み）・controller。
-- Produces: view → controller への `HostCommand::Hide`（view は `RuntimeFrame::hide_window` で先に paint 停止してよい＝前倒し）。
+- Produces: `pub(crate) fn register_hide_listener(app: &tauri::AppHandle)`（`egui-hide-requested` → `hide_egui_main`）。
 
-- [ ] **Step 1: view に focus 観測 + policy を実装する**
+- [ ] **Step 1: listener を登録する**
 
-`SearchWindowView` に `app_handle: tauri::AppHandle`・`was_focused: bool`・`unfocus_at: Option<Instant>` を足し、`update` で:
+`src-tauri/src/egui_shell/mod.rs`:
 
 ```rust
-    fn update(&mut self, ui: &mut egui::Ui, frame: &mut RuntimeFrame) {
+/// view からの hide 要求を受け、メインスレッドで hide_egui_main を実行する（全 hide の合流点）。
+pub(crate) fn register_hide_listener(app: &tauri::AppHandle) {
+    let handle = app.clone();
+    app.listen("egui-hide-requested", move |_| {
+        hide_egui_main(&handle);
+    });
+}
+```
+
+`src-tauri/src/main.rs` の setup、`setup_hotkey_listener` 付近でフラグ ON のとき登録:
+
+```rust
+    if crate::trace::env_flag("SNOTRA_EGUI_MAIN") {
+        egui_shell::register_hide_listener(&app_handle);
+    }
+```
+
+- [ ] **Step 2: view に focus/Escape 観測 + policy + emit を実装**
+
+`SearchWindowView::update` を実装（stale リセット込み・codex #8）:
+
+```rust
+    fn update(&mut self, ui: &mut egui::Ui, _frame: &mut RuntimeFrame) {
         let ctx = ui.ctx().clone();
         let focused = ctx.input(|i| i.focused);
         let escape = ctx.input(|i| i.key_pressed(egui::Key::Escape));
 
-        // Escape → 即 Hide（SPEC §8.1。内側モードの復帰優先は SU3）。
-        if escape {
-            self.request_hide(frame);
-        }
-
-        // focus 喪失 → 100ms 猶予後に policy を満たせば Hide。
-        if self.was_focused && !focused {
-            self.unfocus_at = Some(Instant::now());
-            ctx.request_repaint_after(std::time::Duration::from_millis(100));
-        }
+        // 再表示直後の stale 猶予をリセット（codex #8）: focused に戻ったら pending 破棄。
         if focused {
-            self.unfocus_at = None; // refocus で pending 破棄
+            self.unfocus_at = None;
+            self.hide_sent = false;
+        }
+        // Escape → 即 hide 要求（内側モード優先は SU3）。
+        if escape {
+            self.emit_hide();
+        }
+        // focus 喪失 → 100ms 猶予後に policy を満たせば hide 要求。
+        if self.was_focused && !focused {
+            self.unfocus_at = Some(std::time::Instant::now());
+            ctx.request_repaint_after(std::time::Duration::from_millis(100));
         }
         if let Some(at) = self.unfocus_at
             && !focused
             && at.elapsed() >= std::time::Duration::from_millis(100)
-            && self.auto_hide_enabled()   // config live-read
-            && !self.settings_running()   // SettingsProcessState ガード
+            && self.auto_hide_enabled()
+            && !self.settings_running()
         {
             self.unfocus_at = None;
-            self.request_hide(frame);
+            self.emit_hide();
         }
         self.was_focused = focused;
 
@@ -873,17 +551,18 @@ view が focus 喪失を観測し、100ms 猶予・`auto_hide_on_focus_lost` ゲ
     }
 ```
 
-`request_hide`・`auto_hide_enabled`・`settings_running` を実装する:
+ヘルパー（`SearchWindowView` に追加）:
 
 ```rust
-    fn request_hide(&mut self, frame: &mut RuntimeFrame) {
-        frame.hide_window(); // 前倒しで paint 停止（合流点は controller）
-        controller_apply_hide(&self.app_handle); // egui_shell の controller へ HostCommand::Hide
+    fn emit_hide(&mut self) {
+        if self.hide_sent { return; } // 多重防止
+        self.hide_sent = true;
+        let _ = self.app_handle.emit("egui-hide-requested", ());
     }
     fn auto_hide_enabled(&self) -> bool {
         self.app_handle.try_state::<crate::AppState>()
             .map(|s| s.engine.lock().unwrap().config().general.auto_hide_on_focus_lost)
-            .unwrap_or(true) // config.rs の既定と一致（要確認）
+            .unwrap_or(true) // config.rs 既定と一致（mini-gate で確認）
     }
     fn settings_running(&self) -> bool {
         self.app_handle.try_state::<crate::SettingsProcessState>()
@@ -891,116 +570,88 @@ view が focus 喪失を観測し、100ms 猶予・`auto_hide_on_focus_lost` ゲ
     }
 ```
 
-（`controller_apply_hide` は `egui_shell` が `pub(crate)` で公開する薄いヘルパー。controller の保持先＝Step 6 Task 6 の managed state を読む。`SearchWindowView::new(app_handle)` に引数追加＝Task 5 の `create` の `SearchWindowView::new()` 呼び出しも更新する。`auto_hide_on_focus_lost` の既定値は `snotra-core` の config.rs で確認。）
+（`use tauri::{Emitter, Manager};` を view.rs へ。`auto_hide_on_focus_lost` の既定値を `snotra-core` config.rs で確認＝mini-gate。Task 2 の dead-code allow を除去。）
 
-- [ ] **Step 2: focus-lost 自動非表示とサイドカーガードを確認する（G3）**
+- [ ] **Step 3: focus-lost 自動非表示とサイドカーガードを確認（G3 blur）**
 
-Run（PowerShell）:
-```
-$env:SNOTRA_EGUI_MAIN="1"; cargo run -p snotra
-```
-- ウィンドウ表示 → 別アプリをクリックして focus を奪う → **100ms 後に自動非表示**（`auto_hide_on_focus_lost=true` 時）
-- 表示中に `/o` 等で `snotra-settings` を起動 → 設定が focus を奪う → **メインは非表示にならない**（サイドカーガード）
+Run（フラグ ON）: `$env:SNOTRA_EGUI_MAIN="1"; cargo run -p snotra`
+- 表示 → 別アプリをクリック → **100ms 後に自動非表示**（`auto_hide_on_focus_lost=true`）
+- 表示中に `snotra-settings` を外部起動（Task 6 前ゆえ手動 spawn か、Task 6 の §8.5 と合わせて検証）→ 設定が focus を奪っても**メインは非表示にならない**
 - Escape → 非表示
+- focus 喪失→即 refocus（100ms 未満）→ hide しない（stale リセット）
 
-Expected: 上記どおり。**設定起動で本体が消えたら STOP** — サイドカーガードが focus-lost 経路に効いていない。
+Expected: 上記どおり。**設定 focus で本体が消えたら STOP** — サイドカーガード不全。
 
-- [ ] **Step 3: コミット**
+- [ ] **Step 4: コミット**
 
 ```
 git add src-tauri/src/
-git commit -F <tmpfile>   # "feat(#532): SU2 blur 自動非表示 + Escape（focus 観測・100ms 猶予・サイドカーガード・G3）"
+git commit -F <tmpfile>   # "feat(#532): SU2 blur 自動非表示 + Escape（view→emit→listener・100ms・stale リセット）"
 ```
 
 ---
 
-### Task 8: 位置永続（復元 + save-on-hide + 可視時終了保存）
+### Task 6: SPEC §8.5 — 設定サイドカー起動中の alwaysOnTop 解除（egui 窓）
 
-egui window の位置を SPEC §8.2 どおり復元・保存する。復元は `show_main` の `position_on_target_monitor`（Task 4 で既に共有列に在る）。保存は save-on-hide + 可視時終了保存。
+現行は設定起動中にメインの `alwaysOnTop=false`、終了検知で復元（`get_webview_window("main")` キー）。egui 窓では no-op ゆえ検索窓が設定 UI を覆う（codex #3）。フラグ ON のとき `get_window("main")` に対し同制御を適用する。
 
 **Files:**
-- Modify: `src-tauri/src/egui_shell/mod.rs`（`hide_main` に位置保存を追加）
-- Modify: `src-tauri/src/main.rs`（`setup_exit_listener` に egui 可視時の位置保存）
+- Modify: 設定 launch/exit 監視箇所（`commands/window.rs` の `open_settings` 系 + 設定プロセス終了監視。`get_webview_window("main")` を使う `commands/window.rs:91-94, 131-134`）
 
 **Interfaces:**
-- Consumes: `position_on_target_monitor`（復元・共有列内）・既存の位置保存経路（`commands::save_search_placement` が使う `window.bin` 書き込み。相対座標算出は `monitor.rs`）。
-- Produces: なし（副作用）。
+- Consumes: `get_window("main")`・`set_always_on_top`。
 
-- [ ] **Step 1: 位置保存経路を確認しヘルパーを作る**
+- [ ] **Step 1: 現行の alwaysOnTop 制御箇所を特定**
 
-復元と対称の保存経路を確認する。復元は `snotra_core::window_data::load_search_placement()`（`position_on_target_monitor:355` で使用）。保存は対の `window_data::save_search_placement(placement)`（`commands/window.rs` の `commands::save_search_placement` が現在 `get_webview_window("main")` から相対座標を出して呼ぶ）。その相対座標算出（現在の物理位置 − ターゲットモニター作業領域原点。`monitor.rs` のモニター決定 + 原点）を **`&tauri::Window` で一般化**し、`egui_shell` に `pub(crate) fn save_placement_relative(app: &AppHandle, window: &tauri::Window)` を作る（`window.outer_position()`/`monitor.rs` の作業領域原点 → `window_data::save_search_placement` へ）。既存 `commands::save_search_placement` のロジックを共有できるなら関数抽出で DRY 化（`/dry-check`）。
+`commands/window.rs` の設定起動（`always_on_top(false)` 相当）と終了監視（`always_on_top(true)` 復元）を読む。`get_webview_window("main")` で窓を取り `set_always_on_top` している 2 箇所（launch 時 false・exit 検知時 true）。
 
-Run: `cargo build -p snotra`（型が合うこと）。`window_data::save_search_placement` のシグネチャ（引数の placement 型）を `commands/window.rs` で確認してから呼ぶ。
+- [ ] **Step 2: フラグ ON で `get_window("main")` に同制御を並置**
 
-- [ ] **Step 2: `hide_main` に save-on-hide を足す**
-
-`egui_shell::hide_main` の `window.hide()` の**前**に、可視中の現在位置を保存する:
+各箇所を「フラグ ON なら `get_window("main")`、OFF なら既存 `get_webview_window("main")`」で分岐（または `get_window` は両窓を返すなら共通化＝Task 3 で確認済みの挙動に合わせる）。`set_always_on_top(false/true)` を egui 窓へ適用。
 
 ```rust
-pub(crate) fn hide_main(app: &AppHandle, backend: MainBackend) {
-    if let Some(window) = app.get_window("main") {
-        if backend == MainBackend::Egui {
-            save_placement_relative(app, &window); // save-on-hide（JS チョークポイントが無いため）
-        }
-        let _ = window.hide();
-    }
-    // ... 既存（main_visible=false・post_hide）
-}
+    let window = if crate::trace::env_flag("SNOTRA_EGUI_MAIN") {
+        app.get_window("main")
+    } else {
+        app.get_webview_window("main").map(|w| /* &Window 化 or 既存のまま set */ )
+    };
+    // 既存が WebviewWindow 前提なら、egui 分岐だけ get_window で set_always_on_top する薄い分岐に留める。
 ```
 
-- [ ] **Step 3: `setup_exit_listener` に可視時終了保存を足す**
+mini-gate: 既存コードが `WebviewWindow` の `set_always_on_top` を呼ぶ形なら、egui 分岐は `get_window("main").set_always_on_top(...)` を別途呼ぶ最小差分にする（WebView2 側の既存呼びは不変）。
 
-`src-tauri/src/main.rs:867` の `setup_exit_listener` 内、history/icon flush と並べて、egui かつ可視なら位置保存:
+- [ ] **Step 3: 設定を開いても egui 窓が最前面を明け渡すことを確認（§8.5）**
 
-```rust
-        if crate::trace::env_flag("SNOTRA_EGUI_MAIN")
-            && handle_for_exit.try_state::<AppState>()
-                .map(|s| s.main_visible.load(Ordering::SeqCst)).unwrap_or(false)
-            && let Some(window) = handle_for_exit.get_window("main")
-        {
-            egui_shell::save_placement_relative(&handle_for_exit, &window);
-        }
-```
+Run（フラグ ON）: `$env:SNOTRA_EGUI_MAIN="1"; cargo run -p snotra` → 設定を開く（トレイ「設定」等）
+Expected: 設定 UI が検索窓に覆われず操作できる。設定終了後にメインが `alwaysOnTop=true` へ復元。
 
-- [ ] **Step 4: 位置の復元・保存を確認する**
-
-Run（PowerShell）:
-```
-$env:SNOTRA_EGUI_MAIN="1"; cargo run -p snotra
-```
-- ウィンドウをドラッグ移動（検索バー余白）→ Alt+Q で非表示 → Alt+Q で再表示 → **同じ位置に復元**
-- マルチモニター: カーソルを別モニターへ → Alt+Q → `follow_cursor_monitor=true` ならそのモニターの作業領域内に出る（画面外に出ない = クランプ）
-- 保存位置なしの初回相当 → ターゲットモニター中央
-
-Expected: SPEC §8.2 どおり。位置が画面外へ出ない。
-
-- [ ] **Step 5: コミット + PR**
+- [ ] **Step 4: コミット + PR**
 
 ```
 git add src-tauri/src/
-git commit -F <tmpfile>   # "feat(#532): SU2 位置永続（復元 + save-on-hide + 可視時終了保存）"
+git commit -F <tmpfile>   # "feat(#532): SU2 設定起動中の egui 窓 alwaysOnTop 解除（SPEC §8.5・codex #3）"
 git push -u origin HEAD && gh pr create --fill
 ```
 
-（PR 本文は SU2 の受け入れ条件チェックリスト。**マージ前に** `gh pr view <PR> --json closingIssuesReferences` で #532 を誤 close しないか確認＝ルート `CLAUDE.md` の squash マージ手順。#532 は親 issue ゆえ SU2 単独では閉じない。）
+（PR 本文は SU2 受け入れ条件チェックリスト。**マージ前に** `gh pr view <PR> --json closingIssuesReferences` で #532 誤 close を確認＝ルート `CLAUDE.md` squash 手順。#532 は親ゆえ SU2 単独では閉じない。）
 
 ---
 
 ## Self-Review（spec 照合）
 
-- **spec §backend seam（3 フック）** → Task 4（`pre_show`/`post_show`/`post_hide`・WV2 leaf 逐語移動）。✓
-- **spec §状態機械（plan_hotkey/plan_ui_action・合流点）** → Task 1（純粋核）+ Task 6（controller 適用）。✓
-- **spec §blur 自動非表示（100ms・ゲート・サイドカーガード・policy を view 側）** → Task 7。✓
-- **spec §フラグと生成（windows:[]・build_webview2_window・egui create・label "main"）** → Task 2（G0）+ Task 5。✓
-- **spec §placeholder view + font-first** → Task 3。✓
-- **spec §位置永続（復元・save-on-hide・可視時終了保存）** → Task 8。✓
-- **spec §再利用部品（残留 Alt #558・monitor.rs・window.bin）** → Task 4（Alt）+ Task 8（位置）。✓
-- **spec 検証ゲート G0/G1/G2/G3/G4** → G0=Task 2 / G1=Task 4 / G2=Task 5(partial)+Task 6(full) / G3=Task 7 / G4=Task 6。✓
-- **spec §受け入れ条件 1-6** → 全 Task を通じて。SPEC §8 一致=Task 5-8 のスモーク、flag OFF 不変=G0+G1、純関数=Task 1、policy が src-tauri=Task 7、font-first=Task 3、clippy/test/子孫0=各境界。✓
+- **spec §フラグと生成（config_mut 除去・create &mut App・tauri.conf.json 不変）** → Task 3（+ codex #1/#2）。✓
+- **spec §egui show/hide（show_egui_main/hide_egui_main・全 hide 外部化・main_visible のみ）** → Task 4（+ codex #4/#7）。✓
+- **spec §状態機械（plan_hotkey・view→emit→listener 合流）** → Task 1 + Task 4 + Task 5。✓
+- **spec §blur（100ms・ゲート・サイドカーガード・stale リセット・policy を view）** → Task 5（+ codex #8）。✓
+- **spec §8.5 alwaysOnTop（codex #3）** → Task 6。✓
+- **spec §placeholder + font-first** → Task 2。✓
+- **spec §位置永続（復元 show 内・save-on-hide・一般化）** → Task 4。デバウンス保存は残余（記録済み・codex #10）。
+- **spec 検証ゲート G1/G2/G3/G4** → G1/G4=Task 3・G2/G3=Task 4・blur=Task 5。✓
+- **spec §受け入れ条件 1-6** → 全 Task。flag OFF 完全不変=G1、plan_hotkey 純関数=Task 1、blur policy が view=Task 5、font-first=Task 2、子孫 0=G4。✓
+- **spec 否定の知識（seam/controller/静的空化/RuntimeFrame 直 hide の却下）** → 本計画は簡素化版で seam を持たない。✓
 
-**未解決の実装時確認（各タスクの mini-gate で潰す・fabrication を避けた箇所）:**
-- Task 4 Step 1: `WebviewWindow` → `&tauri::Window` の手段（`as_ref().window()` / `get_window`）。
-- Task 5 Step 1: `Window::builder` の `skip_taskbar`/`always_on_top` メソッド名（無ければ setup 後 setter）。
-- Task 5 Step 2: `RuntimeError` → setup エラー型の変換。
-- Task 7 Step 1: `auto_hide_on_focus_lost` の config.rs 既定値。
-- Task 8 Step 1: `window.bin` 保存関数の所在（`snotra-core` placement or `monitor.rs`）と `&tauri::Window` 一般化。
+**実装時 mini-gate（fabrication を避けた箇所）:**
+- Task 3: `Window::builder` の `skip_taskbar`/`always_on_top` 有無・`RuntimeError` From・`config_mut().app.windows` の label フィールド名。
+- Task 4: `position_on_target_monitor` 一般化での呼び出し元互換（`&WebviewWindow→&Window`）・`save_search_placement` シグネチャ・`get_window("main")` が egui 窓を返す（Task 3 で確認）。
+- Task 5: `auto_hide_on_focus_lost` の config.rs 既定値・`Emitter`/`Manager` トレイト import。
+- Task 6: 既存 alwaysOnTop 制御の実型（WebviewWindow）と egui 分岐の最小差分。

--- a/docs/superpowers/plans/2026-07-22-su2-window-shell.md
+++ b/docs/superpowers/plans/2026-07-22-su2-window-shell.md
@@ -1,0 +1,978 @@
+# SU2: ウィンドウシェル + 状態機械 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 製品 `src-tauri` のメインウィンドウに、WebView2 と並行して egui/softbuffer 経路を env フラグ選択で立ち上げる外殻を作る。Alt+Q 表示/非表示・blur 自動非表示・フォーカス列・残留 Alt 解除・位置永続・起動時/初回フローを SPEC §8 と一致させ、フラグ OFF で WebView2 挙動を不変に保つ。
+
+**Architecture:** 両ウィンドウが同じ `tauri::Window` 抽象（`.show()`/`.hide()`/`.set_focus()`/`.hwnd()`）を共有するため、show/hide の Win32 骨格を 1 本の共有オーケストレーション（`show_main`/`hide_main`）に集約し、renderer(resume/suspend)+frontend(emit) の副作用だけを `MainBackend::{WebView2, Egui}` の薄い 3 フック（`pre_show`/`post_show`/`post_hide`）へ逃がす。ホットキー分岐と UI コマンド適用は純関数 `plan_hotkey`/`plan_ui_action` として `egui_shell/lifecycle.rs` に置き、冪等性と show 進行中 Hide の Defer をユニットテストで固定する。宣言窓（`tauri.conf.json`）を廃し両経路とも setup で programmatic 生成へ寄せ、フラグ ON で egui が WebView2 を真に置き換える（子孫 0）。
+
+**Tech Stack:** Rust 2024 / egui 0.35 / `snotra-egui-runtime`（SU1・softbuffer）/ tauri v2・tauri-runtime-wry（unstable）/ windows 0.62 / Windows・PowerShell。
+
+## Global Constraints
+
+- **`main` へ直接コミットしない**（現在ブランチ `docs/532-su2-window-shell-spec`。実装用に `feat/532-su2-window-shell` を切る）。コミットメッセージは一時ファイル `git commit -F <tmpfile>`。bash HEREDOC 不可。パス区切りは `/`。
+- **フラグ**: `SNOTRA_EGUI_MAIN=1`（env・setup で 1 回読む）。判定は既存 `crate::trace::env_flag("SNOTRA_EGUI_MAIN")`（`src-tauri/src/trace.rs:20`）を使う。
+- **窓生成**: `tauri.conf.json` の `app.windows` を `[]` にする。両経路とも setup で programmatic 生成。ラベルは両方 `"main"`。生成は **setup フェーズ限定**（`WebviewWindowBuilder::build()` はメッセージポンプ進行を要求・`src-tauri/CLAUDE.md`）。
+- **2 つの visible を混同しない**: `AppState.main_visible: AtomicBool`（`state.rs:17`・policy＝`plan_hotkey` 入力・Standby/SearchVisible 判定）と runtime 内 `visible`（SU1 の描画ゲート・不変条件⑥）は別物。
+- **backend seam**: WebView2 の `resume_webview`/`suspend_and_trim_after_hide`/`emit(window-shown|hidden)` を `MainBackend::WebView2` フックへ**逐語移動**。順序制約（resume を show の前後 2 回・emit を suspend より先・FIFO 直列化＝`src-tauri/CLAUDE.md`「TrySuspend / Resume パターン」）を温存。egui フックは `pre_show`/`post_hide` 空・`post_show` は ime_control のみ。
+- **純粋核**: `plan_hotkey`/`plan_ui_action` は Win32 非依存・ユニットテスト。冪等性（`Visible+Show→Refocus`・`Suspended+Hide→Ignore`）と Defer（`Recreating+Hide→Defer`）を固定。
+- **focus 観測**: view が `ctx.input(|i| i.focused)` で観測（`snotra-egui-mvp/src/main.rs:174` で実証）。blur policy（100ms 猶予・`auto_hide_on_focus_lost` ゲート・`SettingsProcessState` 非起動ガード）は **src-tauri の view 側**に置く。`snotra-egui-runtime` の公開 API を拡張しない。
+- **フォント**: `SearchWindowView::setup` は `jp_font` を Proportional/Monospace の **index 0**（`insert(0, ...)`）。`FONT_PATH` 候補は `C:/Windows/Fonts/YuGothM.ttc` 他。`push`（末尾）にすると #399/#579 のベースラインずれ再発。
+- **位置永続**: 復元は show 経路で `position_on_target_monitor`（順序: サイズ確定 → 位置 → show）。保存は save-on-hide + 可視時終了保存。SPEC §8.2 の相対物理座標・`follow_cursor_monitor`・クランプ・中央フォールバックを踏襲。
+- **Win32 ヘルパー再利用**: `is_alt_pressed()`（`main.rs:90`）・`wait_alt_release_or_timeout()`（`main.rs:106`）・`send_alt_key_up()`（`main.rs:131`）。残留 Alt 解除は **focus 確定後かつ物理 Alt 解放後にのみ**注入（#558）。
+- **子孫 0**: フラグ ON で `msedgewebview2.exe` が 0 件（egui が置き換え）。
+- **各タスク境界で** `cargo clippy -p snotra --all-targets` と `cargo test -p snotra` が緑。PostToolUse hook が `*.rs` 編集時に自動実行する（沈黙=合格・失敗時のみ会話に届く）が、各タスクの Step でも明示実行する。
+
+## File Structure
+
+- `src-tauri/src/egui_shell/mod.rs`（新規）: `MainBackend` enum・`create()`（`Window::builder`+`install`+`attach`）・`show_main`/`hide_main` 共有オーケストレーション・3 フック・controller（合流点）。
+- `src-tauri/src/egui_shell/lifecycle.rs`（新規・純粋核）: `HotkeyPlan`/`plan_hotkey`・`LifecycleState`/`LifecycleEvent`/`transition`・`HostCommand`/`UiAction`/`plan_ui_action`。Win32 非依存。
+- `src-tauri/src/egui_shell/view.rs`（新規）: `SearchWindowView: EguiView`（placeholder）。`setup` で font-first・`update` で focus 観測（自動非表示の起点）。
+- `src-tauri/src/main.rs`（改修）: setup 本体に窓生成 flag 分岐 + `build_webview2_window`（新規）。`show_and_focus_main` を `&tauri::Window` へ一般化。WebView2 leaf をフックへ移動。`setup_hotkey_listener`/`setup_startup_display` に flag 分岐。
+- `src-tauri/tauri.conf.json`（改修）: `app.windows = []`。
+- `src-tauri/Cargo.toml`（改修）: `snotra-egui-runtime` path-dep 追加。
+
+---
+
+### Task 1: 依存追加 + egui_shell モジュール骨格 + 純粋核 lifecycle.rs
+
+撤去済み spike（`soft_host_main.rs:130-207` / テスト `1597-1649`・commit 7558cc8）から純粋核を移植する。Win32 非依存ゆえ単独でコンパイル・ユニットテストできる。
+
+**Files:**
+- Modify: `src-tauri/Cargo.toml`（`[dependencies]` に 1 行）
+- Modify: `src-tauri/src/main.rs`（`mod egui_shell;` を 1 行追加）
+- Create: `src-tauri/src/egui_shell/mod.rs`
+- Create: `src-tauri/src/egui_shell/lifecycle.rs`
+
+**Interfaces:**
+- Consumes: なし（純粋・std のみ）。
+- Produces: `plan_hotkey(visible: bool, alt_pressed: bool) -> HotkeyPlan`／`plan_ui_action(state: LifecycleState, command: &HostCommand) -> UiAction`／`transition(state: LifecycleState, event: LifecycleEvent) -> Result<LifecycleState, String>`／enum `HotkeyPlan{HideNow,ShowAfterAltRelease,ShowNow}`・`LifecycleState{Visible,Suspended,Recreating,Exiting}`・`LifecycleEvent{Hide,Show,FramePresented,Exit}`・`HostCommand{Show{hotkey_started:Instant},Hide}`・`UiAction{Show,Hide,Refocus,Defer,Ignore}`。Task 5/6 の controller が消費。
+
+- [ ] **Step 1: Cargo 依存を追加**
+
+`src-tauri/Cargo.toml` の `[dependencies]` に追加:
+
+```toml
+snotra-egui-runtime = { path = "../snotra-egui-runtime" }
+```
+
+- [ ] **Step 2: モジュールを登録**
+
+`src-tauri/src/main.rs` の他の `mod` 宣言群（`mod trace;` 等の近く）に追加:
+
+```rust
+mod egui_shell;
+```
+
+`src-tauri/src/egui_shell/mod.rs` を作成（Task 4 以降で拡張。今は純粋核の入れ物）:
+
+```rust
+//! egui/softbuffer メインウィンドウの外殻。WebView2 と並行する window 生成・
+//! show/hide 状態機械・blur 自動非表示・位置永続を持つ（#532 SU2）。
+mod lifecycle;
+```
+
+- [ ] **Step 3: 失敗するテストを書く（純粋核 + テスト）**
+
+`src-tauri/src/egui_shell/lifecycle.rs` を作成（spike から逐語移植・製品用にコメント調整）:
+
+```rust
+//! Alt+Q ホットキー分岐と UI コマンド適用の純粋な決定核（Win32 非依存）。
+//! 冪等性（表示中+Show / 非表示中+Hide）と show 進行中に届いた Hide の繰り延べを
+//! ここに一元化する。SU1 spike（soft_host_main.rs）で実証済み・#532 SU2 で製品へ移植。
+
+use std::time::Instant;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum HotkeyPlan {
+    HideNow,
+    ShowAfterAltRelease,
+    ShowNow,
+}
+
+/// Alt+Q 押下時の分岐。表示中なら即 hide、非表示中は Alt が押されている限り
+/// 解放を待ってから show する（製品 WebView2 経路と同じ意味論）。
+pub(crate) fn plan_hotkey(visible: bool, alt_pressed: bool) -> HotkeyPlan {
+    if visible {
+        HotkeyPlan::HideNow
+    } else if alt_pressed {
+        HotkeyPlan::ShowAfterAltRelease
+    } else {
+        HotkeyPlan::ShowNow
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LifecycleState {
+    Visible,
+    Suspended,
+    /// show 済みで最初のフレーム提示を待っている。
+    Recreating,
+    Exiting,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LifecycleEvent {
+    Hide,
+    Show,
+    FramePresented,
+    Exit,
+}
+
+pub(crate) fn transition(
+    state: LifecycleState,
+    event: LifecycleEvent,
+) -> Result<LifecycleState, String> {
+    match (state, event) {
+        (LifecycleState::Visible, LifecycleEvent::Hide) => Ok(LifecycleState::Suspended),
+        (LifecycleState::Suspended, LifecycleEvent::Show) => Ok(LifecycleState::Recreating),
+        (LifecycleState::Recreating, LifecycleEvent::FramePresented) => Ok(LifecycleState::Visible),
+        (LifecycleState::Visible, LifecycleEvent::Exit)
+        | (LifecycleState::Suspended, LifecycleEvent::Exit) => Ok(LifecycleState::Exiting),
+        _ => Err(format!("invalid lifecycle transition: {state:?} + {event:?}")),
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum HostCommand {
+    Show { hotkey_started: Instant },
+    Hide,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum UiAction {
+    Show,
+    Hide,
+    Refocus,
+    /// show 完了（FramePresented）後まで Hide を繰り延べる。
+    Defer,
+    Ignore,
+}
+
+/// ホストコマンドを現在の lifecycle 状態へ適用する計画。冪等性
+/// （Visible+Show / Suspended+Hide）と、show 進行中に届いた Hide の繰り延べを決める。
+pub(crate) fn plan_ui_action(state: LifecycleState, command: &HostCommand) -> UiAction {
+    match (state, command) {
+        (LifecycleState::Visible, HostCommand::Show { .. }) => UiAction::Refocus,
+        (LifecycleState::Visible, HostCommand::Hide) => UiAction::Hide,
+        (LifecycleState::Suspended, HostCommand::Show { .. }) => UiAction::Show,
+        (LifecycleState::Suspended, HostCommand::Hide) => UiAction::Ignore,
+        (LifecycleState::Recreating, HostCommand::Show { .. }) => UiAction::Ignore,
+        (LifecycleState::Recreating, HostCommand::Hide) => UiAction::Defer,
+        (LifecycleState::Exiting, _) => UiAction::Ignore,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        HostCommand, HotkeyPlan, LifecycleEvent, LifecycleState, UiAction, plan_hotkey,
+        plan_ui_action, transition,
+    };
+    use std::time::Instant;
+
+    fn show_command() -> HostCommand {
+        HostCommand::Show { hotkey_started: Instant::now() }
+    }
+
+    #[test]
+    fn hotkey_branches_match_product_semantics() {
+        assert_eq!(plan_hotkey(true, false), HotkeyPlan::HideNow);
+        assert_eq!(plan_hotkey(true, true), HotkeyPlan::HideNow);
+        assert_eq!(plan_hotkey(false, true), HotkeyPlan::ShowAfterAltRelease);
+        assert_eq!(plan_hotkey(false, false), HotkeyPlan::ShowNow);
+    }
+
+    #[test]
+    fn ui_commands_are_idempotent_and_defer_hide_while_showing() {
+        assert_eq!(plan_ui_action(LifecycleState::Visible, &show_command()), UiAction::Refocus);
+        assert_eq!(plan_ui_action(LifecycleState::Suspended, &HostCommand::Hide), UiAction::Ignore);
+        assert_eq!(plan_ui_action(LifecycleState::Suspended, &show_command()), UiAction::Show);
+        assert_eq!(plan_ui_action(LifecycleState::Visible, &HostCommand::Hide), UiAction::Hide);
+        assert_eq!(plan_ui_action(LifecycleState::Recreating, &HostCommand::Hide), UiAction::Defer);
+        assert_eq!(plan_ui_action(LifecycleState::Recreating, &show_command()), UiAction::Ignore);
+        assert_eq!(plan_ui_action(LifecycleState::Exiting, &show_command()), UiAction::Ignore);
+    }
+
+    #[test]
+    fn lifecycle_requires_frame_before_visible_and_allows_hidden_exit() {
+        let showing = transition(LifecycleState::Suspended, LifecycleEvent::Show).unwrap();
+        assert_eq!(showing, LifecycleState::Recreating);
+        let visible = transition(showing, LifecycleEvent::FramePresented).unwrap();
+        assert_eq!(visible, LifecycleState::Visible);
+        assert!(transition(LifecycleState::Suspended, LifecycleEvent::Hide).is_err());
+    }
+}
+```
+
+- [ ] **Step 4: テストが通ることを確認する**
+
+Run: `cargo test -p snotra egui_shell::lifecycle`
+Expected: 3 tests（`hotkey_branches_match_product_semantics` / `ui_commands_are_idempotent_and_defer_hide_while_showing` / `lifecycle_requires_frame_before_visible_and_allows_hidden_exit`）PASS。
+
+注: `pub(crate)` の未使用シンボルは Task 5/6 で消費されるまで dead-code 警告が出る。clippy を止めないため、`mod.rs` の `mod lifecycle;` 直後にこの時点だけ `#[allow(dead_code)]` を付け、**Task 6 完了時に除去する**（除去を Task 6 Step の最後に明記済み）。
+
+- [ ] **Step 5: コミット**
+
+```
+git add src-tauri/Cargo.toml src-tauri/src/main.rs src-tauri/src/egui_shell/
+git commit -F <tmpfile>   # "feat(#532): SU2 純粋核 plan_hotkey/plan_ui_action を src-tauri へ移植"
+```
+
+---
+
+### Task 2: G0 — 宣言窓を programmatic 生成へ変換（flag OFF byte-identical）
+
+`tauri.conf.json` の宣言窓を廃し、setup で `WebviewWindowBuilder` により逐語再現する。**このタスクではまだ flag 分岐を入れない**（純粋に宣言→programmatic の等価変換だけを接地し、回帰が無いことを確定する = G0）。
+
+**Files:**
+- Modify: `src-tauri/tauri.conf.json:14-28`（`windows` 配列を空に）
+- Modify: `src-tauri/src/main.rs`（`build_webview2_window` 新規 + setup 本体で呼ぶ）
+
+**Interfaces:**
+- Consumes: なし。
+- Produces: `fn build_webview2_window(app: &tauri::AppHandle) -> tauri::Result<()>`。Task 5 で flag 分岐の else 側に置かれる。
+
+- [ ] **Step 1: 宣言窓を空にする**
+
+`src-tauri/tauri.conf.json` の `app.windows` を空配列にする（`app.security` / `bundle` / `plugins` は不変）:
+
+```json
+  "app": {
+    "windows": [],
+    "security": {
+      "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:"
+    }
+  },
+```
+
+- [ ] **Step 2: `build_webview2_window` を書く（宣言窓 10 フィールドを逐語再現）**
+
+`src-tauri/src/main.rs` に追加（`use tauri::{WebviewUrl, WebviewWindowBuilder};` を先頭 use 群へ）:
+
+```rust
+/// 旧 tauri.conf.json の宣言窓（label "main"）を programmatic に再現する。
+/// フラグ OFF（WebView2 経路）の窓生成。宣言時と挙動一致（G0）。
+fn build_webview2_window(app: &tauri::AppHandle) -> tauri::Result<()> {
+    WebviewWindowBuilder::new(app, "main", WebviewUrl::App("main.html".into()))
+        .title("Snotra")
+        .inner_size(600.0, 52.0)
+        .visible(false)
+        .decorations(false)
+        .skip_taskbar(true)
+        .always_on_top(true)
+        .resizable(false)
+        .center()
+        .build()?;
+    Ok(())
+}
+```
+
+- [ ] **Step 3: setup 本体の先頭で窓を生成する**
+
+`src-tauri/src/main.rs` の `.setup(move |app| {` 直後、`let app_handle = app.handle().clone();`（現 633 行）の**直後**に追加（`setup_window_geometry` 等の既存呼び出しより前・宣言窓が消えた分をここで作る）:
+
+```rust
+    // 宣言窓を廃し programmatic 生成へ変換（#532 SU2 G0）。フラグ分岐は Task 5。
+    build_webview2_window(&app_handle)?;
+```
+
+- [ ] **Step 4: フラグ OFF で回帰が無いことを確認する（G0）**
+
+Run（PowerShell・`SNOTRA_EGUI_MAIN` 未設定）:
+```
+npm run smoke:startup
+npm run e2e:tauri
+```
+Expected: 両方 PASS（宣言時と同じ起動・ウィンドウ挙動）。`app.get_webview_window("main")` が従来どおり取れ、`main.html` がロードされる。**FAIL したら STOP** — programmatic 再現が宣言窓と非等価。10 フィールドの差分（特に `center`/`skip_taskbar`/`always_on_top`）を洗い直す。
+
+- [ ] **Step 5: コミット**
+
+```
+git add src-tauri/tauri.conf.json src-tauri/src/main.rs
+git commit -F <tmpfile>   # "feat(#532): SU2 G0 宣言窓を programmatic 生成へ変換（flag OFF 不変）"
+```
+
+---
+
+### Task 3: placeholder view（SearchWindowView）+ font-first カナリア
+
+egui window に描く最小 view を作る。SU1 申し送りの font-first（`insert(0, jp_font)`）を機構化し、実 `setup` を駆動するテストで固定する。本体（検索・結果・モード）は SU3。
+
+**Files:**
+- Create: `src-tauri/src/egui_shell/view.rs`
+- Modify: `src-tauri/src/egui_shell/mod.rs`（`mod view;`）
+
+**Interfaces:**
+- Consumes: `snotra_egui_runtime::{EguiView, RuntimeFrame}`・`egui`。
+- Produces: `struct SearchWindowView`（`SearchWindowView::new() -> Self`・`impl EguiView`）。`fn japanese_font_definitions(bytes: &'static [u8]) -> egui::FontDefinitions`（テスト対象）。Task 5 の `create()` が `attach` に渡す。
+
+- [ ] **Step 1: 失敗するテストを書く（view + font-first テスト）**
+
+`src-tauri/src/egui_shell/view.rs` を作成（`japanese_font_definitions` は probe `snotra-egui-mvp/src/main.rs:635-653` から移植・テストは `:798-811` から移植）:
+
+```rust
+//! egui メインウィンドウの placeholder view（#532 SU2）。show/hide/focus/位置を
+//! 視覚検証できる最小 chrome を描く。検索本体は SU3。font-first（jp_font を index 0）は
+//! SU1 申し送りの義務——push（末尾）だと softbuffer で #399/#579 のベースラインずれ再発。
+
+use std::sync::OnceLock;
+
+use snotra_egui_runtime::{EguiView, RuntimeFrame};
+
+static JP_FONT_BYTES: OnceLock<Box<[u8]>> = OnceLock::new();
+
+/// `jp_font` を Proportional/Monospace の先頭（`insert(0, ...)`）へ差し込んだ
+/// `FontDefinitions` を組む純粋部分。`push`（末尾）だと Latin=egui既定/CJK=Yu Gothic の
+/// 2フォントに分かれ、softbuffer の被覆AA無しラスタが vertical metrics 差を整数pxへ
+/// 丸めて混在行のベースラインをずらす（#399/#579）。
+fn japanese_font_definitions(bytes: &'static [u8]) -> egui::FontDefinitions {
+    let mut fonts = egui::FontDefinitions::default();
+    let mut font = egui::FontData::from_static(bytes);
+    font.tweak = egui::FontTweak { scale: 1.0, y_offset_factor: 0.3, y_offset: 0.0, ..Default::default() };
+    fonts.font_data.insert("jp_font".to_owned(), font.into());
+    for family in [egui::FontFamily::Proportional, egui::FontFamily::Monospace] {
+        fonts.families.entry(family).or_default().insert(0, "jp_font".to_owned());
+    }
+    fonts
+}
+
+fn configure_japanese_font(context: &egui::Context) {
+    let candidates = [
+        "C:/Windows/Fonts/YuGothM.ttc",
+        "C:/Windows/Fonts/yugothic.ttf",
+        "C:/Windows/Fonts/msgothic.ttc",
+        "C:/Windows/Fonts/meiryo.ttc",
+    ];
+    if JP_FONT_BYTES.get().is_none() {
+        for path in candidates {
+            if let Ok(bytes) = std::fs::read(path) {
+                let _ = JP_FONT_BYTES.set(bytes.into_boxed_slice());
+                break;
+            }
+        }
+    }
+    if let Some(bytes) = JP_FONT_BYTES.get() {
+        // OnceLock はプロセス寿命ゆえ &'static へ延命できる（再表示ごとのリークを作らない）。
+        let static_bytes: &'static [u8] = unsafe { std::mem::transmute::<&[u8], &'static [u8]>(bytes) };
+        context.set_fonts(japanese_font_definitions(static_bytes));
+    }
+}
+
+/// SU2 の placeholder view。検索バー枠と最小テキストだけを描く。
+pub(crate) struct SearchWindowView {
+    // Task 7 で focus 観測 + blur policy 用の状態（was_focused / unfocus_at）を足す。
+}
+
+impl SearchWindowView {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+}
+
+impl EguiView for SearchWindowView {
+    fn setup(&mut self, context: &egui::Context) {
+        configure_japanese_font(context);
+    }
+
+    fn update(&mut self, ui: &mut egui::Ui, _frame: &mut RuntimeFrame) {
+        // placeholder: SU3 が検索 UI で置き換える。混在行（Latin+CJK）を出して
+        // font-first の視覚検証を可能にする。
+        ui.label("Snotra — 検索ウィンドウ（C:/Program Files/example）");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::japanese_font_definitions;
+
+    #[test]
+    fn jp_font_is_registered_at_index_zero_for_both_families() {
+        let dummy: &'static [u8] = &[0u8; 4];
+        let fonts = japanese_font_definitions(dummy);
+        for family in [egui::FontFamily::Proportional, egui::FontFamily::Monospace] {
+            let list = fonts.families.get(&family).expect("family present");
+            assert_eq!(
+                list.first().map(String::as_str),
+                Some("jp_font"),
+                "jp_font must be index 0 for {family:?}（push=末尾だと #579 再発）"
+            );
+        }
+    }
+}
+```
+
+`src-tauri/src/egui_shell/mod.rs` に追加:
+
+```rust
+mod view;
+```
+
+- [ ] **Step 2: テストが通ることを確認する**
+
+Run: `cargo test -p snotra egui_shell::view`
+Expected: `jp_font_is_registered_at_index_zero_for_both_families` PASS。
+
+注: `SearchWindowView` は Task 5 で `attach` に渡るまで未使用ゆえ、Task 1 で付けた `#[allow(dead_code)]` の傘に入れる（`view` mod も同様）。
+
+- [ ] **Step 3: コミット**
+
+```
+git add src-tauri/src/egui_shell/
+git commit -F <tmpfile>   # "feat(#532): SU2 placeholder SearchWindowView + font-first カナリア"
+```
+
+---
+
+### Task 4: MainBackend seam + 共有 show_main/hide_main（WebView2 leaf 抽出・G1）
+
+show/hide の Win32 骨格を共有関数へ集約し、WebView2 の renderer/frontend 副作用をフックへ逐語移動する。**このタスクは WebView2 側だけを触り**（`Egui` variant は定義するが未使用）、フラグ OFF が不変であることを接地する（G1）。
+
+**Files:**
+- Modify: `src-tauri/src/egui_shell/mod.rs`（`MainBackend`・フック・`show_main`/`hide_main`）
+- Modify: `src-tauri/src/main.rs`（`show_and_focus_main` を `&tauri::Window` へ一般化 → `show_and_focus_window`。`show_main_and_emit` を `show_main` 経由へ。`resume_webview`/`suspend_and_trim_after_hide`/`emit` をフックから呼ぶ）
+
+**Interfaces:**
+- Consumes: `crate::{resume_webview, suspend_and_trim_after_hide, apply_ime_control, position_on_target_monitor, show_and_focus_window}`（`show_and_focus_window` は本タスクで一般化）。
+- Produces: `enum MainBackend { WebView2, Egui }`・`fn show_main(app: &AppHandle, backend: MainBackend, t0: Instant)`・`fn hide_main(app: &AppHandle, backend: MainBackend)`。Task 5/6 が消費。
+
+- [ ] **Step 1: WebviewWindow から &tauri::Window を得る手段を 1 行で確定（mini-gate）**
+
+共有 show 列は `&tauri::Window` で回す（egui/WebView2 両対応）。WebView2 側で `WebviewWindow` から `Window` を得る手段を確定する。`src-tauri/src/main.rs` の任意関数内に一時的に置いてコンパイル確認:
+
+```rust
+// 確認用（このあと削除）: WebviewWindow -> &Window
+if let Some(wv) = app_handle.get_webview_window("main") {
+    let _w: &tauri::Window = wv.as_ref().window();
+}
+```
+
+Run: `cargo build -p snotra`
+Expected: コンパイル成功。**失敗したら** `wv.as_ref()` / `wv.window()` / `app.get_window("main")` の別手段を試し、通る 1 行を採用してから次へ（確認コードは削除）。以降のステップはこの確定手段を `webview_window_as_window(&wv)` 相当として使う。
+
+- [ ] **Step 2: `show_and_focus_main` を `&tauri::Window` へ一般化**
+
+`src-tauri/src/main.rs:397` の `show_and_focus_main(app_handle, main: &tauri::WebviewWindow, t0)` を `show_and_focus_window(app_handle: &AppHandle, window: &tauri::Window, t0: Instant)` へ改名し、引数型を `&tauri::Window` に変える。本体（`show()`/`main_visible=true`/`set_focus()`/WM_NULL 同期/残留 Alt: `is_alt_pressed()` skip or `send_alt_key_up()`）はそのまま（すべて `&tauri::Window` で動く）。`.hwnd()` は両型にある。
+
+呼び出し元 `show_main_and_emit`（`main.rs:499`）は Step 4 で `show_main` へ移すため一旦保留。
+
+- [ ] **Step 3: `MainBackend` とフックを書く**
+
+`src-tauri/src/egui_shell/mod.rs` に追加:
+
+```rust
+use std::time::Instant;
+use tauri::{AppHandle, Manager};
+
+/// メインウィンドウの renderer+frontend backend。show/hide の Win32 骨格は共有し、
+/// backend 固有の副作用（WV2: resume/suspend/emit、egui: なし）だけをフックへ逃がす。
+/// SU7 で WebView2 variant を削除すれば egui が素で残る。
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum MainBackend {
+    WebView2,
+    Egui,
+}
+
+impl MainBackend {
+    /// show の Win32 列（show/focus/位置）より前。WV2 はレンダラー resume。
+    fn pre_show(self, app: &AppHandle) {
+        if self == MainBackend::WebView2
+            && let Some(wv) = app.get_webview_window("main")
+        {
+            crate::resume_webview(&wv);
+        }
+    }
+
+    /// show の Win32 列の後。WV2 は resume 再適用 + ime_control + emit("window-shown")。
+    /// egui は ime_control のみ（repaint は runtime が Focused 観測で運ぶ）。
+    fn post_show(self, app: &AppHandle, t0: Instant) {
+        match self {
+            MainBackend::WebView2 => {
+                if let Some(wv) = app.get_webview_window("main") {
+                    crate::resume_webview(&wv); // 冒頭 resume 後〜可視反映前の残余窓を是正（#576）
+                    crate::apply_ime_control_if_enabled(app, &wv, t0);
+                }
+                crate::emit_window_shown(app, t0);
+            }
+            MainBackend::Egui => {
+                crate::apply_ime_control_egui(app, t0);
+            }
+        }
+    }
+
+    /// hide の後。WV2 は emit("window-hidden") + suspend + trim。egui は何もしない。
+    fn post_hide(self, app: &AppHandle) {
+        if self == MainBackend::WebView2 {
+            let _ = app.emit("window-hidden", ());
+            crate::suspend_and_trim_after_hide(app, "egui_shell_hide");
+        }
+    }
+}
+
+/// 両経路が通る唯一の show 経路。順序: pre_show → 位置 → Win32 show 列 → post_show。
+pub(crate) fn show_main(app: &AppHandle, backend: MainBackend, t0: Instant) {
+    let Some(window) = app.get_window("main") else { return };
+    backend.pre_show(app);
+    #[cfg(windows)]
+    crate::position_on_target_monitor(app, &window);
+    crate::show_and_focus_window(app, &window, t0);
+    backend.post_show(app, t0);
+}
+
+/// 両経路が通る唯一の hide 経路。window.hide → main_visible=false → post_hide。
+pub(crate) fn hide_main(app: &AppHandle, backend: MainBackend) {
+    if let Some(window) = app.get_window("main") {
+        let _ = window.hide();
+    }
+    if let Some(state) = app.try_state::<crate::AppState>() {
+        state.main_visible.store(false, std::sync::atomic::Ordering::SeqCst);
+    }
+    backend.post_hide(app);
+}
+```
+
+注: `app.get_window("main")` が programmatic WebView2 窓と egui 窓の両方を `tauri::Window` として返せることを Step 1 の確認で担保する（返せない場合は Step 1 の確定手段に合わせ `show_main`/`hide_main` の window 取得を差し替える）。
+
+- [ ] **Step 4: 既存の WebView2 side-effect を helper 化してフックから呼ぶ**
+
+`show_main_and_emit`（`main.rs:475`）内の以下を `egui_shell` から呼べるよう整理する:
+- `resume_webview`（`main.rs:266`・既存 `pub` 化が要れば `pub(crate)`）
+- `emit_window_shown`（`main.rs:463`）→ `pub(crate)`
+- `apply_ime_control`（`main.rs:447`）を `apply_ime_control_if_enabled(app, &wv, t0)`（`ime_off_on_show` の live-read 判定込み・現 `show_main_and_emit:511-517` のロジックを移設）と、egui 版 `apply_ime_control_egui(app, t0)`（`get_window("main").hwnd()` に `PlatformCommand::TurnOffIme`）へ切り出す。
+- `suspend_and_trim_after_hide`（`main.rs:305`・既に `pub(crate)`）。
+
+そのうえで `show_main_and_emit(app)` を **薄いラッパー**にする（既存の全呼び出し元＝`single_instance` プラグイン `main.rs:607`・`setup_startup_display`・hotkey listener の互換を保つ）:
+
+```rust
+fn show_main_and_emit(app_handle: &AppHandle) {
+    egui_shell::show_main(app_handle, egui_shell::MainBackend::WebView2, Instant::now());
+}
+```
+
+`reset_search_height`（`main.rs:379`）は WebView2 の高さ折りたたみ。SU2 placeholder は固定サイズゆえ egui では不要。WebView2 経路では `show_main` の `pre_show` 前に呼ぶ必要があるため、`MainBackend::WebView2::pre_show` の先頭で `reset_search_height` を呼ぶ（順序: height reset → resume → 位置 → show を温存。`src-tauri/CLAUDE.md`「操作順序制約」）。
+
+- [ ] **Step 5: フラグ OFF で回帰が無いことを確認する（G1）**
+
+Run（`SNOTRA_EGUI_MAIN` 未設定）:
+```
+cargo clippy -p snotra --all-targets
+cargo test -p snotra
+npm run smoke:startup
+npm run e2e:tauri
+```
+Expected: すべて PASS。hotkey show/hide・focus 喪失・`/s`・二重起動が従来どおり。**FAIL したら STOP** — leaf 移動が順序（resume 2 回・emit を suspend より先・height reset の位置）を壊した。`SNOTRA_TRACE=1` で `show_main:*` / `suspend:*` の順序を従来ログと比較。
+
+- [ ] **Step 6: コミット**
+
+```
+git add src-tauri/src/
+git commit -F <tmpfile>   # "feat(#532): SU2 MainBackend seam + 共有 show_main/hide_main（WV2 leaf 抽出・G1）"
+```
+
+---
+
+### Task 5: egui window 生成 + Egui backend + 起動時表示（子孫 0）
+
+フラグ ON で egui window を setup 生成し、`EguiRuntime` を install/attach する。`show_main` は Task 4 で在るため起動時表示はそれを使う。
+
+**Files:**
+- Modify: `src-tauri/src/egui_shell/mod.rs`（`create()`・`EguiRuntime` 保持）
+- Modify: `src-tauri/src/main.rs`（setup 窓生成 flag 分岐・`setup_startup_display` 分岐）
+
+**Interfaces:**
+- Consumes: `snotra_egui_runtime::EguiRuntime`・`crate::egui_shell::{show_main, MainBackend}`・`SearchWindowView`。
+- Produces: `fn create(app: &tauri::App) -> Result<(), snotra_egui_runtime::RuntimeError>`（install + Window::builder("main") + attach）。
+
+- [ ] **Step 1: `create()` を書く**
+
+`src-tauri/src/egui_shell/mod.rs` に追加（probe `snotra-egui-mvp/src/main.rs:691-756` の install/builder/attach 構造を移植・window は `visible(false)`）:
+
+```rust
+use snotra_egui_runtime::EguiRuntime;
+use crate::egui_shell::view::SearchWindowView;
+
+/// フラグ ON の窓生成。EguiRuntime を install し、webview 無しの "main" 窓を
+/// programmatic 生成して SearchWindowView を attach する。生成は setup 限定。
+pub(crate) fn create(app: &tauri::App) -> Result<(), snotra_egui_runtime::RuntimeError> {
+    let runtime = EguiRuntime::new();
+    runtime.install(app);
+    let window = tauri::Window::builder(app, "main")
+        .title("Snotra")
+        .inner_size(600.0, 52.0)
+        .decorations(false)
+        .skip_taskbar(true)
+        .always_on_top(true)
+        .resizable(false)
+        .visible(false)
+        .build()?;
+    runtime.attach(window, SearchWindowView::new())?;
+    Ok(())
+}
+```
+
+注: `Window::builder` の利用可能メソッド（`skip_taskbar`/`always_on_top` 等）が `WebviewWindowBuilder` と同名かは Tauri v2 API 依存。`cargo build` で確認し、無いメソッドは setup 後 `window.set_skip_taskbar(true)` 等で補う。
+
+- [ ] **Step 2: setup 本体で flag 分岐する**
+
+`src-tauri/src/main.rs` の Task 2 Step 3 で入れた `build_webview2_window(&app_handle)?;` を flag 分岐に置き換える:
+
+```rust
+    // 窓生成: フラグで egui / WebView2 を選ぶ（#532 SU2）。生成は setup 限定。
+    if crate::trace::env_flag("SNOTRA_EGUI_MAIN") {
+        egui_shell::create(app)?;
+    } else {
+        build_webview2_window(&app_handle)?;
+    }
+```
+
+（`app` は `&tauri::App`・`create` が要求。`app_handle` は既存。**エラー変換の確定（mini-gate）**: setup クロージャの戻りは `Result<(), Box<dyn std::error::Error>>`。`create` の `RuntimeError` が `std::error::Error` を実装していれば `?` がそのまま通る（`RuntimeError` は `thiserror::Error` 派生＝`runtime.rs:43`・実装済み）。`build_webview2_window` の `tauri::Result` も同様に `?`。通らなければ `.map_err(|e| e.to_string())?` で `String`（`Box<dyn Error>` へ変換可）にする。`cargo build` で確認。）
+
+- [ ] **Step 3: `setup_startup_display` を flag 分岐する**
+
+`src-tauri/src/main.rs:952` の `setup_startup_display` を、egui のとき `show_main(app, MainBackend::Egui, Instant::now())` を呼ぶよう分岐:
+
+```rust
+fn setup_startup_display(app_handle: &AppHandle, show_on_startup: bool) {
+    if show_on_startup {
+        let backend = if crate::trace::env_flag("SNOTRA_EGUI_MAIN") {
+            egui_shell::MainBackend::Egui
+        } else {
+            egui_shell::MainBackend::WebView2
+        };
+        egui_shell::show_main(app_handle, backend, Instant::now());
+    }
+}
+```
+
+- [ ] **Step 4: フラグ ON で egui window が上がり子孫 0 を確認する（G2-partial）**
+
+Run（PowerShell）:
+```
+$env:SNOTRA_EGUI_MAIN="1"; $env:SNOTRA_TRACE="1"; cargo run -p snotra 2>&1 | Select-String "SNOTRA_EGUI|show_main"
+```
+（`show_on_startup=true` の config で起動、または起動後にウィンドウが出ることを確認）
+別ターミナルで:
+```
+Get-Process msedgewebview2 -ErrorAction SilentlyContinue
+```
+Expected: egui window が可視・日本語 + 長パスが正しいベースラインで描画。`Get-Process msedgewebview2` が **0 件**。**msedgewebview2 が spawn していたら STOP** — 宣言窓が残存（Task 2 の `windows:[]` を確認）か WebView2 経路へ誤分岐。
+
+- [ ] **Step 5: コミット**
+
+```
+git add src-tauri/src/
+git commit -F <tmpfile>   # "feat(#532): SU2 egui window 生成 + 起動時表示（子孫 0・G2-partial）"
+```
+
+---
+
+### Task 6: ホットキー配線（controller + plan_hotkey/plan_ui_action 適用）
+
+製品ホットキー（`emit("hotkey-pressed")` → `setup_hotkey_listener`）を egui 経路の show/hide へ配線する。controller が全 Show/Hide 要求を `plan_ui_action` に通し、冪等性と Defer を一元化する。
+
+**Files:**
+- Modify: `src-tauri/src/egui_shell/mod.rs`（controller: `LifecycleState` 保持 + `apply_command`）
+- Modify: `src-tauri/src/main.rs`（`setup_hotkey_listener` の flag 分岐）
+
+**Interfaces:**
+- Consumes: `lifecycle::{plan_hotkey, plan_ui_action, transition, HotkeyPlan, HostCommand, LifecycleState, LifecycleEvent, UiAction}`・`show_main`/`hide_main`。
+- Produces: controller 状態（`AppState` へ `Mutex<LifecycleState>` を足すか、`egui_shell` 内 `static`）。`fn on_hotkey(app: &AppHandle, generation: ...)`（egui 経路の Alt+Q 処理）。
+
+- [ ] **Step 1: controller を書く（合流点）**
+
+`src-tauri/src/egui_shell/mod.rs` に追加。lifecycle 状態を保持し、`HostCommand` を受けて `plan_ui_action` → 適用 → `transition` する:
+
+```rust
+use std::sync::Mutex;
+use lifecycle::{HostCommand, LifecycleEvent, LifecycleState, UiAction, plan_ui_action, transition};
+
+/// show/hide の合流点。hotkey・Escape・focus-lost の全 Show/Hide 要求がここを通り、
+/// 冪等性と show 進行中 Hide の Defer を一元化する。egui 経路専用（WV2 は従来の直接呼び）。
+pub(crate) struct LifecycleController {
+    state: Mutex<LifecycleState>,
+    deferred_hide: Mutex<bool>,
+}
+
+impl LifecycleController {
+    pub(crate) fn new() -> Self {
+        Self { state: Mutex::new(LifecycleState::Suspended), deferred_hide: Mutex::new(false) }
+    }
+
+    pub(crate) fn apply(&self, app: &AppHandle, command: HostCommand) {
+        let state = *self.state.lock().unwrap();
+        match plan_ui_action(state, &command) {
+            UiAction::Show => {
+                if let HostCommand::Show { hotkey_started } = command {
+                    show_main(app, MainBackend::Egui, hotkey_started);
+                }
+                self.advance(LifecycleEvent::Show);
+                // FramePresented は runtime の初回 present 後に別途通知（Step 3 注）。
+            }
+            UiAction::Hide => {
+                hide_main(app, MainBackend::Egui);
+                self.advance(LifecycleEvent::Hide);
+            }
+            UiAction::Refocus => {
+                if let Some(w) = app.get_window("main") { let _ = w.set_focus(); }
+            }
+            UiAction::Defer => { *self.deferred_hide.lock().unwrap() = true; }
+            UiAction::Ignore => {}
+        }
+    }
+
+    fn advance(&self, event: LifecycleEvent) {
+        let mut state = self.state.lock().unwrap();
+        if let Ok(next) = transition(*state, event) { *state = next; }
+    }
+}
+```
+
+controller を `AppState` の managed state か `egui_shell` の `OnceLock<LifecycleController>` として保持する（threading: hotkey listener はメインスレッド、view は event loop スレッドから `apply` を呼ぶため `Mutex` で保護）。
+
+- [ ] **Step 2: `setup_hotkey_listener` を flag 分岐する**
+
+`src-tauri/src/main.rs:781` の `setup_hotkey_listener` 内、`hotkey-pressed` クロージャで egui のとき `plan_hotkey` → `HostCommand` → `controller.apply` へ分岐する。WebView2 側は既存ロジック不変。サイドカーガード（`SettingsProcessState`・`main.rs:790`）と generation ガード（`main.rs:795`）と `ShowAfterAltRelease` の alt 解放待ちスレッド（`main.rs:830`）は共有構造で、egui では:
+
+```rust
+        // egui 経路: 純粋核で分岐を決め、controller へ HostCommand を送る。
+        // current_gen / hotkey_generation_for_listener は既存 listener の変数（main.rs:784,795）。
+        if crate::trace::env_flag("SNOTRA_EGUI_MAIN") {
+            let visible = handle_for_hotkey.try_state::<AppState>()
+                .map(|s| s.main_visible.load(Ordering::SeqCst)).unwrap_or(false);
+            // hotkey_toggle の live-read は WebView2 経路（main.rs:808-812）と同じ。
+            let hotkey_toggle = handle_for_hotkey.try_state::<AppState>()
+                .map(|s| s.engine.lock().unwrap().config().general.hotkey_toggle)
+                .unwrap_or(true);
+            match egui_shell::plan_hotkey(visible, is_alt_pressed()) {
+                HotkeyPlan::HideNow if hotkey_toggle => {
+                    egui_shell::controller(&handle_for_hotkey)
+                        .apply(&handle_for_hotkey, HostCommand::Hide);
+                }
+                HotkeyPlan::HideNow => {} // hotkey_toggle=false は可視のまま（hide しない）
+                HotkeyPlan::ShowNow => {
+                    egui_shell::controller(&handle_for_hotkey)
+                        .apply(&handle_for_hotkey, HostCommand::Show { hotkey_started: t0 });
+                }
+                HotkeyPlan::ShowAfterAltRelease => {
+                    let h = handle_for_hotkey.clone();
+                    let gen_for_wait = hotkey_generation_for_listener.clone();
+                    std::thread::spawn(move || {
+                        wait_alt_release_or_timeout();
+                        if gen_for_wait.load(Ordering::SeqCst) != current_gen { return; }
+                        egui_shell::controller(&h)
+                            .apply(&h, HostCommand::Show { hotkey_started: Instant::now() });
+                    });
+                }
+            }
+            return;
+        }
+```
+
+（`plan_hotkey`/`HotkeyPlan`/`HostCommand` は `lifecycle` の `pub(crate)`。`main.rs` から使うため `egui_shell/mod.rs` で `pub(crate) use lifecycle::{plan_hotkey, HotkeyPlan, HostCommand};` を re-export。`egui_shell::controller(app) -> &LifecycleController` は Task 6 Step 1 の managed state を返す薄いヘルパー。`t0` は listener 冒頭の `Instant::now()`＝`main.rs:786`。）
+
+- [ ] **Step 3: dead-code allow を除去し、Alt+Q show/hide/toggle を確認する（G2-full・G4）**
+
+Task 1 で付けた `#[allow(dead_code)]` を除去する（全シンボルが消費された）。
+
+Run: `cargo clippy -p snotra --all-targets`（dead-code 警告が出ないこと）
+
+Run（PowerShell・トレース）:
+```
+$env:SNOTRA_EGUI_MAIN="1"; $env:SNOTRA_TRACE="1"; cargo run -p snotra
+```
+手動で Alt+Q を押下:
+- 非表示 → 表示（`ShowNow` / Alt 押しっぱなしなら `ShowAfterAltRelease` 後）
+- 表示中に Alt+Q（`hotkey_toggle=true`）→ 非表示
+- 表示中に focus を奪わず連打 → 冪等（多重 show/hide しない）
+
+Expected: show/hide が対称に動く。**hide 後アイドルで present 失敗リトライが繰り返されない**（G4: 隠れ窓に RedrawRequested が来ないので runtime は描かない）。`SNOTRA_TRACE` に `SNOTRA_EGUI_RENDER_ERROR` の連発が無い。**あれば STOP** — 外部 hide と runtime.visible の不整合。
+
+- [ ] **Step 4: コミット**
+
+```
+git add src-tauri/src/
+git commit -F <tmpfile>   # "feat(#532): SU2 ホットキー配線 + controller（plan_ui_action 合流・G2/G4）"
+```
+
+---
+
+### Task 7: blur 自動非表示 + Escape（focus 観測 + policy）
+
+view が focus 喪失を観測し、100ms 猶予・`auto_hide_on_focus_lost` ゲート・サイドカーガードを満たすとき controller へ `HostCommand::Hide` を送る。Escape も Hide。policy は view（src-tauri）側に置き runtime API を拡張しない。
+
+**Files:**
+- Modify: `src-tauri/src/egui_shell/view.rs`（focus 観測 + Escape + policy 判定）
+
+**Interfaces:**
+- Consumes: `ctx.input(|i| i.focused)`・`ctx.input(|i| i.key_pressed(egui::Key::Escape))`・`app_handle`（config/`SettingsProcessState` 読み）・controller。
+- Produces: view → controller への `HostCommand::Hide`（view は `RuntimeFrame::hide_window` で先に paint 停止してよい＝前倒し）。
+
+- [ ] **Step 1: view に focus 観測 + policy を実装する**
+
+`SearchWindowView` に `app_handle: tauri::AppHandle`・`was_focused: bool`・`unfocus_at: Option<Instant>` を足し、`update` で:
+
+```rust
+    fn update(&mut self, ui: &mut egui::Ui, frame: &mut RuntimeFrame) {
+        let ctx = ui.ctx().clone();
+        let focused = ctx.input(|i| i.focused);
+        let escape = ctx.input(|i| i.key_pressed(egui::Key::Escape));
+
+        // Escape → 即 Hide（SPEC §8.1。内側モードの復帰優先は SU3）。
+        if escape {
+            self.request_hide(frame);
+        }
+
+        // focus 喪失 → 100ms 猶予後に policy を満たせば Hide。
+        if self.was_focused && !focused {
+            self.unfocus_at = Some(Instant::now());
+            ctx.request_repaint_after(std::time::Duration::from_millis(100));
+        }
+        if focused {
+            self.unfocus_at = None; // refocus で pending 破棄
+        }
+        if let Some(at) = self.unfocus_at
+            && !focused
+            && at.elapsed() >= std::time::Duration::from_millis(100)
+            && self.auto_hide_enabled()   // config live-read
+            && !self.settings_running()   // SettingsProcessState ガード
+        {
+            self.unfocus_at = None;
+            self.request_hide(frame);
+        }
+        self.was_focused = focused;
+
+        ui.label("Snotra — 検索ウィンドウ（C:/Program Files/example）");
+    }
+```
+
+`request_hide`・`auto_hide_enabled`・`settings_running` を実装する:
+
+```rust
+    fn request_hide(&mut self, frame: &mut RuntimeFrame) {
+        frame.hide_window(); // 前倒しで paint 停止（合流点は controller）
+        controller_apply_hide(&self.app_handle); // egui_shell の controller へ HostCommand::Hide
+    }
+    fn auto_hide_enabled(&self) -> bool {
+        self.app_handle.try_state::<crate::AppState>()
+            .map(|s| s.engine.lock().unwrap().config().general.auto_hide_on_focus_lost)
+            .unwrap_or(true) // config.rs の既定と一致（要確認）
+    }
+    fn settings_running(&self) -> bool {
+        self.app_handle.try_state::<crate::SettingsProcessState>()
+            .map(|p| p.lock().unwrap().is_some()).unwrap_or(false)
+    }
+```
+
+（`controller_apply_hide` は `egui_shell` が `pub(crate)` で公開する薄いヘルパー。controller の保持先＝Step 6 Task 6 の managed state を読む。`SearchWindowView::new(app_handle)` に引数追加＝Task 5 の `create` の `SearchWindowView::new()` 呼び出しも更新する。`auto_hide_on_focus_lost` の既定値は `snotra-core` の config.rs で確認。）
+
+- [ ] **Step 2: focus-lost 自動非表示とサイドカーガードを確認する（G3）**
+
+Run（PowerShell）:
+```
+$env:SNOTRA_EGUI_MAIN="1"; cargo run -p snotra
+```
+- ウィンドウ表示 → 別アプリをクリックして focus を奪う → **100ms 後に自動非表示**（`auto_hide_on_focus_lost=true` 時）
+- 表示中に `/o` 等で `snotra-settings` を起動 → 設定が focus を奪う → **メインは非表示にならない**（サイドカーガード）
+- Escape → 非表示
+
+Expected: 上記どおり。**設定起動で本体が消えたら STOP** — サイドカーガードが focus-lost 経路に効いていない。
+
+- [ ] **Step 3: コミット**
+
+```
+git add src-tauri/src/
+git commit -F <tmpfile>   # "feat(#532): SU2 blur 自動非表示 + Escape（focus 観測・100ms 猶予・サイドカーガード・G3）"
+```
+
+---
+
+### Task 8: 位置永続（復元 + save-on-hide + 可視時終了保存）
+
+egui window の位置を SPEC §8.2 どおり復元・保存する。復元は `show_main` の `position_on_target_monitor`（Task 4 で既に共有列に在る）。保存は save-on-hide + 可視時終了保存。
+
+**Files:**
+- Modify: `src-tauri/src/egui_shell/mod.rs`（`hide_main` に位置保存を追加）
+- Modify: `src-tauri/src/main.rs`（`setup_exit_listener` に egui 可視時の位置保存）
+
+**Interfaces:**
+- Consumes: `position_on_target_monitor`（復元・共有列内）・既存の位置保存経路（`commands::save_search_placement` が使う `window.bin` 書き込み。相対座標算出は `monitor.rs`）。
+- Produces: なし（副作用）。
+
+- [ ] **Step 1: 位置保存経路を確認する**
+
+`commands::save_search_placement`（`get_webview_window("main")` を使う・`commands/window.rs`）が呼ぶ `window.bin` 書き込み関数（`snotra-core` 側の placement 保存 or `monitor.rs`）を特定する。egui window（`get_window("main")`）の物理位置 + ターゲットモニター作業領域原点から**相対座標**を出して同じ形式で保存する共有ヘルパー `save_placement_relative(app, &window)` を `egui_shell` に用意する（WebView2 の保存ロジックを `&tauri::Window` で一般化・`monitor.rs` の相対座標算出を再利用）。
+
+Run: `cargo build -p snotra`（型が合うこと）
+
+- [ ] **Step 2: `hide_main` に save-on-hide を足す**
+
+`egui_shell::hide_main` の `window.hide()` の**前**に、可視中の現在位置を保存する:
+
+```rust
+pub(crate) fn hide_main(app: &AppHandle, backend: MainBackend) {
+    if let Some(window) = app.get_window("main") {
+        if backend == MainBackend::Egui {
+            save_placement_relative(app, &window); // save-on-hide（JS チョークポイントが無いため）
+        }
+        let _ = window.hide();
+    }
+    // ... 既存（main_visible=false・post_hide）
+}
+```
+
+- [ ] **Step 3: `setup_exit_listener` に可視時終了保存を足す**
+
+`src-tauri/src/main.rs:867` の `setup_exit_listener` 内、history/icon flush と並べて、egui かつ可視なら位置保存:
+
+```rust
+        if crate::trace::env_flag("SNOTRA_EGUI_MAIN")
+            && handle_for_exit.try_state::<AppState>()
+                .map(|s| s.main_visible.load(Ordering::SeqCst)).unwrap_or(false)
+            && let Some(window) = handle_for_exit.get_window("main")
+        {
+            egui_shell::save_placement_relative(&handle_for_exit, &window);
+        }
+```
+
+- [ ] **Step 4: 位置の復元・保存を確認する**
+
+Run（PowerShell）:
+```
+$env:SNOTRA_EGUI_MAIN="1"; cargo run -p snotra
+```
+- ウィンドウをドラッグ移動（検索バー余白）→ Alt+Q で非表示 → Alt+Q で再表示 → **同じ位置に復元**
+- マルチモニター: カーソルを別モニターへ → Alt+Q → `follow_cursor_monitor=true` ならそのモニターの作業領域内に出る（画面外に出ない = クランプ）
+- 保存位置なしの初回相当 → ターゲットモニター中央
+
+Expected: SPEC §8.2 どおり。位置が画面外へ出ない。
+
+- [ ] **Step 5: コミット + PR**
+
+```
+git add src-tauri/src/
+git commit -F <tmpfile>   # "feat(#532): SU2 位置永続（復元 + save-on-hide + 可視時終了保存）"
+git push -u origin HEAD && gh pr create --fill
+```
+
+（PR 本文は SU2 の受け入れ条件チェックリスト。**マージ前に** `gh pr view <PR> --json closingIssuesReferences` で #532 を誤 close しないか確認＝ルート `CLAUDE.md` の squash マージ手順。#532 は親 issue ゆえ SU2 単独では閉じない。）
+
+---
+
+## Self-Review（spec 照合）
+
+- **spec §backend seam（3 フック）** → Task 4（`pre_show`/`post_show`/`post_hide`・WV2 leaf 逐語移動）。✓
+- **spec §状態機械（plan_hotkey/plan_ui_action・合流点）** → Task 1（純粋核）+ Task 6（controller 適用）。✓
+- **spec §blur 自動非表示（100ms・ゲート・サイドカーガード・policy を view 側）** → Task 7。✓
+- **spec §フラグと生成（windows:[]・build_webview2_window・egui create・label "main"）** → Task 2（G0）+ Task 5。✓
+- **spec §placeholder view + font-first** → Task 3。✓
+- **spec §位置永続（復元・save-on-hide・可視時終了保存）** → Task 8。✓
+- **spec §再利用部品（残留 Alt #558・monitor.rs・window.bin）** → Task 4（Alt）+ Task 8（位置）。✓
+- **spec 検証ゲート G0/G1/G2/G3/G4** → G0=Task 2 / G1=Task 4 / G2=Task 5(partial)+Task 6(full) / G3=Task 7 / G4=Task 6。✓
+- **spec §受け入れ条件 1-6** → 全 Task を通じて。SPEC §8 一致=Task 5-8 のスモーク、flag OFF 不変=G0+G1、純関数=Task 1、policy が src-tauri=Task 7、font-first=Task 3、clippy/test/子孫0=各境界。✓
+
+**未解決の実装時確認（各タスクの mini-gate で潰す・fabrication を避けた箇所）:**
+- Task 4 Step 1: `WebviewWindow` → `&tauri::Window` の手段（`as_ref().window()` / `get_window`）。
+- Task 5 Step 1: `Window::builder` の `skip_taskbar`/`always_on_top` メソッド名（無ければ setup 後 setter）。
+- Task 5 Step 2: `RuntimeError` → setup エラー型の変換。
+- Task 7 Step 1: `auto_hide_on_focus_lost` の config.rs 既定値。
+- Task 8 Step 1: `window.bin` 保存関数の所在（`snotra-core` placement or `monitor.rs`）と `&tauri::Window` 一般化。

--- a/docs/superpowers/specs/2026-07-22-su2-window-shell-design.md
+++ b/docs/superpowers/specs/2026-07-22-su2-window-shell-design.md
@@ -34,7 +34,7 @@
 - **`SNOTRA_EGUI_MAIN=1`**（env・`main()` で 1 回読む。`crate::trace::env_flag`）。
 - **`tauri.conf.json` は不変**（宣言窓 "main" を残す）。
 - **`main()`**: `generate_context!()` と E2E 注入ブロックの後、フラグ ON なら `app_context.config_mut().app.windows` から `label=="main"` を除去（`.retain(|w| w.label != "main")`）。これで Tauri は WebView2 窓を作らない。
-- **setup（フラグ ON）**: `egui_shell::create(app)`（`&mut App`）が `EguiRuntime::install(app)` → `tauri::Window::builder(app, "main")`（webview 無し・`visible(false)`・`decorations(false)`・600×52）→ `attach(window, SearchWindowView::new(app_handle))`。生成は setup 限定。
+- **setup（フラグ ON）**: `egui_shell::create(app, window_width)`（`&mut App`）が `EguiRuntime::install(app)` → `tauri::Window::builder(app, "main")`（webview 無し・`visible(false)`・`decorations(false)`・**config の `window_width`×52**・**`skip_taskbar(true)`・`always_on_top(true)`**＝宣言窓プロパティ再現・codex #11/(B)#1）→ `attach(window, SearchWindowView::new(app_handle))`。生成は setup 限定で、**`setup_platform_thread` の後**に置く（SPEC §8.5 の「platform thread を窓生成より前に spawn」の並列化順序・codex #12）。
 - **setup（フラグ OFF）**: 変更なし。宣言窓が Tauri により生成され、既存 WebView2 経路がそのまま動く。
 - **ラベルは両方 `"main"`**: egui 経路は `get_window("main")` で掴む。フラグ OFF の `get_webview_window("main")` 依存（幅復元・config 幅反映・位置保存・Settings 制御）は宣言窓が在るので従来どおり動く。フラグ ON でそれらが no-op になる箇所（幅反映は SU3/SU6・幅復元は placeholder 固定 600px で無害）は各所で確認する（codex #9/#11）。
 
@@ -54,7 +54,9 @@ hide_egui_main(app):
     window.hide(); main_visible = false        // 外部 hide（RuntimeFrame::hide_window は使わない・#4）
 ```
 
-- **状態は `AppState.main_visible`（bool）だけ**。controller も 4 状態機械も持たない。ホットキーは `plan_hotkey(main_visible, is_alt_pressed())` で分岐する。
+- **状態は `AppState.main_visible`（bool）+ 共有 `EguiShellState`**（managed）。controller も 4 状態機械も持たない。ホットキーは `plan_hotkey(main_visible, is_alt_pressed())` で分岐する。`EguiShellState { hotkey_generation: AtomicU64, hide_pending: AtomicBool }` が show/hide/view を跨ぐ 2 点を協調させる:
+  - **`hotkey_generation`**: `ShowAfterAltRelease` の spawn スレッドが待機後に世代一致を確認して show する。**hide（`hide_egui_main`）が世代を bump** し、保留中の alt 解放待ち show を無効化する（hide 後の再表示を防ぐ・codex #5/(B)#2）。
+  - **`hide_pending`**: view の `emit("egui-hide-requested")` 多重防止フラグ。**show（`show_egui_main`）がクリア**する（view-local だと hide 後に `Focused(true)` が来ないとき true が残り以後の hide を抑止する・codex #8）。
 - **全 hide は外部 `window.hide()`**（codex #4/#7 の解）。`RuntimeFrame::hide_window`（runtime.visible=false）は使わない。これで (a) 次の show が `Focused(true)` に依存せず確実に描け、(b) hide の副作用所有が一箇所（`hide_egui_main`）に一元化する。
 - **`main_visible` は `AtomicBool`**（`state.rs:17`・既存）。hotkey（メインスレッド）と hide 経路が触るが単一 atomic ゆえ tear しない。plan_hotkey の判定→show/hide は各トリガーが直列に行う（controller の lock 非保持競合＝codex #5 は controller を廃したことで消える）。
 

--- a/docs/superpowers/specs/2026-07-22-su2-window-shell-design.md
+++ b/docs/superpowers/specs/2026-07-22-su2-window-shell-design.md
@@ -76,6 +76,7 @@ Escape・focus-lost（view が egui 入力で観測）                    → Ho
 ```
 
 - **合流点（controller）は 1 つ**: hotkey・Escape・focus-lost の全 Hide/Show 要求が `plan_ui_action` を通る。冪等性と Defer をここに一元化する（散らさない）。
+- **egui 経路では `Recreating` は transient・`Defer` は runtime 到達不能**: egui の show は同期（`window.show()` は即・SU1 runtime は surface を再生成せず `Focused` 観測で repaint）ゆえ「最初のフレーム提示を待つ」mid-flight race が無い。controller は `Show` 適用時に `Show→FramePresented` を即座に畳んで `Visible` へ進める（さもないと後続 Hide が `Recreating+Hide→Defer` に吸われ、`FramePresented` を誰も emit せずデッドロックする）。**`Defer` の純粋契約は `plan_ui_action` のユニットテストで固定する**（roadmap「Defer をテストで固定」を満たす）が、live では走らない。将来 async show を導入するなら再活性化する。
 - **2 つの `visible` を混同しない**（SU1 申し送り + 助言）: `AppState.main_visible`（policy＝`Standby`/`SearchVisible` 判定・`plan_hotkey` の入力）と `runtime.visible`（SU1 の描画ゲート・不変条件⑥）は**別物**。egui 経路は自前の policy フラグ（`main_visible`）を runtime の描画ゲートと独立に持つ。
 - **hotkey listener の toggle 判定**: `hotkey_toggle` は config live-read（既存の #576 パターン踏襲・キャッシュしない）。`hotkey_toggle && main_visible` で hide、さもなくば show。
 

--- a/docs/superpowers/specs/2026-07-22-su2-window-shell-design.md
+++ b/docs/superpowers/specs/2026-07-22-su2-window-shell-design.md
@@ -24,7 +24,8 @@
 
 ### 実装初手で確定させる検証ゲート（崩れると設計が反転する）
 
-- **G1（フラグ OFF byte-identical）**: WebView2 の `resume`/`suspend`/`emit`/`trim` を backend フックへ逐語で寄せた後、`SNOTRA_EGUI_MAIN` 未設定で `smoke:startup` / `e2e:tauri` が緑を保つ（回帰なし）。**これが最優先ゲート**——整合の代償（既存 WebView2 経路を触る）が回帰を生まないことを最初に接地する。
+- **G0（宣言→programmatic 変換 byte-identical）**: `tauri.conf.json` の `windows` を空にし `build_webview2_window` で宣言窓を逐語再現した直後、`SNOTRA_EGUI_MAIN` 未設定で `smoke:startup` / `e2e:tauri` が緑（宣言時と挙動一致）。**最初に接地するゲート**——窓生成の変換が flag OFF を壊さないことを、show/hide 整合より前に確定する。
+- **G1（フラグ OFF byte-identical・show/hide 整合後）**: WebView2 の `resume`/`suspend`/`emit`/`trim` を backend フックへ逐語で寄せた後、`SNOTRA_EGUI_MAIN` 未設定で `smoke:startup` / `e2e:tauri` が緑を保つ（回帰なし）。整合の代償（既存 WebView2 経路を触る）が回帰を生まないことを接地する。
 - **G2（hotkey → egui show の配線）**: 製品ホットキーは Win32 `RegisterHotKey`（platform スレッド）→ `emit("hotkey-pressed")` → listener。listener は egui 経路では `get_window("main")`（`tauri::Window`）を掴む必要がある（`get_webview_window("main")` は egui ウィンドウに対し `None`）。emit→listener→egui show が実機で 1 回通ることをトレースで確認する（初手スモーク）。
 - **G3（focus-lost 観測の起動）**: probe `main.rs:174` は focus を **refocus** に使うのみで自動非表示は実装していない。SU2 は focus 喪失で猶予タイマを起こす。`Focused(false)` → egui repaint → view が `!focused` を観測 → `request_repaint_after(100ms)` が発火 → 猶予明け判定、の一巡が実機で回ることを確認する。
 - **G4（外部 hide と runtime.visible の両立）**: hotkey トグル hide は listener から `window.hide()`（外部）で行う。隠れたウィンドウには `RedrawRequested` が配送されないため runtime は描かない（SU1 不変条件⑥の paint ゲートと衝突しない）ことを、hide 後のアイドルで present 失敗リトライstorm が起きないことで確認する。
@@ -102,11 +103,14 @@ Escape・focus-lost（view が egui 入力で観測）                    → Ho
 
 ## フラグと生成
 
+**重要な as-built 事実**: 製品の "main" 窓は **`tauri.conf.json` の `windows[]` で宣言的生成**される（`label:"main"`・`url:"main.html"`・600×52・`visible:false`・`decorations:false`・`skipTaskbar:true`・`alwaysOnTop:true`・`resizable:false`・`center:true`）。setup に `WebviewWindowBuilder` は無い。`build.rs` が config をコンパイル時に焼き込むため、実行時 env フラグで宣言窓だけ抑止する手は無い（`src-tauri/CLAUDE.md`「WebView2 ウィンドウ生成の制約」）。ゆえに **egui が WebView2 を置き換える（子孫 0・ラベル `"main"` 共有）には、宣言窓を config から外し、両経路とも setup で programmatic 生成へ寄せる**（2026-07-22 決定・programmatic 統一）。
+
 - **`SNOTRA_EGUI_MAIN=1`**（env・setup フェーズで 1 回読む。`SNOTRA_DISABLE_SUSPEND`/`SNOTRA_TRACE` と同じ流儀）。ユーザー向け config には出さない（移行/ドッグフード用）。
-- **ON**: `EguiRuntime::install(app)` → `tauri::Window::builder(app, "main")`（webview 無し・`decorations(false)`・`visible(false)`・サイズは製品既定）→ `runtime.attach(window, SearchWindowView::new(...))`。WebView2 ウィンドウは**作らない**。
-- **OFF**: 既存 `WebviewWindowBuilder` 経路で不変。
-- **ラベルは `"main"` を踏襲**: `position`/`window.bin`/`monitor.rs` が同ラベルで動く。WebView2 固有経路（`get_webview_window("main")`・resume/suspend・IPC コマンド）は egui ウィンドウを型で掴めず、かつ各入口（hotkey listener・`setup_startup_display`・focus-lost）で backend/flag 分岐するため**到達しない**。
-- **生成は setup 限定**（`src-tauri/CLAUDE.md`「WebView2 ウィンドウ生成の制約」）。egui ウィンドウ（tao）も同様に setup で生成し、ランタイムでは show/hide のみ。
+- **`tauri.conf.json`**: `app.windows` を **`[]`（空）** にする。宣言窓を廃し、両経路とも programmatic 生成にする。CSP・bundle・plugins は不変。
+- **ON**: `EguiRuntime::install(app)` → `tauri::Window::builder(app, "main")`（webview 無し・`decorations(false)`・`visible(false)`・600×52）→ `runtime.attach(window, SearchWindowView::new(...))`。WebView2 ウィンドウは**作らない**。
+- **OFF**: `build_webview2_window(app)`（新規）が `WebviewWindowBuilder::new(app, "main", WebviewUrl::App("main.html"))` で**宣言窓の 10 フィールドを逐語再現**（title/size/visible:false/decorations:false/skipTaskbar/alwaysOnTop:true/resizable:false/center）。挙動を宣言時と一致させる（G0）。
+- **ラベルは `"main"` を踏襲**: `position`/`window.bin`/`monitor.rs`・既存 `get_webview_window("main")` 経路が同ラベルで動く。WebView2 固有経路（resume/suspend・IPC コマンド）は egui ウィンドウを型で掴めず（`get_webview_window` は `None`）、かつ各入口（hotkey listener・`setup_startup_display`・focus-lost）で backend/flag 分岐するため egui 経路では**到達しない**。
+- **生成は setup 限定**（同上制約: `WebviewWindowBuilder::build()` はメッセージポンプ進行を要求。setup フェーズは自前で処理でき正常）。egui ウィンドウ（tao）も同様に setup で生成し、ランタイムでは show/hide のみ。
 
 ## placeholder view と font-first（SU1 申し送りの義務）
 
@@ -120,7 +124,8 @@ Escape・focus-lost（view が egui 入力で観測）                    → Ho
 | `src-tauri/src/egui_shell/mod.rs`（新規） | `MainBackend` enum・生成（`Window::builder`+`install`+`attach`）・`show_main`/`hide_main` 共有オーケストレーション・backend フック（`pre_show`/`post_show`/`post_hide`）・controller（合流点） |
 | `src-tauri/src/egui_shell/lifecycle.rs`（新規・純粋核） | `HotkeyPlan`/`plan_hotkey`・`LifecycleState`/`LifecycleEvent`/`transition`・`HostCommand`/`UiAction`/`plan_ui_action`。Win32 非依存・ユニットテスト対象。spike から移植 |
 | `src-tauri/src/egui_shell/view.rs`（新規） | `SearchWindowView: EguiView`（placeholder）。`setup` で font-first・`update` で focus 観測（自動非表示の起点） |
-| `src-tauri/src/main.rs` | 各 setup 関数に `if egui_main { egui_shell::... } else { 既存 }` の入口分岐を足す（生成・`setup_hotkey_listener`・`setup_startup_display`）。WebView2 の `resume`/`suspend`/`emit`/`trim` を `MainBackend::WebView2` のフックへ**逐語移動**。既存の判定・順序は温存 |
+| `src-tauri/tauri.conf.json` | `app.windows` を `[]` にする（宣言窓廃止）。CSP・bundle・plugins は不変 |
+| `src-tauri/src/main.rs` | setup 本体に **窓生成の flag 分岐**（`if egui_main { egui_shell::create } else { build_webview2_window }`）を足す。`build_webview2_window`（新規）が宣言窓 10 フィールドを `WebviewWindowBuilder` で逐語再現。各 setup 関数（`setup_hotkey_listener`・`setup_startup_display`）に `if egui_main { egui_shell::... } else { 既存 }` の入口分岐。WebView2 の `resume`/`suspend`/`emit`/`trim` を `MainBackend::WebView2` のフックへ**逐語移動**。既存の判定・順序は温存 |
 | WebView2 経路の既存ファイル（`commands/`・`config_watcher.rs` 等） | **触らない**（SU2 の egui view は placeholder ゆえ IPC/config 反映は SU3/SU6）。exit-save の位置保存のみ egui 可視時に追加 |
 | `Cargo.toml`（`src-tauri`） | **`snotra-egui-runtime = { path = "../snotra-egui-runtime" }` を新規追加**（現状 `src-tauri` は未依存＝workspace member だが dep ではない・実測）。`EguiRuntime`/`EguiView`/`RuntimeFrame` を使うため |
 
@@ -142,7 +147,7 @@ Escape・focus-lost（view が egui 入力で観測）                    → Ho
 ## 受け入れ条件（SU2）
 
 1. Alt+Q 表示/非表示・blur 自動非表示・フォーカス列・残留 Alt 解除・位置永続・起動時表示・初回フローが SPEC §8（8.1–8.6）と一致する（egui 経路・trace スモークで実証）。
-2. **フラグ OFF で WebView2 挙動が不変**（G1 緑・回帰なし）。resume/suspend/emit/trim のフック移動が既存の順序制約を温存する。
+2. **フラグ OFF で WebView2 挙動が不変**（G0 + G1 緑・回帰なし）。宣言→programmatic 窓生成の変換（`build_webview2_window` が 10 フィールド逐語再現）と、resume/suspend/emit/trim のフック移動が、既存挙動・順序制約を温存する。`app.windows=[]` で宣言窓が二重生成されない。
 3. **`plan_hotkey`/`plan_ui_action` が純関数**として `egui_shell/lifecycle.rs` に在り、冪等性（表示中+Show / 非表示中+Hide）と show 進行中 Hide の Defer がユニットテストで固定される。
 4. focus-lost 自動非表示の policy（100ms 猶予・`auto_hide_on_focus_lost` ゲート・サイドカーガード）が `src-tauri` の view 側にあり、`snotra-egui-runtime` の公開 API を拡張していない。
 5. `SearchWindowView::setup` の font-first が実 setup 駆動テストで機構化されている。

--- a/docs/superpowers/specs/2026-07-22-su2-window-shell-design.md
+++ b/docs/superpowers/specs/2026-07-22-su2-window-shell-design.md
@@ -4,168 +4,150 @@
 - 日付: 2026-07-22
 - 親: `docs/superpowers/specs/2026-07-21-phase2-softbuffer-migration-roadmap.md`（SU2）／#532
 - 前段: `docs/superpowers/specs/2026-07-21-su1-softbuffer-runtime-design.md`（SU1・実装完了）
-- 履歴: 撤去済み spike（`soft_host_main.rs`・commit 7558cc8）から純粋核を復元し一次証拠化。焦点を絞った設計問答（構造の岐路 → backend seam の深さ）で硬化
+- 履歴: 初版は「共有 show_main + MainBackend 3 フック seam + LifecycleController(4 状態)」だったが、codex 敵対的レビュー（2026-07-22）が (a) E2E が宣言窓へ依存、(b) controller の lock 非保持競合、(c) egui 専用で `Recreating`/`Defer` が live 到達不能な過剰設計、を実測で指摘。**egui 専用フォーク（共有は位置計算のみ）へ簡素化**した。旧設計の否定の知識は本節末「否定の知識」に残す
 
 ## 目的
 
-製品 `src-tauri` のメインウィンドウに、**WebView2 と並行して egui/softbuffer 経路**を env フラグ選択で立ち上げる「外殻」を作る。SU2 が持つのは `Standby ⇄ SearchVisible` の**外側の状態機械**——Alt+Q 表示/非表示・blur 自動非表示・フォーカス列・残留 Alt 解除・位置永続・起動時表示・初回フロー。内側の検索モード（Normal/Command/Tool/Folder/Instant/Indexing）と検索体験は SU3。SU2 の egui view は **placeholder**（show/hide/focus/位置が視覚的に検証できる最小の chrome）。
+製品 `src-tauri` のメインウィンドウに、WebView2 と**並行して** egui/softbuffer 経路（クレート `snotra-egui-runtime`＝SU1 完了）を env フラグ選択で立ち上げる「外殻」を作る。SU2 が持つのは外側の状態機械——Alt+Q 表示/非表示・blur 自動非表示・フォーカス列・残留 Alt 解除・位置永続・起動時表示・初回フロー。内側の検索モードと検索体験は SU3。SU2 の egui view は **placeholder**。
 
-## 決定の要石
+## アプローチ（簡素化後の要石）
+
+**egui 経路は WebView2 経路と分離した専用の show/hide を持つ。共有するのは位置計算（`position_on_target_monitor` の `&tauri::Window` 一般化）だけ。** WebView2 経路（フラグ OFF）は `show_main_and_emit` を含め**一切変更しない**。理由（codex #13）: controller/4 状態機械/`plan_ui_action`/`Defer` は egui 専用で live 到達不能（egui の show は同期）——共有 seam は共通化でなく二重の状態所有と競合面を作る。SU7 は egui 専用関数がそのまま残り WebView2 経路を削除するだけ。
 
 ### 検証済み（この設計の前提・一次証拠）
 
-1. **純粋な決定核は spike で実証済み**（`soft_host_main.rs:131-207` から復元）。以下 2 関数を `src-tauri` へ移植する。設計を反転させる不確実性は無い:
-   - `plan_hotkey(visible, alt_pressed) -> HotkeyPlan{ HideNow | ShowAfterAltRelease | ShowNow }` — Alt+Q 押下時の分岐。表示中なら即 hide、非表示中は Alt 押下中なら解放待ち後 show。
-   - `plan_ui_action(state: LifecycleState, cmd: &HostCommand) -> UiAction{ Show | Hide | Refocus | Defer | Ignore }` — ホストコマンドを lifecycle 状態へ適用する計画。**冪等性**（`Visible+Show→Refocus`・`Suspended+Hide→Ignore`）と、**show 進行中に届いた Hide の繰り延べ**（`Recreating+Hide→Defer`）をここで一元決定する。
-   - `LifecycleState{ Visible | Suspended | Recreating | Exiting }` と `transition(state, event) -> Result<LifecycleState>`。`Recreating` は「show 済みで最初のフレーム提示待ち」。
-2. **focus 観測の経路が確定**（runtime 駆動 probe `snotra-egui-mvp/src/main.rs:174`）。runtime は tao の `Focused` を egui 入力へ流し込み済みで、`ctx.input(|i| i.focused)` で **EguiView（＝製品では `src-tauri` のコード）が focus を観測できる**。→ **blur 自動非表示のために `snotra-egui-runtime` の公開 API を拡張する必要はなく、SU2 は `src-tauri` 境界に留まる**（ロードマップの「境界: src-tauri」を満たす）。runtime は `Focused(true)` を「再表示された」の代理シグナルに `visible` を復帰させる（`runtime.rs:270`）ため、show は外から `set_visible(true)+set_focus()` を打てば runtime が観測して repaint まで運ぶ。
-3. **両ウィンドウは同じ `tauri::Window` 抽象を共有する。** WebView2 ウィンドウも egui ウィンドウも `.show()`/`.hide()`/`.set_focus()`/`.hwnd()`/`.set_position()` を持つ。ゆえに show/hide の Win32 レベルの骨格（表示・フォーカス・位置・残留 Alt 解除・WM_NULL 同期）は**両経路で文字通り同一**で、共通の window ハンドルに対して回せる。真に分岐するのは renderer と frontend の副作用だけ（後述 backend seam）。
-4. **egui ウィンドウは webview 無しで生成できる**（probe `main.rs:740`・`snotra-egui-mvp/CLAUDE.md` 不変条件「`tauri::Window::builder` だけで生成」「`app.windows` は空」）。`msedgewebview2.exe` 子孫 0 を維持する（`src-tauri/CLAUDE.md`「WebView2 ウィンドウ生成の制約」）。
+1. **フラグ選択は config の実行時ミューテーションで行う**（codex #2 の解）。製品 "main" 窓は `tauri.conf.json` の宣言生成（`src-tauri/tauri.conf.json:14-28`）。E2E feature は `app_context.config_mut().app.windows` を実行時に書き換えてブラウザ引数を注入する（`main.rs:588-599`・`configure_e2e_webview`）。**同じ経路でフラグ ON のとき `config_mut().app.windows` から "main" を除去**すれば、Tauri は WebView2 窓を作らず（子孫 0）、egui を programmatic 生成できる。**フラグ OFF は宣言窓も E2E 注入も完全に不変**——`tauri.conf.json` は書き換えない。
+2. **`plan_hotkey` は spike で実証済み**（`soft_host_main.rs:139-147`）。`plan_hotkey(visible, alt_pressed) -> HotkeyPlan{HideNow|ShowAfterAltRelease|ShowNow}`。表示中なら即 hide、非表示中は Alt 押下中なら解放待ち後 show。これは egui/WebView2 両経路が同じ意味論で使う純粋核。**`plan_ui_action`/`LifecycleState`/`Recreating`/`Defer` は採らない**（下記「否定の知識」）。
+3. **egui window は webview 無しで生成できる**（probe `snotra-egui-mvp/src/main.rs:740`・`snotra-egui-mvp/CLAUDE.md`）。`msedgewebview2.exe` 子孫 0 を維持。
+4. **focus 観測は view 内 egui 入力**（probe `main.rs:174`: `ctx.input(|i| i.focused)`）。runtime は tao の `Focused` を egui 入力へ流し込み済みで、blur policy を **src-tauri の view 側**に置ける。runtime API を拡張しない。
+5. **`EguiRuntime::install` は `&mut tauri::App<Wry>` を取る**（`runtime.rs:77`・codex #1）。生成関数 `create` は setup クロージャの `&mut App` を受ける。
 
 ### 実装初手で確定させる検証ゲート（崩れると設計が反転する）
 
-- **G0（宣言→programmatic 変換 byte-identical）**: `tauri.conf.json` の `windows` を空にし `build_webview2_window` で宣言窓を逐語再現した直後、`SNOTRA_EGUI_MAIN` 未設定で `smoke:startup` / `e2e:tauri` が緑（宣言時と挙動一致）。**最初に接地するゲート**——窓生成の変換が flag OFF を壊さないことを、show/hide 整合より前に確定する。
-- **G1（フラグ OFF byte-identical・show/hide 整合後）**: WebView2 の `resume`/`suspend`/`emit`/`trim` を backend フックへ逐語で寄せた後、`SNOTRA_EGUI_MAIN` 未設定で `smoke:startup` / `e2e:tauri` が緑を保つ（回帰なし）。整合の代償（既存 WebView2 経路を触る）が回帰を生まないことを接地する。
-- **G2（hotkey → egui show の配線）**: 製品ホットキーは Win32 `RegisterHotKey`（platform スレッド）→ `emit("hotkey-pressed")` → listener。listener は egui 経路では `get_window("main")`（`tauri::Window`）を掴む必要がある（`get_webview_window("main")` は egui ウィンドウに対し `None`）。emit→listener→egui show が実機で 1 回通ることをトレースで確認する（初手スモーク）。
-- **G3（focus-lost 観測の起動）**: probe `main.rs:174` は focus を **refocus** に使うのみで自動非表示は実装していない。SU2 は focus 喪失で猶予タイマを起こす。`Focused(false)` → egui repaint → view が `!focused` を観測 → `request_repaint_after(100ms)` が発火 → 猶予明け判定、の一巡が実機で回ることを確認する。
-- **G4（外部 hide と runtime.visible の両立）**: hotkey トグル hide は listener から `window.hide()`（外部）で行う。隠れたウィンドウには `RedrawRequested` が配送されないため runtime は描かない（SU1 不変条件⑥の paint ゲートと衝突しない）ことを、hide 後のアイドルで present 失敗リトライstorm が起きないことで確認する。
+- **G1（フラグ OFF 完全不変）**: `config_mut().app.windows` の条件付き除去はフラグ ON のときだけ走る。フラグ未設定で `smoke:startup` / `e2e:tauri` が緑（WebView2 経路・E2E 注入とも無改変）。**最優先ゲート**——簡素化の眼目は「flag OFF を一行も触らない」こと。
+- **G2（hotkey → egui show の配線）**: 製品ホットキー（Win32 `RegisterHotKey` → `emit("hotkey-pressed")` → listener）が egui 経路では `get_window("main")` を掴む必要がある。emit→listener→egui show が実機で 1 回通ることを確認（初手スモーク）。
+- **G3（hide→show で runtime が確実に再描画する・codex #4）**: egui の全 hide を**外部 `window.hide()`** で行い（`RuntimeFrame::hide_window` を使わない）、runtime の `visible` を false にしない。隠れ窓は `RedrawRequested` が来ないので描かれず、show（`window.show()`）で OS が配送を再開すると runtime が `visible=true` のまま再描画する。hide→show サイクルで空白窓（`set_focus` 失敗時に `Focused(true)` が来ず runtime が描かない縁）が起きないことを確認。**起きるなら** runtime に最小の「可視化/再描画」フックを足す（SU1 隣接・要相談）。
+- **G4（`config_mut` 除去が子孫 0 を生む）**: フラグ ON で `msedgewebview2.exe` 子孫 0。宣言窓が二重生成されない。
 
-## backend seam（整合の実体・薄い 2〜3 フック）
+## フラグと生成（簡素化後）
 
-**共有オーケストレーションを 1 本に保ち、renderer + frontend 固有の副作用だけをフックへ逃がす。** backend は enum 2 値（`MainBackend::{ WebView2, Egui }`）。フラグが選ぶのは「生成時にどちらの window+backend を作るか」の一点。SU7 は `WebView2` variant とそのフック中身を delete するだけで egui が素で残る（trait を作り込まない）。
+- **`SNOTRA_EGUI_MAIN=1`**（env・`main()` で 1 回読む。`crate::trace::env_flag`）。
+- **`tauri.conf.json` は不変**（宣言窓 "main" を残す）。
+- **`main()`**: `generate_context!()` と E2E 注入ブロックの後、フラグ ON なら `app_context.config_mut().app.windows` から `label=="main"` を除去（`.retain(|w| w.label != "main")`）。これで Tauri は WebView2 窓を作らない。
+- **setup（フラグ ON）**: `egui_shell::create(app)`（`&mut App`）が `EguiRuntime::install(app)` → `tauri::Window::builder(app, "main")`（webview 無し・`visible(false)`・`decorations(false)`・600×52）→ `attach(window, SearchWindowView::new(app_handle))`。生成は setup 限定。
+- **setup（フラグ OFF）**: 変更なし。宣言窓が Tauri により生成され、既存 WebView2 経路がそのまま動く。
+- **ラベルは両方 `"main"`**: egui 経路は `get_window("main")` で掴む。フラグ OFF の `get_webview_window("main")` 依存（幅復元・config 幅反映・位置保存・Settings 制御）は宣言窓が在るので従来どおり動く。フラグ ON でそれらが no-op になる箇所（幅反映は SU3/SU6・幅復元は placeholder 固定 600px で無害）は各所で確認する（codex #9/#11）。
 
-```
-fn show_main(app, backend, t0):              // ← 両経路が通る唯一の show 経路
-    main_visible = true                      // 共有（policy フラグ・後述「2 つの visible」）
-    backend.pre_show(app)                     //  WV2: resume_webview   / Egui: nop
-    position_on_target_monitor(window)        //  共有（hwnd 経由・monitor.rs）
-    window.show(); set_focus();               //  共有（Win32・#558 順序）
-    WM_NULL 同期待ち; 残留 Alt 解除            //  共有（focus 確定 & 物理 Alt 解放後にのみ注入）
-    backend.post_show(app, t0)                //  WV2: resume 再適用 + ime_control + emit("window-shown")
-                                              //  Egui: ime_control のみ（repaint は runtime 任せ）
-
-fn hide_main(app, backend):
-    window.hide(); main_visible = false       //  共有
-    backend.post_hide(app)                    //  WV2: emit("window-hidden") + suspend + trim
-                                              //  Egui: nop
-```
-
-- **フックは 3 つ**: `pre_show` / `post_show` / `post_hide`。WV2 の `resume` は show の**前後 2 回**積む必要がある（#576 の残余窓是正）ため pre/post に分けて保つ。egui 側の中身は `pre_show`/`post_hide` が空、`post_show` は ime_control のみ。
-- **移すのは逐語**: `resume_webview`/`suspend_and_trim_after_hide`/`emit(window-shown|hidden)`/`working_set::trim` の既存コードをフックへ寄せるだけで、順序制約（`src-tauri/CLAUDE.md`「TrySuspend / Resume パターン」の FIFO 直列化・emit を suspend より先）は温存する。
-- **`plan_hotkey`/`plan_ui_action` は backend 非依存の共有決定核**。両経路が同じ核を呼び、副作用適用（`show_main`/`hide_main`）だけが backend で分岐する。
-
-**留保（設計の限界を明示）**: 「差異は WebView2/egui と frontend だけ」が literal に成り立つのは **SU2 の外殻まで**。内側 UI（検索・モード・結果＝SU3）は JS のイベント駆動と egui の即時モードで質が異なり、薄いフックには収まらない。SU2 のスコープが外殻なので、いま整合できる範囲＝整合すべき範囲が一致する。
-
-## 状態機械のデータフロー（合流点は 1 つ）
+## egui 経路の show/hide（専用・共有は位置計算のみ）
 
 ```
-Alt+Q（platform thread RegisterHotKey → emit "hotkey-pressed"）
-  → listener: サイドカーガード（SettingsProcessState）→ plan_hotkey(main_visible, alt_pressed)
-       HideNow(hotkey_toggle 時) / ShowNow / ShowAfterAltRelease → HostCommand
-Escape・focus-lost（view が egui 入力で観測）                    → HostCommand::Hide
-                    │
-                    ▼
-   controller: plan_ui_action(LifecycleState, cmd) → UiAction を適用
-       Show    → show_main(app, backend, t0)
-       Hide    → hide_main(app, backend)   （view 起点でも必ず controller を通す。加えて view は
-                                            RuntimeFrame::hide_window を呼び 1 フレーム早く paint を止めてよい＝迂回ではなく前倒し）
-       Refocus → window.set_focus()        （冪等: 表示中 + Show）
-       Defer   → FramePresented 後まで Hide 繰り延べ
-       Ignore  → 何もしない                （非表示中 + Hide 等）
-   → transition で LifecycleState 前進、main_visible を coherent に更新
+show_egui_main(app, t0):
+    main_visible = true                       // AppState.main_visible（policy・plan_hotkey 入力）
+    position_on_target_monitor(app, &window)  // 唯一の共有（&tauri::Window 一般化）
+    window.show(); window.set_focus()          // Win32・runtime は Focused(true) で visible 復帰
+    WM_NULL 同期待ち; 残留 Alt 解除             // focus 確定後かつ物理 Alt 解放後のみ（#558）
+    // ime_off_on_show が有効なら Win32 IME off（hwnd 経由）
+    // emit は無し（JS フロントが無い）
+
+hide_egui_main(app):
+    save_placement_relative(app, &window)      // save-on-hide（JS チョークポイントが無い）
+    window.hide(); main_visible = false        // 外部 hide（RuntimeFrame::hide_window は使わない・#4）
 ```
 
-- **合流点（controller）は 1 つ**: hotkey・Escape・focus-lost の全 Hide/Show 要求が `plan_ui_action` を通る。冪等性と Defer をここに一元化する（散らさない）。
-- **egui 経路では `Recreating` は transient・`Defer` は runtime 到達不能**: egui の show は同期（`window.show()` は即・SU1 runtime は surface を再生成せず `Focused` 観測で repaint）ゆえ「最初のフレーム提示を待つ」mid-flight race が無い。controller は `Show` 適用時に `Show→FramePresented` を即座に畳んで `Visible` へ進める（さもないと後続 Hide が `Recreating+Hide→Defer` に吸われ、`FramePresented` を誰も emit せずデッドロックする）。**`Defer` の純粋契約は `plan_ui_action` のユニットテストで固定する**（roadmap「Defer をテストで固定」を満たす）が、live では走らない。将来 async show を導入するなら再活性化する。
-- **2 つの `visible` を混同しない**（SU1 申し送り + 助言）: `AppState.main_visible`（policy＝`Standby`/`SearchVisible` 判定・`plan_hotkey` の入力）と `runtime.visible`（SU1 の描画ゲート・不変条件⑥）は**別物**。egui 経路は自前の policy フラグ（`main_visible`）を runtime の描画ゲートと独立に持つ。
-- **hotkey listener の toggle 判定**: `hotkey_toggle` は config live-read（既存の #576 パターン踏襲・キャッシュしない）。`hotkey_toggle && main_visible` で hide、さもなくば show。
+- **状態は `AppState.main_visible`（bool）だけ**。controller も 4 状態機械も持たない。ホットキーは `plan_hotkey(main_visible, is_alt_pressed())` で分岐する。
+- **全 hide は外部 `window.hide()`**（codex #4/#7 の解）。`RuntimeFrame::hide_window`（runtime.visible=false）は使わない。これで (a) 次の show が `Focused(true)` に依存せず確実に描け、(b) hide の副作用所有が一箇所（`hide_egui_main`）に一元化する。
+- **`main_visible` は `AtomicBool`**（`state.rs:17`・既存）。hotkey（メインスレッド）と hide 経路が触るが単一 atomic ゆえ tear しない。plan_hotkey の判定→show/hide は各トリガーが直列に行う（controller の lock 非保持競合＝codex #5 は controller を廃したことで消える）。
+
+## 状態機械のデータフロー
+
+```
+Alt+Q（platform thread → emit "hotkey-pressed"）
+  → listener（フラグ ON 分岐）: サイドカーガード → plan_hotkey(main_visible, is_alt_pressed())
+       HideNow(hotkey_toggle 時) → hide_egui_main
+       ShowNow                   → show_egui_main
+       ShowAfterAltRelease       → spawn: alt 解放待ち → generation 確認 → show_egui_main
+Escape・focus-lost（view が egui 入力で観測）
+  → view が emit("egui-hide-requested")（多重防止フラグで 1 回）
+  → src-tauri listener → hide_egui_main    // view から直接 window を触らず listener 合流（#7）
+```
+
+- **view は window を直接 hide しない**（codex #7）。focus-lost/Escape を検出したら `app_handle.emit("egui-hide-requested")` し、src-tauri の listener（メインスレッド）が `hide_egui_main` を呼ぶ。hide の副作用（位置保存・window.hide・main_visible）は listener 側の 1 経路に集約する。
+- **2 つの visible を混同しない**: `AppState.main_visible`（policy）と runtime 内 `visible`（SU1 描画ゲート）。本設計では runtime.visible は常に true に保つ（外部 hide のみ使う）。
 
 ## blur 自動非表示（policy は src-tauri 側 view に置く）
 
-- **観測**: `view` が `ctx.input(|i| i.focused)` で focus 喪失を検出（要石2・G3）。focus→unfocus の遷移で `unfocus_at` を記録し `request_repaint_after(100ms)` を積む。
-- **判定（猶予明け）**: なお非表示 **かつ** `auto_hide_on_focus_lost`（config live-read）**かつ** `SettingsProcessState` が非起動、の三条件で `HostCommand::Hide` を controller へ。refocus で pending を破棄。
-- **サイドカーガード必須**（助言・`/state-check` 型の相互作用）: `snotra-settings` を開くと focus を奪い `alwaysOnTop` を落とす。ここで hide してはならない。既存 hotkey listener の `SettingsProcessState` ガードと同型を focus-lost 経路にも置く。
-- **policy は runtime クレートに漏らさない**: 100ms 猶予・config ゲート・サイドカーガードはすべて製品 policy。view（`src-tauri` コード）が `app_handle` 経由で config/`SettingsProcessState` を読んで決める。product 非依存の `snotra-egui-runtime` には置かない。
-- WebView2 経路は従来どおり JS `onFocusChanged` + `config_watcher` のゲート（`auto-hide-focus-lost-changed`）で不変。egui はこれを view 内でネイティブに再実装する（JS リスナーは無い）。SPEC §8.1 の「100ms 猶予付き」に一致させる。
+- **観測**: view が `ctx.input(|i| i.focused)` で focus 喪失を検出。focus→unfocus 遷移で `unfocus_at=Some(now)` + `request_repaint_after(100ms)`。
+- **判定（猶予明け）**: なお非表示 **かつ** `auto_hide_on_focus_lost`（config live-read）**かつ** `SettingsProcessState` 非起動、で `emit("egui-hide-requested")`（多重防止）。
+- **stale 猶予の防止（codex #8）**: `focused` のとき `unfocus_at=None`。加えて **show のたびに view 側の `was_focused`/`unfocus_at` をリセット**（再表示直後に前回の stale な猶予で即 hide しない）。focus 復帰と多重 focus-loss を状態として扱う。
+- **サイドカーガード必須**（`/state-check` 型）: `snotra-settings` は focus を奪うので focus-lost で hide してはならない。
+- **policy は runtime クレートに漏らさない**: 100ms 猶予・config ゲート・サイドカーガードは view（src-tauri）が `app_handle` 経由で読む。
+
+## SPEC §8.5 の alwaysOnTop（codex #3・SU2 に最小で含める）
+
+現行は `snotra-settings` 起動中にメインの `alwaysOnTop=false`、終了検知で復元する（`SPEC.md:412`）。この制御は `get_webview_window("main")` にキーされ、egui 窓では no-op になる。**egui 窓が常に最前面のまま設定 UI を覆うのは dogfooding を不能にする**ため、SU2 に最小で含める: 設定 launch/exit 監視で、フラグ ON なら `get_window("main")` に対し `set_always_on_top(false/true)` を適用する（`get_webview_window` 分岐と並置）。**これは §8.5 の parity であって設定サイドカー共存の本体（SU6）ではない**——SU6 は config 反映・終了保存の統合を担う。
 
 ## 再利用する renderer 非依存部品
 
-- **残留 Alt 解除**（#558）: focus 確認後**かつ物理 Alt が解放済み**のときにのみ `SendInput` で注入。物理 Alt 押下中に key-up を注入すると OS 論理修飾キーが物理キーと desync し Alt+Q が dead-zone する（既存 `show_and_focus_main` の #558 nuance を踏襲）。
-- **`monitor.rs`**: `window.hwnd()` に対し作業領域クランプ・中央配置。物理座標ベースで backend 非依存。
-- **`window.bin` 相対座標保存**・`setup_first_run`（`--first-run` で `snotra-settings` 起動）・`setup_exit_listener`（history/icon flush は engine 級で不変）。
+- **残留 Alt 解除**（#558）: `is_alt_pressed()`/`wait_alt_release_or_timeout()`/`send_alt_key_up()`（`main.rs:90,106,131`）。focus 確定後かつ物理 Alt 解放後にのみ注入。
+- **位置計算**: `position_on_target_monitor`（`main.rs:329`）を `&tauri::WebviewWindow` → `&tauri::Window` へ一般化（唯一の共有点）。`monitor.rs`・`window_data::load_search_placement()`/`save_search_placement()` を再利用。
+- `setup_first_run`（`--first-run` で `snotra-settings` 起動）・`setup_exit_listener`（history/icon flush）はフラグに依らず不変。
 
 ## 位置永続
 
-- **復元**: show 経路で `position_on_target_monitor`（順序: **サイズ確定 → 位置 → show**）。SPEC §8.2 のマルチモニター規約（作業領域原点からの相対物理座標・`follow_cursor_monitor` でターゲット決定・クランプ・保存なしは中央）を踏襲。
-  - **順序制約の SU3 申し送り**: 製品 WebView2 は「高さリセット（52px 折りたたみ）→ 位置 → show」で、位置計算を折りたたみサイズでクランプする（`src-tauri/CLAUDE.md`「`show_main_and_emit` の操作順序制約」）。SU2 の placeholder は固定サイズゆえ高さリセットは no-op だが、**結果リストで高さが動的化する SU3 でこの結合が活性化する**ことを明記する。
-- **保存**: **save-on-hide** を主とする（hide 時に現在位置を相対座標で `window.bin` へ保存）。JS チョークポイントが無い egui 経路では、これが最も単純で十分（次回 show で復元・最終ドラッグ位置は hide 時に捕捉）。
-  - 表示中終了に備え `setup_exit_listener` でも可視時に位置保存を積む（history/icon flush と同じ終了フラッシュ）。
-  - **ドラッグ中デバウンス保存は WANT**: ドラッグは `RuntimeFrame::drag_window`（既存）で動くが、`Moved` を観測してデバウンス保存する経路は現状空白。低コストで載らなければ defer（save-on-hide があるため機能欠落にはならない）。
-
-## フラグと生成
-
-**重要な as-built 事実**: 製品の "main" 窓は **`tauri.conf.json` の `windows[]` で宣言的生成**される（`label:"main"`・`url:"main.html"`・600×52・`visible:false`・`decorations:false`・`skipTaskbar:true`・`alwaysOnTop:true`・`resizable:false`・`center:true`）。setup に `WebviewWindowBuilder` は無い。`build.rs` が config をコンパイル時に焼き込むため、実行時 env フラグで宣言窓だけ抑止する手は無い（`src-tauri/CLAUDE.md`「WebView2 ウィンドウ生成の制約」）。ゆえに **egui が WebView2 を置き換える（子孫 0・ラベル `"main"` 共有）には、宣言窓を config から外し、両経路とも setup で programmatic 生成へ寄せる**（2026-07-22 決定・programmatic 統一）。
-
-- **`SNOTRA_EGUI_MAIN=1`**（env・setup フェーズで 1 回読む。`SNOTRA_DISABLE_SUSPEND`/`SNOTRA_TRACE` と同じ流儀）。ユーザー向け config には出さない（移行/ドッグフード用）。
-- **`tauri.conf.json`**: `app.windows` を **`[]`（空）** にする。宣言窓を廃し、両経路とも programmatic 生成にする。CSP・bundle・plugins は不変。
-- **ON**: `EguiRuntime::install(app)` → `tauri::Window::builder(app, "main")`（webview 無し・`decorations(false)`・`visible(false)`・600×52）→ `runtime.attach(window, SearchWindowView::new(...))`。WebView2 ウィンドウは**作らない**。
-- **OFF**: `build_webview2_window(app)`（新規）が `WebviewWindowBuilder::new(app, "main", WebviewUrl::App("main.html"))` で**宣言窓の 10 フィールドを逐語再現**（title/size/visible:false/decorations:false/skipTaskbar/alwaysOnTop:true/resizable:false/center）。挙動を宣言時と一致させる（G0）。
-- **ラベルは `"main"` を踏襲**: `position`/`window.bin`/`monitor.rs`・既存 `get_webview_window("main")` 経路が同ラベルで動く。WebView2 固有経路（resume/suspend・IPC コマンド）は egui ウィンドウを型で掴めず（`get_webview_window` は `None`）、かつ各入口（hotkey listener・`setup_startup_display`・focus-lost）で backend/flag 分岐するため egui 経路では**到達しない**。
-- **生成は setup 限定**（同上制約: `WebviewWindowBuilder::build()` はメッセージポンプ進行を要求。setup フェーズは自前で処理でき正常）。egui ウィンドウ（tao）も同様に setup で生成し、ランタイムでは show/hide のみ。
+- **復元**: `show_egui_main` の `position_on_target_monitor`（順序: サイズ確定 → 位置 → show）。SPEC §8.2 のマルチモニター規約（相対物理座標・`follow_cursor_monitor`・クランプ・中央フォールバック）を踏襲。SU2 placeholder は固定サイズゆえ高さリセットは不要だが、結果リストで高さが動的化する **SU3 で高さリセット→位置→show の結合が活性化**する旨を申し送る。
+- **保存**: **save-on-hide**（`hide_egui_main`）+ 可視時終了保存（`setup_exit_listener`）。
+- **ドラッグ中デバウンス保存は残余（codex #10）**: SPEC §8.2 はデバウンス保存を要求するが、`Moved` 観測経路が現状空白。save-on-hide は Alt+F4/クラッシュで位置を巻き戻す穴が残る。低コストで `Moved`→デバウンス保存を載せられれば載せ、困難なら **SU2 の受容する残余**として記録し SU3/SU6 で解消する（placeholder 段階では優先度低）。
 
 ## placeholder view と font-first（SU1 申し送りの義務）
 
-- `SearchWindowView: EguiView`（`egui_shell/view.rs`）は SU2 では最小 chrome（検索バー枠 + 最小テキスト）を描く。本体（検索・結果・モード）は SU3 が埋める。
-- **font-first カナリア必須**（SU1 申し送り・`snotra-egui-mvp/CLAUDE.md` #579）: `SearchWindowView::setup` は `jp_font` を Proportional/Monospace 両 family の **index 0**（`insert(0, ...)`）に置く。`push`（末尾 fallback）にすると Latin=egui 既定 / CJK=Yu Gothic の 2 フォントに分離し、被覆 AA を持たない softbuffer が vertical metrics 差を整数 px に丸めてベースラインずれ（#399/#579）を顕在化させる。glow/wgpu は sub-pixel AA で隠すが softbuffer は露見する。**型検査・clippy・単体テストを素通りし視覚でのみ出る**ため、実 `setup` を駆動する config テストで先頭配置を機構的に固定する。
+- `SearchWindowView: EguiView`（`egui_shell/view.rs`）は最小 chrome（検索バー枠 + 混在テキスト）を描く。本体は SU3。
+- **font-first カナリア必須**（`snotra-egui-mvp/CLAUDE.md` #579）: `setup` は `jp_font` を Proportional/Monospace の **index 0**（`insert(0, ...)`）。`push` にすると softbuffer で #399/#579 のベースラインずれ再発。実 `setup` を駆動する config テストで固定。
 
 ## 変更目録（`src-tauri`）
 
 | 対象 | 扱い |
 |---|---|
-| `src-tauri/src/egui_shell/mod.rs`（新規） | `MainBackend` enum・生成（`Window::builder`+`install`+`attach`）・`show_main`/`hide_main` 共有オーケストレーション・backend フック（`pre_show`/`post_show`/`post_hide`）・controller（合流点） |
-| `src-tauri/src/egui_shell/lifecycle.rs`（新規・純粋核） | `HotkeyPlan`/`plan_hotkey`・`LifecycleState`/`LifecycleEvent`/`transition`・`HostCommand`/`UiAction`/`plan_ui_action`。Win32 非依存・ユニットテスト対象。spike から移植 |
-| `src-tauri/src/egui_shell/view.rs`（新規） | `SearchWindowView: EguiView`（placeholder）。`setup` で font-first・`update` で focus 観測（自動非表示の起点） |
-| `src-tauri/tauri.conf.json` | `app.windows` を `[]` にする（宣言窓廃止）。CSP・bundle・plugins は不変 |
-| `src-tauri/src/main.rs` | setup 本体に **窓生成の flag 分岐**（`if egui_main { egui_shell::create } else { build_webview2_window }`）を足す。`build_webview2_window`（新規）が宣言窓 10 フィールドを `WebviewWindowBuilder` で逐語再現。各 setup 関数（`setup_hotkey_listener`・`setup_startup_display`）に `if egui_main { egui_shell::... } else { 既存 }` の入口分岐。WebView2 の `resume`/`suspend`/`emit`/`trim` を `MainBackend::WebView2` のフックへ**逐語移動**。既存の判定・順序は温存 |
-| WebView2 経路の既存ファイル（`commands/`・`config_watcher.rs` 等） | **触らない**（SU2 の egui view は placeholder ゆえ IPC/config 反映は SU3/SU6）。exit-save の位置保存のみ egui 可視時に追加 |
-| `Cargo.toml`（`src-tauri`） | **`snotra-egui-runtime = { path = "../snotra-egui-runtime" }` を新規追加**（現状 `src-tauri` は未依存＝workspace member だが dep ではない・実測）。`EguiRuntime`/`EguiView`/`RuntimeFrame` を使うため |
+| `src-tauri/src/egui_shell/mod.rs`（新規） | `create(&mut App)`・`show_egui_main`/`hide_egui_main`・`plan_hotkey` の re-export・`egui-hide-requested` listener 登録・`save_placement_relative` |
+| `src-tauri/src/egui_shell/lifecycle.rs`（新規・純粋核） | `HotkeyPlan`/`plan_hotkey` のみ。Win32 非依存・ユニットテスト。spike から移植 |
+| `src-tauri/src/egui_shell/view.rs`（新規） | `SearchWindowView`（placeholder）。`setup` で font-first・`update` で focus 観測 → `emit("egui-hide-requested")` |
+| `src-tauri/src/main.rs` | `main()` に `config_mut().app.windows` の条件付き "main" 除去。setup に窓生成の flag 分岐（`egui_shell::create`）。`setup_hotkey_listener`/`setup_startup_display`/`setup_exit_listener`/設定 launch-exit（§8.5）に flag 分岐。`position_on_target_monitor` を `&tauri::Window` へ一般化 |
+| `src-tauri/src/main.rs`（`show_and_focus_main` 等） | **WebView2 経路は変更しない**（`show_main_and_emit`・resume/suspend/emit・hooks 化はしない）。共有するのは `position_on_target_monitor` の型一般化のみ |
+| `src-tauri/Cargo.toml` | `snotra-egui-runtime = { path = "../snotra-egui-runtime" }` 追加（現状未依存） |
+| `src-tauri/tauri.conf.json` | **不変**（宣言窓を残す） |
 
 ## テスト計画
 
-- **純粋核（ユニット・Win32 非依存）**: spike のテスト（`soft_host_main.rs:1590-1640`）を `egui_shell/lifecycle.rs` へ移植。
-  - `plan_hotkey` 表: `(false,false)→ShowNow`・`(false,true)→ShowAfterAltRelease`・`(true,_)→HideNow`。
-  - `plan_ui_action` 表: **冪等** `Visible+Show→Refocus`・`Suspended+Hide→Ignore`、**Defer** `Recreating+Hide→Defer`、`Recreating+Show→Ignore`、`Exiting+_→Ignore`。
-  - `transition` の valid（`Visible+Hide→Suspended` 等）/ invalid（未定義遷移は `Err`）。
-- **font-first カナリア**: 実 `SearchWindowView::setup` を駆動し `jp_font` が両 family index 0（`push` なら fail する canary）。
-- **flag-OFF 回帰（G1）**: `SNOTRA_EGUI_MAIN` 未設定で既存 WebView2 テスト + `smoke:startup` / `e2e:tauri` 緑。resume/suspend/emit の逐語移動が挙動を変えないこと。
-- **スモーク（trace ベース・`src-tauri.md` カテゴリ C。Win32 依存ゆえユニット前提にしない）**: `SNOTRA_EGUI_MAIN=1` で
-  - 起動時表示（`show_on_startup`）/ 初回フロー（`--first-run` で `snotra-settings` 起動）
-  - hotkey show / hide（トグル）・`ShowAfterAltRelease`（Alt 押下中の解放待ち）
-  - Escape hide / focus-lost 自動非表示（100ms 猶予）・**サイドカー起動中は非 hide**（ガード検証）
-  - 位置復元（マルチモニター・クランプ）と save-on-hide
-  - `msedgewebview2.exe` 子孫 0 の確認
+- **純粋核（ユニット）**: `plan_hotkey` 表（`(false,false)→ShowNow`・`(false,true)→ShowAfterAltRelease`・`(true,_)→HideNow`）。
+- **font-first カナリア**: 実 `SearchWindowView::setup` を駆動し jp_font が両 family index 0。
+- **flag-OFF 完全不変（G1）**: `SNOTRA_EGUI_MAIN` 未設定で既存テスト + `smoke:startup` + `e2e:tauri` 緑。`config_mut` 除去がフラグ ON でしか走らないこと。
+- **スモーク（trace ベース・Win32 依存ゆえユニット前提にしない）**: `SNOTRA_EGUI_MAIN=1` で 起動時表示/初回フロー・hotkey show/hide/`ShowAfterAltRelease`・Escape/focus-lost 自動非表示（100ms・サイドカー起動中は非 hide）・**hide→show を反復して空白窓が出ない（G3）**・設定起動で最前面を明け渡す（§8.5）・位置復元/save-on-hide・`msedgewebview2.exe` 子孫 0（G4）。
 
 ## 受け入れ条件（SU2）
 
-1. Alt+Q 表示/非表示・blur 自動非表示・フォーカス列・残留 Alt 解除・位置永続・起動時表示・初回フローが SPEC §8（8.1–8.6）と一致する（egui 経路・trace スモークで実証）。
-2. **フラグ OFF で WebView2 挙動が不変**（G0 + G1 緑・回帰なし）。宣言→programmatic 窓生成の変換（`build_webview2_window` が 10 フィールド逐語再現）と、resume/suspend/emit/trim のフック移動が、既存挙動・順序制約を温存する。`app.windows=[]` で宣言窓が二重生成されない。
-3. **`plan_hotkey`/`plan_ui_action` が純関数**として `egui_shell/lifecycle.rs` に在り、冪等性（表示中+Show / 非表示中+Hide）と show 進行中 Hide の Defer がユニットテストで固定される。
-4. focus-lost 自動非表示の policy（100ms 猶予・`auto_hide_on_focus_lost` ゲート・サイドカーガード）が `src-tauri` の view 側にあり、`snotra-egui-runtime` の公開 API を拡張していない。
-5. `SearchWindowView::setup` の font-first が実 setup 駆動テストで機構化されている。
-6. `cargo clippy --workspace --all-targets` 緑・`src-tauri` テスト緑・`msedgewebview2.exe` 子孫 0（egui 経路）。
+1. Alt+Q・blur・フォーカス列・残留 Alt 解除・位置永続・起動時表示・初回フローが SPEC §8（8.1–8.6）と一致（trace スモーク）。
+2. **フラグ OFF で WebView2 挙動・E2E 注入が完全不変**（G1）。`config_mut().app.windows` 除去はフラグ ON でのみ走り、`tauri.conf.json`・`show_main_and_emit`・E2E 経路を触らない。
+3. `plan_hotkey` が純関数として `lifecycle.rs` に在りユニットテストされる。ホットキー分岐がテストで固定。
+4. blur policy（100ms 猶予・`auto_hide_on_focus_lost`・サイドカーガード・stale リセット）が view 側にあり runtime API を拡張していない。全 hide が外部 `window.hide()` で runtime.visible を false にしない（G3）。
+5. `SearchWindowView::setup` の font-first が実 setup 駆動テストで機構化。
+6. `cargo clippy -p snotra --all-targets` 緑・`src-tauri` テスト緑・`msedgewebview2.exe` 子孫 0（G4）。
 
 ## リスク
 
-- **既存 WebView2 経路を触る（整合の代償）**: resume/suspend/emit/trim のフック移動が #576/#361 の順序制約を壊すと hide/show 競合が再発する。G1（flag-OFF byte-identical）を最優先ゲートに置き、逐語移動 + 既存 e2e で押さえる。
-- **focus-lost 猶予タイマの immediate-mode 実装**: egui は即時モードゆえ 100ms 猶予を `request_repaint_after` + 状態フラグ（`unfocus_at`）で組む。refocus のキャンセルと猶予明けの再判定を取りこぼさないことを G3 + スモークで固定する。
-- **外部 hide と runtime.visible の二重管理**: hotkey トグル hide は外部 `window.hide()`、view 起点 hide は `RuntimeFrame::hide_window`。両者が `main_visible` と `runtime.visible` を coherent に保つこと（G4）。
-- **hotkey 配線の window 型差**: listener が egui では `get_window`、WebView2 では `get_webview_window` を掴む。入口分岐の取りこぼしが無いこと（G2）。
-- **Tauri 内部 API 追随**: `tauri-runtime-wry` unstable feature 依存は #532 既知。SU2 で新たな追随は増やさない。
+- **egui runtime の可視化（codex #4）**: 全 hide を外部化して runtime.visible を false に落とさない設計で回避するが、view 起点の hide も外部化（emit→listener）で通す必要がある。hide→show サイクルの空白窓不在を G3 で接地。破れるなら runtime に最小フックを足す（要相談）。
+- **フラグ ON での `get_webview_window("main")` no-op（codex #9/#11）**: 幅復元・config 幅反映・位置保存・Settings 制御が egui 窓を掴めない。SU2 で必要な §8.5（alwaysOnTop）は含める。幅系は placeholder 固定 600px で無害・本格対応は SU3/SU6。各所を列挙して確認する。
+- **デバウンス保存の欠落（codex #10）**: save-on-hide では Alt+F4/クラッシュで位置巻き戻り。残余として記録。
+- **Tauri 内部 API 追随**: `tauri-runtime-wry` unstable 依存（#532 既知）。SU2 で増やさない。
+
+## 否定の知識（なぜ初版の seam を却下したか）
+
+- **共有 `show_main` + `MainBackend` 3 フック seam を却下**（codex #13）。egui 専用で `plan_ui_action`/`Recreating`/`Defer` が live 到達不能。共有できるのは実質 show/hide/位置の数行で、enum seam は共通化でなく二重の状態所有と競合面（codex #5/#6/#7）を作る。→ egui 専用 `show_egui_main`/`hide_egui_main` に分離し、共有は `position_on_target_monitor` の型一般化のみ。SU7 は egui 関数を残し WebView2 を削除するだけ。
+- **`LifecycleController`（4 状態 + `plan_ui_action` + `Defer`）を却下**。roadmap SU2 受け入れは「`plan_ui_action`・冪等性・show 進行中 Hide の Defer をテストで固定」を課すが、**egui の show は同期**（`window.show()` は即・SU1 runtime は surface を再生成せず `Focused` 観測で repaint）ゆえ mid-flight race が無く、Defer は live 到達不能。controller の lock を critical section 全体で保持しない実装は競合を生む（codex #5）。→ **live は `main_visible`(bool) + `plan_hotkey` のみ**。roadmap のこの受け入れ条件は egui 同期 show の下では obsolete と判断（本 spec が roadmap を supersede する明示的逸脱）。
+- **`tauri.conf.json` の `app.windows=[]` 静的空化を却下**（codex #2）。E2E feature が宣言窓 "main" へブラウザ引数を注入するため空化は `e2e:tauri` を panic させる。→ フラグ ON のときだけ `config_mut().app.windows` を実行時に除去（flag OFF は宣言窓・E2E とも不変）。
+- **view から `RuntimeFrame::hide_window` で直接 hide を却下**（codex #4/#7）。runtime.visible=false が次 show の空白窓リスクを生み、controller 合流を破る。→ view は `emit("egui-hide-requested")` で listener へ委ね、全 hide を外部 `window.hide()` に一本化。
 
 ## スコープ外（SU2 では触らない）
 
-- 検索体験・クエリ/IME・インクリメンタル検索・直 `Engine`・IPC 撤去・結果リスト/行・キーボードナビ・フォルダ展開・インスタントコマンド・内側モード状態機械（Normal/Command/Tool/Folder/Instant/Indexing）は **SU3**。SU2 の view は placeholder。
-- アイコン抽出/キャッシュは SU4。updater は SU5。config 反映（テーマ/ホットキー/index を egui へ）は SU6。
-- 署名付き配布・portable ZIP・**既定を egui へ切替 + WebView2 経路撤去**は SU7。
+- 検索体験・IPC 撤去・内側モード状態機械は SU3。アイコンは SU4。updater は SU5。config 反映・**設定サイドカー共存の本体（終了保存統合等）**は SU6。切替・配布は SU7。
 - IME 再変換（reconvert）は WANT（SU5）。
+- ドラッグ中デバウンス保存は残余（低コストで載れば SU2、困難なら SU3/SU6）。
 - ルート `CLAUDE.md`/`AGENTS.md` 等の規範文書は変更しない。

--- a/docs/superpowers/specs/2026-07-22-su2-window-shell-design.md
+++ b/docs/superpowers/specs/2026-07-22-su2-window-shell-design.md
@@ -1,0 +1,165 @@
+# SU2 設計 — ウィンドウシェル + 状態機械（#532 Phase 2）
+
+- 種別: サブユニット設計（spec）。実装計画は本 spec 承認後に別途 writing-plans で作る
+- 日付: 2026-07-22
+- 親: `docs/superpowers/specs/2026-07-21-phase2-softbuffer-migration-roadmap.md`（SU2）／#532
+- 前段: `docs/superpowers/specs/2026-07-21-su1-softbuffer-runtime-design.md`（SU1・実装完了）
+- 履歴: 撤去済み spike（`soft_host_main.rs`・commit 7558cc8）から純粋核を復元し一次証拠化。焦点を絞った設計問答（構造の岐路 → backend seam の深さ）で硬化
+
+## 目的
+
+製品 `src-tauri` のメインウィンドウに、**WebView2 と並行して egui/softbuffer 経路**を env フラグ選択で立ち上げる「外殻」を作る。SU2 が持つのは `Standby ⇄ SearchVisible` の**外側の状態機械**——Alt+Q 表示/非表示・blur 自動非表示・フォーカス列・残留 Alt 解除・位置永続・起動時表示・初回フロー。内側の検索モード（Normal/Command/Tool/Folder/Instant/Indexing）と検索体験は SU3。SU2 の egui view は **placeholder**（show/hide/focus/位置が視覚的に検証できる最小の chrome）。
+
+## 決定の要石
+
+### 検証済み（この設計の前提・一次証拠）
+
+1. **純粋な決定核は spike で実証済み**（`soft_host_main.rs:131-207` から復元）。以下 2 関数を `src-tauri` へ移植する。設計を反転させる不確実性は無い:
+   - `plan_hotkey(visible, alt_pressed) -> HotkeyPlan{ HideNow | ShowAfterAltRelease | ShowNow }` — Alt+Q 押下時の分岐。表示中なら即 hide、非表示中は Alt 押下中なら解放待ち後 show。
+   - `plan_ui_action(state: LifecycleState, cmd: &HostCommand) -> UiAction{ Show | Hide | Refocus | Defer | Ignore }` — ホストコマンドを lifecycle 状態へ適用する計画。**冪等性**（`Visible+Show→Refocus`・`Suspended+Hide→Ignore`）と、**show 進行中に届いた Hide の繰り延べ**（`Recreating+Hide→Defer`）をここで一元決定する。
+   - `LifecycleState{ Visible | Suspended | Recreating | Exiting }` と `transition(state, event) -> Result<LifecycleState>`。`Recreating` は「show 済みで最初のフレーム提示待ち」。
+2. **focus 観測の経路が確定**（runtime 駆動 probe `snotra-egui-mvp/src/main.rs:174`）。runtime は tao の `Focused` を egui 入力へ流し込み済みで、`ctx.input(|i| i.focused)` で **EguiView（＝製品では `src-tauri` のコード）が focus を観測できる**。→ **blur 自動非表示のために `snotra-egui-runtime` の公開 API を拡張する必要はなく、SU2 は `src-tauri` 境界に留まる**（ロードマップの「境界: src-tauri」を満たす）。runtime は `Focused(true)` を「再表示された」の代理シグナルに `visible` を復帰させる（`runtime.rs:270`）ため、show は外から `set_visible(true)+set_focus()` を打てば runtime が観測して repaint まで運ぶ。
+3. **両ウィンドウは同じ `tauri::Window` 抽象を共有する。** WebView2 ウィンドウも egui ウィンドウも `.show()`/`.hide()`/`.set_focus()`/`.hwnd()`/`.set_position()` を持つ。ゆえに show/hide の Win32 レベルの骨格（表示・フォーカス・位置・残留 Alt 解除・WM_NULL 同期）は**両経路で文字通り同一**で、共通の window ハンドルに対して回せる。真に分岐するのは renderer と frontend の副作用だけ（後述 backend seam）。
+4. **egui ウィンドウは webview 無しで生成できる**（probe `main.rs:740`・`snotra-egui-mvp/CLAUDE.md` 不変条件「`tauri::Window::builder` だけで生成」「`app.windows` は空」）。`msedgewebview2.exe` 子孫 0 を維持する（`src-tauri/CLAUDE.md`「WebView2 ウィンドウ生成の制約」）。
+
+### 実装初手で確定させる検証ゲート（崩れると設計が反転する）
+
+- **G1（フラグ OFF byte-identical）**: WebView2 の `resume`/`suspend`/`emit`/`trim` を backend フックへ逐語で寄せた後、`SNOTRA_EGUI_MAIN` 未設定で `smoke:startup` / `e2e:tauri` が緑を保つ（回帰なし）。**これが最優先ゲート**——整合の代償（既存 WebView2 経路を触る）が回帰を生まないことを最初に接地する。
+- **G2（hotkey → egui show の配線）**: 製品ホットキーは Win32 `RegisterHotKey`（platform スレッド）→ `emit("hotkey-pressed")` → listener。listener は egui 経路では `get_window("main")`（`tauri::Window`）を掴む必要がある（`get_webview_window("main")` は egui ウィンドウに対し `None`）。emit→listener→egui show が実機で 1 回通ることをトレースで確認する（初手スモーク）。
+- **G3（focus-lost 観測の起動）**: probe `main.rs:174` は focus を **refocus** に使うのみで自動非表示は実装していない。SU2 は focus 喪失で猶予タイマを起こす。`Focused(false)` → egui repaint → view が `!focused` を観測 → `request_repaint_after(100ms)` が発火 → 猶予明け判定、の一巡が実機で回ることを確認する。
+- **G4（外部 hide と runtime.visible の両立）**: hotkey トグル hide は listener から `window.hide()`（外部）で行う。隠れたウィンドウには `RedrawRequested` が配送されないため runtime は描かない（SU1 不変条件⑥の paint ゲートと衝突しない）ことを、hide 後のアイドルで present 失敗リトライstorm が起きないことで確認する。
+
+## backend seam（整合の実体・薄い 2〜3 フック）
+
+**共有オーケストレーションを 1 本に保ち、renderer + frontend 固有の副作用だけをフックへ逃がす。** backend は enum 2 値（`MainBackend::{ WebView2, Egui }`）。フラグが選ぶのは「生成時にどちらの window+backend を作るか」の一点。SU7 は `WebView2` variant とそのフック中身を delete するだけで egui が素で残る（trait を作り込まない）。
+
+```
+fn show_main(app, backend, t0):              // ← 両経路が通る唯一の show 経路
+    main_visible = true                      // 共有（policy フラグ・後述「2 つの visible」）
+    backend.pre_show(app)                     //  WV2: resume_webview   / Egui: nop
+    position_on_target_monitor(window)        //  共有（hwnd 経由・monitor.rs）
+    window.show(); set_focus();               //  共有（Win32・#558 順序）
+    WM_NULL 同期待ち; 残留 Alt 解除            //  共有（focus 確定 & 物理 Alt 解放後にのみ注入）
+    backend.post_show(app, t0)                //  WV2: resume 再適用 + ime_control + emit("window-shown")
+                                              //  Egui: ime_control のみ（repaint は runtime 任せ）
+
+fn hide_main(app, backend):
+    window.hide(); main_visible = false       //  共有
+    backend.post_hide(app)                    //  WV2: emit("window-hidden") + suspend + trim
+                                              //  Egui: nop
+```
+
+- **フックは 3 つ**: `pre_show` / `post_show` / `post_hide`。WV2 の `resume` は show の**前後 2 回**積む必要がある（#576 の残余窓是正）ため pre/post に分けて保つ。egui 側の中身は `pre_show`/`post_hide` が空、`post_show` は ime_control のみ。
+- **移すのは逐語**: `resume_webview`/`suspend_and_trim_after_hide`/`emit(window-shown|hidden)`/`working_set::trim` の既存コードをフックへ寄せるだけで、順序制約（`src-tauri/CLAUDE.md`「TrySuspend / Resume パターン」の FIFO 直列化・emit を suspend より先）は温存する。
+- **`plan_hotkey`/`plan_ui_action` は backend 非依存の共有決定核**。両経路が同じ核を呼び、副作用適用（`show_main`/`hide_main`）だけが backend で分岐する。
+
+**留保（設計の限界を明示）**: 「差異は WebView2/egui と frontend だけ」が literal に成り立つのは **SU2 の外殻まで**。内側 UI（検索・モード・結果＝SU3）は JS のイベント駆動と egui の即時モードで質が異なり、薄いフックには収まらない。SU2 のスコープが外殻なので、いま整合できる範囲＝整合すべき範囲が一致する。
+
+## 状態機械のデータフロー（合流点は 1 つ）
+
+```
+Alt+Q（platform thread RegisterHotKey → emit "hotkey-pressed"）
+  → listener: サイドカーガード（SettingsProcessState）→ plan_hotkey(main_visible, alt_pressed)
+       HideNow(hotkey_toggle 時) / ShowNow / ShowAfterAltRelease → HostCommand
+Escape・focus-lost（view が egui 入力で観測）                    → HostCommand::Hide
+                    │
+                    ▼
+   controller: plan_ui_action(LifecycleState, cmd) → UiAction を適用
+       Show    → show_main(app, backend, t0)
+       Hide    → hide_main(app, backend)   （view 起点でも必ず controller を通す。加えて view は
+                                            RuntimeFrame::hide_window を呼び 1 フレーム早く paint を止めてよい＝迂回ではなく前倒し）
+       Refocus → window.set_focus()        （冪等: 表示中 + Show）
+       Defer   → FramePresented 後まで Hide 繰り延べ
+       Ignore  → 何もしない                （非表示中 + Hide 等）
+   → transition で LifecycleState 前進、main_visible を coherent に更新
+```
+
+- **合流点（controller）は 1 つ**: hotkey・Escape・focus-lost の全 Hide/Show 要求が `plan_ui_action` を通る。冪等性と Defer をここに一元化する（散らさない）。
+- **2 つの `visible` を混同しない**（SU1 申し送り + 助言）: `AppState.main_visible`（policy＝`Standby`/`SearchVisible` 判定・`plan_hotkey` の入力）と `runtime.visible`（SU1 の描画ゲート・不変条件⑥）は**別物**。egui 経路は自前の policy フラグ（`main_visible`）を runtime の描画ゲートと独立に持つ。
+- **hotkey listener の toggle 判定**: `hotkey_toggle` は config live-read（既存の #576 パターン踏襲・キャッシュしない）。`hotkey_toggle && main_visible` で hide、さもなくば show。
+
+## blur 自動非表示（policy は src-tauri 側 view に置く）
+
+- **観測**: `view` が `ctx.input(|i| i.focused)` で focus 喪失を検出（要石2・G3）。focus→unfocus の遷移で `unfocus_at` を記録し `request_repaint_after(100ms)` を積む。
+- **判定（猶予明け）**: なお非表示 **かつ** `auto_hide_on_focus_lost`（config live-read）**かつ** `SettingsProcessState` が非起動、の三条件で `HostCommand::Hide` を controller へ。refocus で pending を破棄。
+- **サイドカーガード必須**（助言・`/state-check` 型の相互作用）: `snotra-settings` を開くと focus を奪い `alwaysOnTop` を落とす。ここで hide してはならない。既存 hotkey listener の `SettingsProcessState` ガードと同型を focus-lost 経路にも置く。
+- **policy は runtime クレートに漏らさない**: 100ms 猶予・config ゲート・サイドカーガードはすべて製品 policy。view（`src-tauri` コード）が `app_handle` 経由で config/`SettingsProcessState` を読んで決める。product 非依存の `snotra-egui-runtime` には置かない。
+- WebView2 経路は従来どおり JS `onFocusChanged` + `config_watcher` のゲート（`auto-hide-focus-lost-changed`）で不変。egui はこれを view 内でネイティブに再実装する（JS リスナーは無い）。SPEC §8.1 の「100ms 猶予付き」に一致させる。
+
+## 再利用する renderer 非依存部品
+
+- **残留 Alt 解除**（#558）: focus 確認後**かつ物理 Alt が解放済み**のときにのみ `SendInput` で注入。物理 Alt 押下中に key-up を注入すると OS 論理修飾キーが物理キーと desync し Alt+Q が dead-zone する（既存 `show_and_focus_main` の #558 nuance を踏襲）。
+- **`monitor.rs`**: `window.hwnd()` に対し作業領域クランプ・中央配置。物理座標ベースで backend 非依存。
+- **`window.bin` 相対座標保存**・`setup_first_run`（`--first-run` で `snotra-settings` 起動）・`setup_exit_listener`（history/icon flush は engine 級で不変）。
+
+## 位置永続
+
+- **復元**: show 経路で `position_on_target_monitor`（順序: **サイズ確定 → 位置 → show**）。SPEC §8.2 のマルチモニター規約（作業領域原点からの相対物理座標・`follow_cursor_monitor` でターゲット決定・クランプ・保存なしは中央）を踏襲。
+  - **順序制約の SU3 申し送り**: 製品 WebView2 は「高さリセット（52px 折りたたみ）→ 位置 → show」で、位置計算を折りたたみサイズでクランプする（`src-tauri/CLAUDE.md`「`show_main_and_emit` の操作順序制約」）。SU2 の placeholder は固定サイズゆえ高さリセットは no-op だが、**結果リストで高さが動的化する SU3 でこの結合が活性化する**ことを明記する。
+- **保存**: **save-on-hide** を主とする（hide 時に現在位置を相対座標で `window.bin` へ保存）。JS チョークポイントが無い egui 経路では、これが最も単純で十分（次回 show で復元・最終ドラッグ位置は hide 時に捕捉）。
+  - 表示中終了に備え `setup_exit_listener` でも可視時に位置保存を積む（history/icon flush と同じ終了フラッシュ）。
+  - **ドラッグ中デバウンス保存は WANT**: ドラッグは `RuntimeFrame::drag_window`（既存）で動くが、`Moved` を観測してデバウンス保存する経路は現状空白。低コストで載らなければ defer（save-on-hide があるため機能欠落にはならない）。
+
+## フラグと生成
+
+- **`SNOTRA_EGUI_MAIN=1`**（env・setup フェーズで 1 回読む。`SNOTRA_DISABLE_SUSPEND`/`SNOTRA_TRACE` と同じ流儀）。ユーザー向け config には出さない（移行/ドッグフード用）。
+- **ON**: `EguiRuntime::install(app)` → `tauri::Window::builder(app, "main")`（webview 無し・`decorations(false)`・`visible(false)`・サイズは製品既定）→ `runtime.attach(window, SearchWindowView::new(...))`。WebView2 ウィンドウは**作らない**。
+- **OFF**: 既存 `WebviewWindowBuilder` 経路で不変。
+- **ラベルは `"main"` を踏襲**: `position`/`window.bin`/`monitor.rs` が同ラベルで動く。WebView2 固有経路（`get_webview_window("main")`・resume/suspend・IPC コマンド）は egui ウィンドウを型で掴めず、かつ各入口（hotkey listener・`setup_startup_display`・focus-lost）で backend/flag 分岐するため**到達しない**。
+- **生成は setup 限定**（`src-tauri/CLAUDE.md`「WebView2 ウィンドウ生成の制約」）。egui ウィンドウ（tao）も同様に setup で生成し、ランタイムでは show/hide のみ。
+
+## placeholder view と font-first（SU1 申し送りの義務）
+
+- `SearchWindowView: EguiView`（`egui_shell/view.rs`）は SU2 では最小 chrome（検索バー枠 + 最小テキスト）を描く。本体（検索・結果・モード）は SU3 が埋める。
+- **font-first カナリア必須**（SU1 申し送り・`snotra-egui-mvp/CLAUDE.md` #579）: `SearchWindowView::setup` は `jp_font` を Proportional/Monospace 両 family の **index 0**（`insert(0, ...)`）に置く。`push`（末尾 fallback）にすると Latin=egui 既定 / CJK=Yu Gothic の 2 フォントに分離し、被覆 AA を持たない softbuffer が vertical metrics 差を整数 px に丸めてベースラインずれ（#399/#579）を顕在化させる。glow/wgpu は sub-pixel AA で隠すが softbuffer は露見する。**型検査・clippy・単体テストを素通りし視覚でのみ出る**ため、実 `setup` を駆動する config テストで先頭配置を機構的に固定する。
+
+## 変更目録（`src-tauri`）
+
+| 対象 | 扱い |
+|---|---|
+| `src-tauri/src/egui_shell/mod.rs`（新規） | `MainBackend` enum・生成（`Window::builder`+`install`+`attach`）・`show_main`/`hide_main` 共有オーケストレーション・backend フック（`pre_show`/`post_show`/`post_hide`）・controller（合流点） |
+| `src-tauri/src/egui_shell/lifecycle.rs`（新規・純粋核） | `HotkeyPlan`/`plan_hotkey`・`LifecycleState`/`LifecycleEvent`/`transition`・`HostCommand`/`UiAction`/`plan_ui_action`。Win32 非依存・ユニットテスト対象。spike から移植 |
+| `src-tauri/src/egui_shell/view.rs`（新規） | `SearchWindowView: EguiView`（placeholder）。`setup` で font-first・`update` で focus 観測（自動非表示の起点） |
+| `src-tauri/src/main.rs` | 各 setup 関数に `if egui_main { egui_shell::... } else { 既存 }` の入口分岐を足す（生成・`setup_hotkey_listener`・`setup_startup_display`）。WebView2 の `resume`/`suspend`/`emit`/`trim` を `MainBackend::WebView2` のフックへ**逐語移動**。既存の判定・順序は温存 |
+| WebView2 経路の既存ファイル（`commands/`・`config_watcher.rs` 等） | **触らない**（SU2 の egui view は placeholder ゆえ IPC/config 反映は SU3/SU6）。exit-save の位置保存のみ egui 可視時に追加 |
+| `Cargo.toml`（`src-tauri`） | **`snotra-egui-runtime = { path = "../snotra-egui-runtime" }` を新規追加**（現状 `src-tauri` は未依存＝workspace member だが dep ではない・実測）。`EguiRuntime`/`EguiView`/`RuntimeFrame` を使うため |
+
+## テスト計画
+
+- **純粋核（ユニット・Win32 非依存）**: spike のテスト（`soft_host_main.rs:1590-1640`）を `egui_shell/lifecycle.rs` へ移植。
+  - `plan_hotkey` 表: `(false,false)→ShowNow`・`(false,true)→ShowAfterAltRelease`・`(true,_)→HideNow`。
+  - `plan_ui_action` 表: **冪等** `Visible+Show→Refocus`・`Suspended+Hide→Ignore`、**Defer** `Recreating+Hide→Defer`、`Recreating+Show→Ignore`、`Exiting+_→Ignore`。
+  - `transition` の valid（`Visible+Hide→Suspended` 等）/ invalid（未定義遷移は `Err`）。
+- **font-first カナリア**: 実 `SearchWindowView::setup` を駆動し `jp_font` が両 family index 0（`push` なら fail する canary）。
+- **flag-OFF 回帰（G1）**: `SNOTRA_EGUI_MAIN` 未設定で既存 WebView2 テスト + `smoke:startup` / `e2e:tauri` 緑。resume/suspend/emit の逐語移動が挙動を変えないこと。
+- **スモーク（trace ベース・`src-tauri.md` カテゴリ C。Win32 依存ゆえユニット前提にしない）**: `SNOTRA_EGUI_MAIN=1` で
+  - 起動時表示（`show_on_startup`）/ 初回フロー（`--first-run` で `snotra-settings` 起動）
+  - hotkey show / hide（トグル）・`ShowAfterAltRelease`（Alt 押下中の解放待ち）
+  - Escape hide / focus-lost 自動非表示（100ms 猶予）・**サイドカー起動中は非 hide**（ガード検証）
+  - 位置復元（マルチモニター・クランプ）と save-on-hide
+  - `msedgewebview2.exe` 子孫 0 の確認
+
+## 受け入れ条件（SU2）
+
+1. Alt+Q 表示/非表示・blur 自動非表示・フォーカス列・残留 Alt 解除・位置永続・起動時表示・初回フローが SPEC §8（8.1–8.6）と一致する（egui 経路・trace スモークで実証）。
+2. **フラグ OFF で WebView2 挙動が不変**（G1 緑・回帰なし）。resume/suspend/emit/trim のフック移動が既存の順序制約を温存する。
+3. **`plan_hotkey`/`plan_ui_action` が純関数**として `egui_shell/lifecycle.rs` に在り、冪等性（表示中+Show / 非表示中+Hide）と show 進行中 Hide の Defer がユニットテストで固定される。
+4. focus-lost 自動非表示の policy（100ms 猶予・`auto_hide_on_focus_lost` ゲート・サイドカーガード）が `src-tauri` の view 側にあり、`snotra-egui-runtime` の公開 API を拡張していない。
+5. `SearchWindowView::setup` の font-first が実 setup 駆動テストで機構化されている。
+6. `cargo clippy --workspace --all-targets` 緑・`src-tauri` テスト緑・`msedgewebview2.exe` 子孫 0（egui 経路）。
+
+## リスク
+
+- **既存 WebView2 経路を触る（整合の代償）**: resume/suspend/emit/trim のフック移動が #576/#361 の順序制約を壊すと hide/show 競合が再発する。G1（flag-OFF byte-identical）を最優先ゲートに置き、逐語移動 + 既存 e2e で押さえる。
+- **focus-lost 猶予タイマの immediate-mode 実装**: egui は即時モードゆえ 100ms 猶予を `request_repaint_after` + 状態フラグ（`unfocus_at`）で組む。refocus のキャンセルと猶予明けの再判定を取りこぼさないことを G3 + スモークで固定する。
+- **外部 hide と runtime.visible の二重管理**: hotkey トグル hide は外部 `window.hide()`、view 起点 hide は `RuntimeFrame::hide_window`。両者が `main_visible` と `runtime.visible` を coherent に保つこと（G4）。
+- **hotkey 配線の window 型差**: listener が egui では `get_window`、WebView2 では `get_webview_window` を掴む。入口分岐の取りこぼしが無いこと（G2）。
+- **Tauri 内部 API 追随**: `tauri-runtime-wry` unstable feature 依存は #532 既知。SU2 で新たな追随は増やさない。
+
+## スコープ外（SU2 では触らない）
+
+- 検索体験・クエリ/IME・インクリメンタル検索・直 `Engine`・IPC 撤去・結果リスト/行・キーボードナビ・フォルダ展開・インスタントコマンド・内側モード状態機械（Normal/Command/Tool/Folder/Instant/Indexing）は **SU3**。SU2 の view は placeholder。
+- アイコン抽出/キャッシュは SU4。updater は SU5。config 反映（テーマ/ホットキー/index を egui へ）は SU6。
+- 署名付き配布・portable ZIP・**既定を egui へ切替 + WebView2 経路撤去**は SU7。
+- IME 再変換（reconvert）は WANT（SU5）。
+- ルート `CLAUDE.md`/`AGENTS.md` 等の規範文書は変更しない。

--- a/src-tauri/CLAUDE.md
+++ b/src-tauri/CLAUDE.md
@@ -30,6 +30,7 @@ Tauri v2 バイナリ crate。Win32 API 統合とフロントエンドとの IPC
 - `working_set.rs`: 非表示アイドル時に Win32 `EmptyWorkingSet` でプロセスツリー全体（自プロセス + WebView2 子孫）の物理 working set を回収（Windows のみ、非 Windows は no-op）。`collect_descendant_pids()` は Toolhelp の (pid,ppid) 上を BFS する純関数（Win32 非依存・ユニットテスト対象）。`trim_idle_working_set()` は hide 経路（hotkey + `notify_main_hidden`）から呼ばれる best-effort 操作で、HANDLE は RAII ガードで解放し、全 Win32 失敗を握りつぶす
 - `commands/`: ディレクトリモジュール（`mod.rs` + `search.rs` / `launch.rs` / `config.rs` / `icon.rs` / `window.rs` / `system.rs` / `instant.rs`）。`#[tauri::command]` を責務別に分割。`launch.rs` は `launch_item_core`（`pub(crate)`、`instant.rs` から再利用）に加え、トレイメニューからの起動用に `launch_item_with_state` / `launch_with_tool_with_state` / `launch_default_with_state` / `resolve_all_openers` を `pub` で公開
 - `platform/`: ディレクトリモジュール（`mod.rs` + `hotkey.rs` / `tray.rs` / `wndproc.rs`）。Win32 メッセージループスレッド + トレイアイコン + ホットキー + ウィンドウプロシージャ
+- `egui_shell/`: ディレクトリモジュール（`mod.rs` + `lifecycle.rs` / `view.rs`）。WebView2 と並行する egui/softbuffer メインウィンドウの外殻（#532 SU2・env フラグ `SNOTRA_EGUI_MAIN`）。`lifecycle.rs` は純粋核（`plan_hotkey` / `blur_should_hide`）、`view.rs` は placeholder view（font-first・focus/blur 観測）、`mod.rs` は窓生成・show/hide・位置永続・hide listener（責務は各 `//!`）
   - `wndproc.rs`: `SendMessage` 経由で届く `WM_TRAY_ICON` および `WM_CONTEXTMENU` を `PostThreadMessageW` でスレッドキューに再投入し、メッセージループでの統一処理を保証
 
 ## 実装パターン

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 snotra-core = { path = "../snotra-core" }
 snotra-egui-runtime = { path = "../snotra-egui-runtime" }
+egui.workspace = true # SearchWindowView が EguiView を実装するため（runtime と同一 egui インスタンスに解決）
 tauri = { version = "2", features = [] }
 tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,6 +14,7 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 snotra-core = { path = "../snotra-core" }
+snotra-egui-runtime = { path = "../snotra-egui-runtime" }
 tauri = { version = "2", features = [] }
 tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -89,7 +89,13 @@ pub(crate) fn launch_settings_process(app: &AppHandle, extra_args: &[&str]) -> R
     drop(guard);
 
     // Temporarily disable main window alwaysOnTop so snotra-settings can be focused.
-    if let Some(main) = app.get_webview_window("main") {
+    // egui 窓（flag ON）は webview 無しゆえ get_webview_window では取れない。get_window で取る
+    // （codex #3・SPEC §8.5）。WebView2 経路（flag OFF）は既存のまま不変。
+    if crate::trace::env_flag("SNOTRA_EGUI_MAIN") {
+        if let Some(main) = app.get_window("main") {
+            let _ = main.set_always_on_top(false);
+        }
+    } else if let Some(main) = app.get_webview_window("main") {
         let _ = main.set_always_on_top(false);
     }
 
@@ -128,8 +134,12 @@ pub(crate) fn launch_settings_process(app: &AppHandle, extra_args: &[&str]) -> R
             }
         }
 
-        // Restore main window alwaysOnTop.
-        if let Some(main) = handle_for_monitor.get_webview_window("main") {
+        // Restore main window alwaysOnTop（egui は get_window・codex #3・SPEC §8.5）。flag OFF は不変。
+        if crate::trace::env_flag("SNOTRA_EGUI_MAIN") {
+            if let Some(main) = handle_for_monitor.get_window("main") {
+                let _ = main.set_always_on_top(true);
+            }
+        } else if let Some(main) = handle_for_monitor.get_webview_window("main") {
             let _ = main.set_always_on_top(true);
         }
 

--- a/src-tauri/src/egui_shell/lifecycle.rs
+++ b/src-tauri/src/egui_shell/lifecycle.rs
@@ -7,10 +7,11 @@ pub(crate) enum HotkeyPlan {
     ShowNow,
 }
 
-/// Alt+Q 押下時の分岐。表示中なら即 hide、非表示中は Alt が押されている限り
-/// 解放を待ってから show する（製品 WebView2 経路と同じ意味論）。
-pub(crate) fn plan_hotkey(visible: bool, alt_pressed: bool) -> HotkeyPlan {
-    if visible {
+/// Alt+Q 押下時の分岐（製品 WebView2 経路と同じ意味論）。表示中かつ hotkey_toggle=true なら
+/// 即 hide。それ以外（非表示、または表示中でも hotkey_toggle=false ＝ 既に見えている窓を
+/// 再フォーカス/再配置）は show 側へ回り、Alt が押されている限り解放を待ってから show する。
+pub(crate) fn plan_hotkey(visible: bool, alt_pressed: bool, hotkey_toggle: bool) -> HotkeyPlan {
+    if visible && hotkey_toggle {
         HotkeyPlan::HideNow
     } else if alt_pressed {
         HotkeyPlan::ShowAfterAltRelease
@@ -37,10 +38,17 @@ mod tests {
 
     #[test]
     fn hotkey_branches_match_product_semantics() {
-        assert_eq!(plan_hotkey(true, false), HotkeyPlan::HideNow);
-        assert_eq!(plan_hotkey(true, true), HotkeyPlan::HideNow);
-        assert_eq!(plan_hotkey(false, true), HotkeyPlan::ShowAfterAltRelease);
-        assert_eq!(plan_hotkey(false, false), HotkeyPlan::ShowNow);
+        // (visible, alt_pressed, hotkey_toggle)
+        assert_eq!(plan_hotkey(true, false, true), HotkeyPlan::HideNow); // 表示+toggle → hide
+        assert_eq!(plan_hotkey(true, true, true), HotkeyPlan::HideNow);
+        assert_eq!(plan_hotkey(true, false, false), HotkeyPlan::ShowNow); // 表示+非toggle → 再フォーカス
+        assert_eq!(
+            plan_hotkey(true, true, false),
+            HotkeyPlan::ShowAfterAltRelease // 表示+非toggle+Alt → 解放待ち show
+        );
+        assert_eq!(plan_hotkey(false, true, true), HotkeyPlan::ShowAfterAltRelease);
+        assert_eq!(plan_hotkey(false, false, true), HotkeyPlan::ShowNow);
+        assert_eq!(plan_hotkey(false, false, false), HotkeyPlan::ShowNow);
     }
 
     #[test]

--- a/src-tauri/src/egui_shell/lifecycle.rs
+++ b/src-tauri/src/egui_shell/lifecycle.rs
@@ -1,5 +1,4 @@
-//! Alt+Q ホットキー分岐の純粋な決定核（Win32 非依存）。SU1 spike で実証済み・#532 SU2 で移植。
-#![allow(dead_code)] // Task 4 で hotkey listener が消費するまで dead-code。Task 4 完了時に除去する。
+//! Alt+Q ホットキー分岐・blur 判定の純粋な決定核（Win32 非依存）。SU1 spike で実証済み・#532 SU2。
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum HotkeyPlan {
@@ -20,6 +19,18 @@ pub(crate) fn plan_hotkey(visible: bool, alt_pressed: bool) -> HotkeyPlan {
     }
 }
 
+/// blur（focus 喪失）猶予明けに hide 要求を出すべきかの純粋判定。焦点が戻っておらず、
+/// 100ms 猶予が明け、auto_hide が有効で、設定サイドカーが非起動のときだけ hide する。
+/// 猶予タイマの発火・repaint 予約という状態は view 側（update）に残す。
+pub(crate) fn blur_should_hide(
+    focused: bool,
+    grace_elapsed: bool,
+    auto_hide: bool,
+    settings_running: bool,
+) -> bool {
+    !focused && grace_elapsed && auto_hide && !settings_running
+}
+
 #[cfg(test)]
 mod tests {
     use super::{HotkeyPlan, plan_hotkey};
@@ -30,5 +41,16 @@ mod tests {
         assert_eq!(plan_hotkey(true, true), HotkeyPlan::HideNow);
         assert_eq!(plan_hotkey(false, true), HotkeyPlan::ShowAfterAltRelease);
         assert_eq!(plan_hotkey(false, false), HotkeyPlan::ShowNow);
+    }
+
+    #[test]
+    fn blur_hides_only_when_all_gates_pass() {
+        use super::blur_should_hide;
+        // focused, grace_elapsed, auto_hide, settings_running
+        assert!(blur_should_hide(false, true, true, false)); // 全成立 → hide
+        assert!(!blur_should_hide(true, true, true, false)); // 焦点復帰 → hide しない
+        assert!(!blur_should_hide(false, false, true, false)); // 猶予未明け → hide しない
+        assert!(!blur_should_hide(false, true, false, false)); // auto_hide 無効 → hide しない
+        assert!(!blur_should_hide(false, true, true, true)); // 設定起動中 → hide しない
     }
 }

--- a/src-tauri/src/egui_shell/lifecycle.rs
+++ b/src-tauri/src/egui_shell/lifecycle.rs
@@ -1,0 +1,34 @@
+//! Alt+Q ホットキー分岐の純粋な決定核（Win32 非依存）。SU1 spike で実証済み・#532 SU2 で移植。
+#![allow(dead_code)] // Task 4 で hotkey listener が消費するまで dead-code。Task 4 完了時に除去する。
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum HotkeyPlan {
+    HideNow,
+    ShowAfterAltRelease,
+    ShowNow,
+}
+
+/// Alt+Q 押下時の分岐。表示中なら即 hide、非表示中は Alt が押されている限り
+/// 解放を待ってから show する（製品 WebView2 経路と同じ意味論）。
+pub(crate) fn plan_hotkey(visible: bool, alt_pressed: bool) -> HotkeyPlan {
+    if visible {
+        HotkeyPlan::HideNow
+    } else if alt_pressed {
+        HotkeyPlan::ShowAfterAltRelease
+    } else {
+        HotkeyPlan::ShowNow
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HotkeyPlan, plan_hotkey};
+
+    #[test]
+    fn hotkey_branches_match_product_semantics() {
+        assert_eq!(plan_hotkey(true, false), HotkeyPlan::HideNow);
+        assert_eq!(plan_hotkey(true, true), HotkeyPlan::HideNow);
+        assert_eq!(plan_hotkey(false, true), HotkeyPlan::ShowAfterAltRelease);
+        assert_eq!(plan_hotkey(false, false), HotkeyPlan::ShowNow);
+    }
+}

--- a/src-tauri/src/egui_shell/mod.rs
+++ b/src-tauri/src/egui_shell/mod.rs
@@ -1,6 +1,7 @@
 //! egui/softbuffer メインウィンドウの外殻（#532 SU2）。WebView2 と並行する
 //! egui 専用 window 生成・show/hide・blur 自動非表示・位置永続。WebView2 経路は触らない。
 mod lifecycle;
+mod view;
 
 // Task 4 の hotkey listener が消費するまで未使用。clippy -D warnings 回避のため許可し、Task 4 で除去する。
 #[allow(unused_imports)]

--- a/src-tauri/src/egui_shell/mod.rs
+++ b/src-tauri/src/egui_shell/mod.rs
@@ -3,13 +3,13 @@
 mod lifecycle;
 mod view;
 
-pub(crate) use lifecycle::{HotkeyPlan, plan_hotkey};
+pub(crate) use lifecycle::{HotkeyPlan, blur_should_hide, plan_hotkey};
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Instant;
 
 use snotra_egui_runtime::EguiRuntime;
-use tauri::Manager;
+use tauri::{Listener, Manager};
 
 use crate::egui_shell::view::SearchWindowView;
 
@@ -135,4 +135,13 @@ pub(crate) fn save_placement_relative(window: &tauri::Window) {
         use snotra_core::window_data::{self, WindowPlacement};
         window_data::save_search_placement(WindowPlacement { x: pos.x, y: pos.y });
     }
+}
+
+/// view からの `egui-hide-requested` を受け、hide_egui_main を実行する（全 hide の合流点・codex #7）。
+/// view（イベントループスレッド）→ emit → この listener で hide を 1 経路に集約する。
+pub(crate) fn register_hide_listener(app: &tauri::AppHandle) {
+    let handle = app.clone();
+    app.listen("egui-hide-requested", move |_| {
+        hide_egui_main(&handle);
+    });
 }

--- a/src-tauri/src/egui_shell/mod.rs
+++ b/src-tauri/src/egui_shell/mod.rs
@@ -55,9 +55,6 @@ pub(crate) fn show_egui_main(app: &tauri::AppHandle, t0: Instant) {
         crate::trace_main("egui_show:no_window", serde_json::json!({}));
         return;
     };
-    if let Some(state) = app.try_state::<crate::AppState>() {
-        state.main_visible.store(true, Ordering::SeqCst);
-    }
     // show のたびに view の emit dedup をリセット（Focused(true) 非依存・codex #8）。
     if let Some(sh) = app.try_state::<EguiShellState>() {
         sh.hide_pending.store(false, Ordering::SeqCst);
@@ -66,6 +63,11 @@ pub(crate) fn show_egui_main(app: &tauri::AppHandle, t0: Instant) {
     #[cfg(windows)]
     crate::position_on_target_monitor(app, &window);
     let _ = window.show();
+    // main_visible は show() の後に立てる（WebView2 の show_and_focus_main と同じ「順序不変」
+    // 制約）。show 完了前に visible=true を読んだホットキートグルが hide するのを避ける。
+    if let Some(state) = app.try_state::<crate::AppState>() {
+        state.main_visible.store(true, Ordering::SeqCst);
+    }
     let _ = window.set_focus();
     // フォーカス移行の同期待ち（SetForegroundWindow は部分的に非同期・Raymond Chen）。
     #[cfg(windows)]

--- a/src-tauri/src/egui_shell/mod.rs
+++ b/src-tauri/src/egui_shell/mod.rs
@@ -39,6 +39,9 @@ pub(crate) fn create(
         .resizable(false)
         .skip_taskbar(true) // 宣言窓 skipTaskbar:true の再現（(B)#1）
         .always_on_top(true) // 宣言窓 alwaysOnTop:true の再現（(B)#1）
+        // 白フラッシュ回避: show 時、最初の softbuffer present 前にネイティブ背景ブラシが一瞬見える。
+        // softbuffer の CLEAR_COLOR（renderer.rs=0x282828）に合わせて暗色にし、白→暗の点滅を消す。
+        .background_color(tauri::window::Color(0x28, 0x28, 0x28, 0xff))
         .visible(false)
         .build()?; // tauri::Error → RuntimeError（#[from]・runtime.rs:46）
     runtime.attach(window, SearchWindowView::new(app_handle))

--- a/src-tauri/src/egui_shell/mod.rs
+++ b/src-tauri/src/egui_shell/mod.rs
@@ -3,13 +3,13 @@
 mod lifecycle;
 mod view;
 
-// Task 4 の hotkey listener が消費するまで未使用。clippy -D warnings 回避のため許可し、Task 4 で除去する。
-#[allow(unused_imports)]
 pub(crate) use lifecycle::{HotkeyPlan, plan_hotkey};
 
-use std::sync::atomic::{AtomicBool, AtomicU64};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Instant;
 
 use snotra_egui_runtime::EguiRuntime;
+use tauri::Manager;
 
 use crate::egui_shell::view::SearchWindowView;
 
@@ -17,7 +17,6 @@ use crate::egui_shell::view::SearchWindowView;
 /// - hotkey_generation: alt 解放待ち show の世代。hide が bump して保留 show を無効化する（codex #5/(B)#2）。
 /// - hide_pending: view の emit dedup。show がクリアして「hide 後に Focused(true) が来ず抑止が残る」を断つ（codex #8）。
 #[derive(Default)]
-#[allow(dead_code)] // フィールドは Task 4/5（show/hide/blur 配線）で読む。Task 4 で除去する。
 pub(crate) struct EguiShellState {
     pub(crate) hotkey_generation: AtomicU64,
     pub(crate) hide_pending: AtomicBool,
@@ -43,4 +42,97 @@ pub(crate) fn create(
         .visible(false)
         .build()?; // tauri::Error → RuntimeError（#[from]・runtime.rs:46）
     runtime.attach(window, SearchWindowView::new(app_handle))
+}
+
+/// egui 経路の show。共有するのは position_on_target_monitor のみ。全 hide は外部化ゆえ
+/// runtime.visible は false にならず、show は Focused(true) に依存せず確実に描ける（codex #4）。
+/// show 列は WebView2 の show_and_focus_main を egui 用に自前複製（WebView2 本体を触らないため）。
+pub(crate) fn show_egui_main(app: &tauri::AppHandle, t0: Instant) {
+    let Some(window) = app.get_window("main") else {
+        crate::trace_main("egui_show:no_window", serde_json::json!({}));
+        return;
+    };
+    if let Some(state) = app.try_state::<crate::AppState>() {
+        state.main_visible.store(true, Ordering::SeqCst);
+    }
+    // show のたびに view の emit dedup をリセット（Focused(true) 非依存・codex #8）。
+    if let Some(sh) = app.try_state::<EguiShellState>() {
+        sh.hide_pending.store(false, Ordering::SeqCst);
+    }
+    // 高さ 52px は create で固定・resizable(false) ゆえリセット不要。位置のみ復元。
+    #[cfg(windows)]
+    crate::position_on_target_monitor(app, &window);
+    let _ = window.show();
+    let _ = window.set_focus();
+    // フォーカス移行の同期待ち（SetForegroundWindow は部分的に非同期・Raymond Chen）。
+    #[cfg(windows)]
+    if let Ok(hwnd) = window.hwnd() {
+        use windows::Win32::Foundation::{HWND, LPARAM, WPARAM};
+        use windows::Win32::UI::WindowsAndMessaging::{SMTO_NORMAL, SendMessageTimeoutW, WM_NULL};
+        let hwnd = HWND(hwnd.0);
+        let mut result = 0usize;
+        unsafe {
+            let _ = SendMessageTimeoutW(
+                hwnd,
+                WM_NULL,
+                WPARAM(0),
+                LPARAM(0),
+                SMTO_NORMAL,
+                100,
+                Some(&mut result),
+            );
+        }
+    }
+    // 残留 Alt 解除: focus 確定後かつ物理 Alt 解放後のみ（#558）。
+    if !crate::is_alt_pressed() {
+        crate::send_alt_key_up();
+    }
+    crate::trace_main(
+        "egui_show:done",
+        serde_json::json!({ "ms": t0.elapsed().as_secs_f64() * 1000.0 }),
+    );
+}
+
+/// egui 経路の hide。全 hide の唯一の副作用所有点（codex #7）。外部 window.hide() のみで
+/// runtime.visible を false にしない（空白窓回避・codex #4）。
+pub(crate) fn hide_egui_main(app: &tauri::AppHandle) {
+    // 保留中の alt 解放待ち show を無効化（codex #5/(B)#2）: 世代を bump し、spawn 済み show
+    // スレッドの gen 一致チェックを外す。
+    if let Some(sh) = app.try_state::<EguiShellState>() {
+        sh.hotkey_generation.fetch_add(1, Ordering::SeqCst);
+    }
+    if let Some(window) = app.get_window("main") {
+        save_placement_relative(&window); // save-on-hide
+        let _ = window.hide();
+    }
+    if let Some(state) = app.try_state::<crate::AppState>() {
+        state.main_visible.store(false, Ordering::SeqCst);
+    }
+    crate::trace_main("egui_hide:done", serde_json::json!({}));
+}
+
+/// 現在の物理位置をターゲットモニター作業領域原点からの相対座標で window.bin に保存。
+/// WebView2 の save_relative_placement（commands/window.rs）と同じ算出を &Window で行う
+/// （別モジュールの private fn は参照できないため複製・WebView2 側は不変）。
+pub(crate) fn save_placement_relative(window: &tauri::Window) {
+    let Ok(pos) = window.outer_position() else {
+        return;
+    };
+    #[cfg(windows)]
+    {
+        use snotra_core::window_data::{self, WindowPlacement};
+        let Ok(hwnd) = window.hwnd() else { return };
+        let Some(wa) = crate::monitor::window_monitor_work_area(hwnd.0 as isize) else {
+            return;
+        };
+        window_data::save_search_placement(WindowPlacement {
+            x: pos.x - wa.left,
+            y: pos.y - wa.top,
+        });
+    }
+    #[cfg(not(windows))]
+    {
+        use snotra_core::window_data::{self, WindowPlacement};
+        window_data::save_search_placement(WindowPlacement { x: pos.x, y: pos.y });
+    }
 }

--- a/src-tauri/src/egui_shell/mod.rs
+++ b/src-tauri/src/egui_shell/mod.rs
@@ -1,0 +1,7 @@
+//! egui/softbuffer メインウィンドウの外殻（#532 SU2）。WebView2 と並行する
+//! egui 専用 window 生成・show/hide・blur 自動非表示・位置永続。WebView2 経路は触らない。
+mod lifecycle;
+
+// Task 4 の hotkey listener が消費するまで未使用。clippy -D warnings 回避のため許可し、Task 4 で除去する。
+#[allow(unused_imports)]
+pub(crate) use lifecycle::{HotkeyPlan, plan_hotkey};

--- a/src-tauri/src/egui_shell/mod.rs
+++ b/src-tauri/src/egui_shell/mod.rs
@@ -6,3 +6,41 @@ mod view;
 // Task 4 の hotkey listener が消費するまで未使用。clippy -D warnings 回避のため許可し、Task 4 で除去する。
 #[allow(unused_imports)]
 pub(crate) use lifecycle::{HotkeyPlan, plan_hotkey};
+
+use std::sync::atomic::{AtomicBool, AtomicU64};
+
+use snotra_egui_runtime::EguiRuntime;
+
+use crate::egui_shell::view::SearchWindowView;
+
+/// egui 経路の show/hide を跨ぐ共有状態（managed state）。
+/// - hotkey_generation: alt 解放待ち show の世代。hide が bump して保留 show を無効化する（codex #5/(B)#2）。
+/// - hide_pending: view の emit dedup。show がクリアして「hide 後に Focused(true) が来ず抑止が残る」を断つ（codex #8）。
+#[derive(Default)]
+#[allow(dead_code)] // フィールドは Task 4/5（show/hide/blur 配線）で読む。Task 4 で除去する。
+pub(crate) struct EguiShellState {
+    pub(crate) hotkey_generation: AtomicU64,
+    pub(crate) hide_pending: AtomicBool,
+}
+
+/// フラグ ON の窓生成。EguiRuntime を install し webview 無しの "main" 窓を生成して attach。setup 限定。
+/// 宣言窓の全プロパティ（52px 高は固定・width は config の window_width・skipTaskbar・
+/// alwaysOnTop・decorations:false・resizable:false・visible:false）を再現する（codex #11・(B)#1）。
+pub(crate) fn create(
+    app: &mut tauri::App,
+    window_width: f64,
+) -> Result<(), snotra_egui_runtime::RuntimeError> {
+    let runtime = EguiRuntime::new();
+    runtime.install(app); // install(&self, &mut App<Wry>)（runtime.rs:77）
+    let app_handle = app.handle().clone();
+    let window = tauri::Window::builder(app, "main")
+        .title("Snotra")
+        .inner_size(window_width, 52.0) // 保存幅を尊重（codex #11）
+        .decorations(false)
+        .resizable(false)
+        .skip_taskbar(true) // 宣言窓 skipTaskbar:true の再現（(B)#1）
+        .always_on_top(true) // 宣言窓 alwaysOnTop:true の再現（(B)#1）
+        .visible(false)
+        .build()?; // tauri::Error → RuntimeError（#[from]・runtime.rs:46）
+    runtime.attach(window, SearchWindowView::new(app_handle))
+}

--- a/src-tauri/src/egui_shell/view.rs
+++ b/src-tauri/src/egui_shell/view.rs
@@ -1,0 +1,104 @@
+//! egui メインウィンドウの placeholder view（#532 SU2）。show/hide/focus/位置を視覚検証できる
+//! 最小 chrome を描く。検索本体は SU3。font-first（jp_font を index 0）は SU1 申し送りの義務。
+
+use std::sync::OnceLock;
+use std::time::Instant;
+
+use snotra_egui_runtime::{EguiView, RuntimeFrame};
+
+static JP_FONT_BYTES: OnceLock<Box<[u8]>> = OnceLock::new();
+
+fn japanese_font_definitions(bytes: &'static [u8]) -> egui::FontDefinitions {
+    let mut fonts = egui::FontDefinitions::default();
+    let mut font = egui::FontData::from_static(bytes);
+    font.tweak = egui::FontTweak {
+        scale: 1.0,
+        y_offset_factor: 0.3,
+        y_offset: 0.0,
+        ..Default::default()
+    };
+    fonts.font_data.insert("jp_font".to_owned(), font.into());
+    for family in [egui::FontFamily::Proportional, egui::FontFamily::Monospace] {
+        // insert(0)＝先頭。jp_font を最優先にして単一フォント化する。push（末尾 fallback）だと
+        // Latin=egui 既定 / CJK=Yu Gothic に分離し、被覆 AA 無の softbuffer でベースラインずれ（#579/#399）。
+        fonts
+            .families
+            .entry(family)
+            .or_default()
+            .insert(0, "jp_font".to_owned());
+    }
+    fonts
+}
+
+fn configure_japanese_font(context: &egui::Context) {
+    let candidates = [
+        "C:/Windows/Fonts/YuGothM.ttc",
+        "C:/Windows/Fonts/yugothic.ttf",
+        "C:/Windows/Fonts/msgothic.ttc",
+        "C:/Windows/Fonts/meiryo.ttc",
+    ];
+    if JP_FONT_BYTES.get().is_none() {
+        for path in candidates {
+            if let Ok(bytes) = std::fs::read(path) {
+                let _ = JP_FONT_BYTES.set(bytes.into_boxed_slice());
+                break;
+            }
+        }
+    }
+    if let Some(bytes) = JP_FONT_BYTES.get() {
+        // OnceLock の中身は以後不変ゆえ 'static として安全に借用できる。
+        let static_bytes: &'static [u8] =
+            unsafe { std::mem::transmute::<&[u8], &'static [u8]>(bytes) };
+        context.set_fonts(japanese_font_definitions(static_bytes));
+    }
+}
+
+#[allow(dead_code)] // フィールドは Task 5（blur/focus 配線）で読む。Task 5 で除去する。
+pub(crate) struct SearchWindowView {
+    app_handle: tauri::AppHandle,
+    was_focused: bool,
+    unfocus_at: Option<Instant>,
+    // emit dedup は共有 EguiShellState.hide_pending（show がクリア・codex #8）。view-local には持たない。
+}
+
+impl SearchWindowView {
+    #[allow(dead_code)] // Task 3（create）が呼ぶまで未使用。Task 3 で除去する。
+    pub(crate) fn new(app_handle: tauri::AppHandle) -> Self {
+        Self {
+            app_handle,
+            was_focused: false,
+            unfocus_at: None,
+        }
+    }
+}
+
+impl EguiView for SearchWindowView {
+    fn setup(&mut self, context: &egui::Context) {
+        configure_japanese_font(context);
+    }
+
+    fn update(&mut self, ui: &mut egui::Ui, _frame: &mut RuntimeFrame) {
+        // placeholder: SU3 が検索 UI で置き換える。混在行（Latin+CJK）で font-first を視覚検証。
+        // focus 観測 + blur emit は Task 5 で本体を実装する。
+        ui.label("Snotra — 検索ウィンドウ（C:/Program Files/example）");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::japanese_font_definitions;
+
+    #[test]
+    fn jp_font_is_registered_at_index_zero_for_both_families() {
+        let dummy: &'static [u8] = &[0u8; 4];
+        let fonts = japanese_font_definitions(dummy);
+        for family in [egui::FontFamily::Proportional, egui::FontFamily::Monospace] {
+            let list = fonts.families.get(&family).expect("family present");
+            assert_eq!(
+                list.first().map(String::as_str),
+                Some("jp_font"),
+                "jp_font must be index 0 for {family:?}（push=末尾だと #579 再発）"
+            );
+        }
+    }
+}

--- a/src-tauri/src/egui_shell/view.rs
+++ b/src-tauri/src/egui_shell/view.rs
@@ -59,6 +59,7 @@ pub(crate) struct SearchWindowView {
     app_handle: tauri::AppHandle,
     was_focused: bool,
     unfocus_at: Option<Instant>,
+    query: String,
     // emit dedup は共有 EguiShellState.hide_pending（show がクリア・codex #8）。view-local には持たない。
 }
 
@@ -68,6 +69,7 @@ impl SearchWindowView {
             app_handle,
             was_focused: false,
             unfocus_at: None,
+            query: String::new(),
         }
     }
 
@@ -120,17 +122,19 @@ impl EguiView for SearchWindowView {
         let focused = ctx.input(|i| i.focused);
         let escape = ctx.input(|i| i.key_pressed(egui::Key::Escape));
 
+        let was_focused = self.was_focused;
         // 再表示直後の stale 猶予をリセット: focused に戻ったら pending 破棄（codex #8）。
         // emit dedup（hide_pending）は show_egui_main がクリアするので view では触らない。
         if focused {
             self.unfocus_at = None;
         }
-        // Escape → 即 hide 要求（内側モード優先は SU3）。
+        // Escape → 即 hide 要求（内側モード優先は SU3）。TextEdit より前に ctx から拾うので
+        // 入力欄に focus があっても届く。
         if escape {
             self.emit_hide();
         }
         // focus 喪失 → 100ms 猶予を張り、猶予明けに repaint させる。
-        if self.was_focused && !focused {
+        if was_focused && !focused {
             self.unfocus_at = Some(Instant::now());
             ctx.request_repaint_after(Duration::from_millis(100));
         }
@@ -147,10 +151,20 @@ impl EguiView for SearchWindowView {
                 self.emit_hide();
             }
         }
-        self.was_focused = focused;
 
-        // placeholder: SU3 が検索 UI で置き換える。混在行（Latin+CJK）で font-first を視覚検証。
-        ui.label("Snotra — 検索ウィンドウ（C:/Program Files/example）");
+        // 検索入力欄（placeholder）。SU3 が検索ロジックを載せる。混在スクリプト（Latin+CJK）を
+        // 打てば font-first のベースライン整合も視覚検証できる。
+        let response = ui.add(
+            egui::TextEdit::singleline(&mut self.query)
+                .hint_text("検索…")
+                .desired_width(f32::INFINITY),
+        );
+        // 窓が focus を得た最初のフレームで入力欄へ focus を移す（Alt+Q 表示直後に打てる）。
+        if focused && !was_focused {
+            response.request_focus();
+        }
+
+        self.was_focused = focused;
     }
 }
 

--- a/src-tauri/src/egui_shell/view.rs
+++ b/src-tauri/src/egui_shell/view.rs
@@ -62,7 +62,6 @@ pub(crate) struct SearchWindowView {
 }
 
 impl SearchWindowView {
-    #[allow(dead_code)] // Task 3（create）が呼ぶまで未使用。Task 3 で除去する。
     pub(crate) fn new(app_handle: tauri::AppHandle) -> Self {
         Self {
             app_handle,

--- a/src-tauri/src/egui_shell/view.rs
+++ b/src-tauri/src/egui_shell/view.rs
@@ -2,9 +2,11 @@
 //! 最小 chrome を描く。検索本体は SU3。font-first（jp_font を index 0）は SU1 申し送りの義務。
 
 use std::sync::OnceLock;
-use std::time::Instant;
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
 
 use snotra_egui_runtime::{EguiView, RuntimeFrame};
+use tauri::{Emitter, Manager};
 
 static JP_FONT_BYTES: OnceLock<Box<[u8]>> = OnceLock::new();
 
@@ -53,7 +55,6 @@ fn configure_japanese_font(context: &egui::Context) {
     }
 }
 
-#[allow(dead_code)] // フィールドは Task 5（blur/focus 配線）で読む。Task 5 で除去する。
 pub(crate) struct SearchWindowView {
     app_handle: tauri::AppHandle,
     was_focused: bool,
@@ -69,6 +70,44 @@ impl SearchWindowView {
             unfocus_at: None,
         }
     }
+
+    /// hide 要求を emit する。多重防止は共有 EguiShellState.hide_pending（show_egui_main が
+    /// クリア・codex #8）。view-local フラグだと hide 後 Focused(true) 非着信で永久 true 化し、
+    /// 以後の hide を抑止してしまう。
+    fn emit_hide(&self) {
+        let already = self
+            .app_handle
+            .try_state::<crate::egui_shell::EguiShellState>()
+            .map(|sh| sh.hide_pending.swap(true, Ordering::SeqCst))
+            .unwrap_or(false);
+        if already {
+            return;
+        }
+        let _ = self.app_handle.emit("egui-hide-requested", ());
+    }
+
+    /// auto_hide_on_focus_lost を実行中 config から都度読む（キャッシュしない・#576 と同設計）。
+    fn auto_hide_enabled(&self) -> bool {
+        self.app_handle
+            .try_state::<crate::AppState>()
+            .map(|s| {
+                s.engine
+                    .lock()
+                    .unwrap()
+                    .config()
+                    .general
+                    .auto_hide_on_focus_lost
+            })
+            .unwrap_or(true) // config.rs 既定と一致
+    }
+
+    /// 設定サイドカー起動中は blur で hide しない（設定が focus を奪っても本体を消さない）。
+    fn settings_running(&self) -> bool {
+        self.app_handle
+            .try_state::<crate::SettingsProcessState>()
+            .map(|p| p.lock().unwrap().is_some())
+            .unwrap_or(false)
+    }
 }
 
 impl EguiView for SearchWindowView {
@@ -77,8 +116,40 @@ impl EguiView for SearchWindowView {
     }
 
     fn update(&mut self, ui: &mut egui::Ui, _frame: &mut RuntimeFrame) {
+        let ctx = ui.ctx().clone();
+        let focused = ctx.input(|i| i.focused);
+        let escape = ctx.input(|i| i.key_pressed(egui::Key::Escape));
+
+        // 再表示直後の stale 猶予をリセット: focused に戻ったら pending 破棄（codex #8）。
+        // emit dedup（hide_pending）は show_egui_main がクリアするので view では触らない。
+        if focused {
+            self.unfocus_at = None;
+        }
+        // Escape → 即 hide 要求（内側モード優先は SU3）。
+        if escape {
+            self.emit_hide();
+        }
+        // focus 喪失 → 100ms 猶予を張り、猶予明けに repaint させる。
+        if self.was_focused && !focused {
+            self.unfocus_at = Some(Instant::now());
+            ctx.request_repaint_after(Duration::from_millis(100));
+        }
+        // 猶予明け判定は純粋核 blur_should_hide に委ねる（focus 復帰・auto_hide・設定起動を AND）。
+        if let Some(at) = self.unfocus_at {
+            let grace_elapsed = at.elapsed() >= Duration::from_millis(100);
+            if crate::egui_shell::blur_should_hide(
+                focused,
+                grace_elapsed,
+                self.auto_hide_enabled(),
+                self.settings_running(),
+            ) {
+                self.unfocus_at = None;
+                self.emit_hide();
+            }
+        }
+        self.was_focused = focused;
+
         // placeholder: SU3 が検索 UI で置き換える。混在行（Latin+CJK）で font-first を視覚検証。
-        // focus 観測 + blur emit は Task 5 で本体を実装する。
         ui.label("Snotra — 検索ウィンドウ（C:/Program Files/example）");
     }
 }

--- a/src-tauri/src/egui_shell/view.rs
+++ b/src-tauri/src/egui_shell/view.rs
@@ -159,8 +159,9 @@ impl EguiView for SearchWindowView {
                 .hint_text("検索…")
                 .desired_width(f32::INFINITY),
         );
-        // 窓が focus を得た最初のフレームで入力欄へ focus を移す（Alt+Q 表示直後に打てる）。
-        if focused && !was_focused {
+        // 窓に focus があるのに入力欄が focus を持たないなら移す（Alt+Q 表示直後に打てる）。
+        // was_focused に依存しないので、hide→reshow で was_focused が stale でも確実に戻る。
+        if focused && !response.has_focus() {
             response.request_focus();
         }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,6 +9,7 @@
 
 mod commands;
 mod config_watcher;
+mod egui_shell;
 mod icon;
 mod ime;
 mod indexing;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -329,7 +329,9 @@ pub(crate) fn suspend_and_trim_after_hide(app: &AppHandle, source: &'static str)
 #[cfg(windows)]
 fn position_on_target_monitor(
     app_handle: &AppHandle,
-    main: &tauri::WebviewWindow,
+    // &Window に一般化して egui 経路と共有（#532 SU2）。両経路とも同一の "main" 窓
+    // （get_window/get_webview_window は同じ内部 Window を指す・manager/window.rs:106）。
+    main: &tauri::Window,
 ) {
     use snotra_core::window_data;
 
@@ -494,8 +496,12 @@ fn show_main_and_emit(app_handle: &AppHandle) {
         // Position window on the target monitor (cursor or primary) using
         // saved relative coordinates, clamped to the target work area.
         // Must run after height reset so clamp uses the collapsed size.
+        // 一般化した position_on_target_monitor は &Window を取る。宣言 WebviewWindow の
+        // 内部 Window は get_window("main") で得られる（同一 OS 窓ゆえ挙動不変・#532 SU2 mini-gate）。
         #[cfg(windows)]
-        position_on_target_monitor(app_handle, &main);
+        if let Some(win) = app_handle.get_window("main") {
+            position_on_target_monitor(app_handle, &win);
+        }
 
         show_and_focus_main(app_handle, &main, t0);
 
@@ -813,6 +819,48 @@ fn setup_hotkey_listener(app_handle: &AppHandle) {
         {
             return;
         }
+        // egui 経路（flag ON）: 共有 EguiShellState.hotkey_generation を使い（hide が bump して
+        // 保留 show を無効化・codex #5/(B)#2）、純粋核 plan_hotkey で分岐する。WebView2 の
+        // generation は使わず早期 return（二重 bump しない）。
+        if crate::trace::env_flag("SNOTRA_EGUI_MAIN") {
+            let current_gen = handle_for_hotkey
+                .try_state::<egui_shell::EguiShellState>()
+                .map(|sh| sh.hotkey_generation.fetch_add(1, Ordering::SeqCst) + 1)
+                .unwrap_or(0);
+            let visible = handle_for_hotkey
+                .try_state::<AppState>()
+                .map(|s| s.main_visible.load(Ordering::SeqCst))
+                .unwrap_or(false);
+            let hotkey_toggle = handle_for_hotkey
+                .try_state::<AppState>()
+                .map(|s| s.engine.lock().unwrap().config().general.hotkey_toggle)
+                .unwrap_or(true); // config.rs 既定と一致
+            match egui_shell::plan_hotkey(visible, is_alt_pressed()) {
+                egui_shell::HotkeyPlan::HideNow if hotkey_toggle => {
+                    egui_shell::hide_egui_main(&handle_for_hotkey);
+                }
+                egui_shell::HotkeyPlan::HideNow => {} // hotkey_toggle=false は可視のまま
+                egui_shell::HotkeyPlan::ShowNow => {
+                    egui_shell::show_egui_main(&handle_for_hotkey, t0);
+                }
+                egui_shell::HotkeyPlan::ShowAfterAltRelease => {
+                    let h = handle_for_hotkey.clone();
+                    std::thread::spawn(move || {
+                        wait_alt_release_or_timeout();
+                        // 共有世代が変わっていたら（別 press や hide が bump）show を諦める。
+                        let gen_now = h
+                            .try_state::<egui_shell::EguiShellState>()
+                            .map(|sh| sh.hotkey_generation.load(Ordering::SeqCst))
+                            .unwrap_or(0);
+                        if gen_now != current_gen {
+                            return;
+                        }
+                        egui_shell::show_egui_main(&h, Instant::now());
+                    });
+                }
+            }
+            return;
+        }
         let current_gen = hotkey_generation_for_listener.fetch_add(1, Ordering::SeqCst) + 1;
         // Use tracked AtomicBool instead of Win32 is_visible() to avoid
         // ~35ms cold-call overhead on first hotkey press.
@@ -972,7 +1020,11 @@ fn setup_tray(app_handle: &AppHandle, show_tray: bool, load_outcome: LoadOutcome
 /// setup: `show_main_and_emit` depends on the platform bridge (IME control).
 fn setup_startup_display(app_handle: &AppHandle, show_on_startup: bool) {
     if show_on_startup {
-        show_main_and_emit(app_handle);
+        if crate::trace::env_flag("SNOTRA_EGUI_MAIN") {
+            egui_shell::show_egui_main(app_handle, Instant::now());
+        } else {
+            show_main_and_emit(app_handle);
+        }
     }
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -676,6 +676,8 @@ fn main() {
                 // show/hide を跨ぐ共有状態（世代・emit dedup）。view/hotkey/hide が参照するので窓生成前に管理下へ。
                 app.manage(egui_shell::EguiShellState::default());
                 egui_shell::create(app, window_width as f64)?;
+                // view→emit→listener の合流点。全 hide を hide_egui_main の 1 経路に集約（codex #7）。
+                egui_shell::register_hide_listener(&app_handle);
             }
 
             // First-run: launch snotra-settings directly (bypassing the indexing guard

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -599,6 +599,18 @@ fn main() {
         app_context
     };
 
+    // フラグ ON: 宣言窓 "main"（WebView2）を除去して egui が置き換える（#532 SU2・codex #2）。
+    // tauri.conf.json は変えず config を実行時ミューテート（E2E 注入と同じ経路）。flag OFF は不変。
+    #[allow(unused_mut)]
+    let mut app_context = app_context;
+    if crate::trace::env_flag("SNOTRA_EGUI_MAIN") {
+        app_context
+            .config_mut()
+            .app
+            .windows
+            .retain(|w| w.label != "main");
+    }
+
     tauri::Builder::default()
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_single_instance::init(move |app, _args, _cwd| {
@@ -651,6 +663,14 @@ fn main() {
             // Must precede setup_hotkey_listener below, which sends RegisterInitialHotkey
             // through the platform bridge managed here.
             setup_platform_thread(&app_handle, hotkey_config, initial_language);
+
+            // 窓生成: フラグ ON は egui（platform thread spawn 後・SPEC §8.5 で Win32 初期化と並列化）、
+            // OFF は宣言窓が Tauri により既に生成済み（何もしない・flag OFF は不変）。
+            if crate::trace::env_flag("SNOTRA_EGUI_MAIN") {
+                // show/hide を跨ぐ共有状態（世代・emit dedup）。view/hotkey/hide が参照するので窓生成前に管理下へ。
+                app.manage(egui_shell::EguiShellState::default());
+                egui_shell::create(app, window_width as f64)?;
+            }
 
             // First-run: launch snotra-settings directly (bypassing the indexing guard
             // in open_settings, since initial_indexing=true during first run).

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -620,10 +620,14 @@ fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_single_instance::init(move |app, _args, _cwd| {
-            // When a second instance tries to start, show the main window
-            // via show_main_and_emit to ensure height reset, IME control,
-            // and window-shown emit are applied consistently.
-            show_main_and_emit(app);
+            // When a second instance tries to start, show the main window.
+            // flag ON は egui 窓（webview 無しゆえ get_webview_window では取れず show_main_and_emit
+            // が no-op になる）を show_egui_main で前面化。OFF は WebView2 の show_main_and_emit。
+            if crate::trace::env_flag("SNOTRA_EGUI_MAIN") {
+                egui_shell::show_egui_main(app, Instant::now());
+            } else {
+                show_main_and_emit(app);
+            }
         }))
         .manage(app_state)
         .manage(icon_cache_state)
@@ -837,11 +841,12 @@ fn setup_hotkey_listener(app_handle: &AppHandle) {
                 .try_state::<AppState>()
                 .map(|s| s.engine.lock().unwrap().config().general.hotkey_toggle)
                 .unwrap_or(true); // config.rs 既定と一致
-            match egui_shell::plan_hotkey(visible, is_alt_pressed()) {
-                egui_shell::HotkeyPlan::HideNow if hotkey_toggle => {
+            // hotkey_toggle は plan_hotkey に渡す。表示中でも hotkey_toggle=false なら hide せず
+            // show 側（再フォーカス/再配置）へ回る＝WebView2 経路の hide_on_toggle と同じ意味論。
+            match egui_shell::plan_hotkey(visible, is_alt_pressed(), hotkey_toggle) {
+                egui_shell::HotkeyPlan::HideNow => {
                     egui_shell::hide_egui_main(&handle_for_hotkey);
                 }
-                egui_shell::HotkeyPlan::HideNow => {} // hotkey_toggle=false は可視のまま
                 egui_shell::HotkeyPlan::ShowNow => {
                     egui_shell::show_egui_main(&handle_for_hotkey, t0);
                 }


### PR DESCRIPTION
## 概要

#532 Phase 2 の **SU2（ウィンドウシェル + 状態機械）**。製品 `src-tauri` のメインウィンドウを、WebView2 と並行して egui/softbuffer 経路（SU1 の `snotra-egui-runtime`）で立ち上げる外殻。env フラグ `SNOTRA_EGUI_MAIN=1` で生成時に経路選択。検索本体は SU3。

codex 敵対レビューを受けた**簡素化版（egui 専用フォーク）**。共有は `position_on_target_monitor` の `&Window` 一般化のみ。状態は `AppState.main_visible`(bool) + 純粋核 `plan_hotkey`/`blur_should_hide`。全 hide は外部 `window.hide()`（runtime.visible を false にせず空白窓回避）+ view→`emit("egui-hide-requested")`→listener 合流。

> **本 PR は #532 を閉じない。** SU2 は #532 Phase 2 の 1 サブユニットであり、親 issue は SU3–SU7 完了まで open のまま。

## 実装（TDD・6 タスク）

1. 純粋核 `plan_hotkey`（Alt+Q 分岐）を移植 — ユニットテスト
2. placeholder `SearchWindowView` + font-first カナリア（`insert(0)`・#579 回帰ガード）— ユニットテスト
3. フラグで宣言窓除去（`config_mut().app.windows.retain`）+ egui window 生成
4. `show_egui_main`/`hide_egui_main` + `position_on_target_monitor` の `&Window` 一般化 + hotkey 配線
5. blur 自動非表示 + Escape（view→emit→listener・純粋核 `blur_should_hide`）— ユニットテスト
6. SPEC §8.5 設定起動中の egui 窓 alwaysOnTop 解除

## 検証（自動・trace 実測）

- [x] **ユニットテスト 3 件**: `plan_hotkey`（4 分岐）・`blur_should_hide`（全ゲート）・font-first（`insert(0)` 両 family）。各 TDD で RED→GREEN。
- [x] **G1（flag OFF 不変）**: clippy/test 緑・`smoke:startup` 5 runs 0 errors。
- [x] **flag-OFF WebView2 位置決め**: Alt+Q 注入で `show_main:get_window found:true` を実測 — 一般化した `get_window("main")` が WebView2 の内部 Window を返し位置決めが実行される（shipping path の回帰なし）。
- [x] **G2（Alt+Q show/hide）**: flag ON で Alt+Q 注入 → `egui_show:done`→`egui_hide:done` をトレース実測（toggle 動作）。
- [x] **G4（flag ON 子孫 0）**: msedgewebview2 の global count が **flag ON +0 / flag OFF +6**（健全な before/after 計測で二重確認）。
- [x] **blur wiring**: notepad で focus 奪取 → update が focus true→false を観測。現行 config `auto_hide_on_focus_lost=false` ゆえゲートが正しく hide を抑止。
- [x] **emit→listener→hide 連鎖**: Escape 注入 → `egui_hide:done` 実測（config 非依存の無条件 emit で end-to-end 確認）。
- [x] **空白窓不在（構造保証）**: egui_shell に `RuntimeFrame::hide_window` 皆無・全 hide 外部 `window.hide()`・RENDER_ERROR トレース皆無。

## レビュー後の修正（実機で発見・修正）

実機テストで 2 件のバグを発見し、systematic-debugging で根本原因を特定して修正:

- **白フラッシュ**（`c19cddb`）: show 時、最初の softbuffer present 前にネイティブ窓の既定背景ブラシ（白）が露出。`create` で `background_color` を CLEAR_COLOR（0x282828）に合わせて解消。**実機で消失を確認済み**。
- **テキスト入力不可**（`a7661cd`）: 入力経路は正常（"abc" 注入で各文字が `Key`+`ImeEvent::Commit` として egui へ到達を実測）だが placeholder が `ui.label` のみで TextEdit を持たなかった。単一行 TextEdit を追加し窓 focus 獲得時に auto-focus。**実機で入力可を確認済み**。

## 手動確認ゲートの状況

- [x] **§8.5 z-order**: トレイから設定を開き、設定ウィンドウが検索窓より前面に出ることを**実機確認済み**。
- [x] **白フラッシュ不在**: 上記修正で**実機確認済み**。
- [x] **テキスト入力**: TextEdit で入力可を**実機確認済み**。
- [ ] **G3 hide→show ×10 の空白窓不在**: 構造保証 + RENDER_ERROR 皆無 + 白フラッシュ解消で担保。×10 反復の明示目視は未実施。
- [ ] **font-first の視覚**: `insert(0)` 機構はユニットテストで固定。TextEdit へ混在スクリプト入力で確認可能。
- [ ] **blur + auto_hide=true の end-to-end**: 部品（ユニットテスト + Escape 連鎖）で検証済み。config を true にすれば live 確認可能。
- [ ] **`e2e:tauri`**: ローカル未実行。paths 起動の `E2E & Smoke` workflow に委譲。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
