### PR TITLE
chore(tooling): /implement + post-edit hook 微調整（モジュール索引更新漏れ再発対策）

### DIFF
--- a/.claude/hooks/post-edit.mjs
+++ b/.claude/hooks/post-edit.mjs
@@ -157,6 +157,25 @@ export function selectChecks(rel) {
 }
 
 /**
+ * 新規ソースファイル（.rs / ui・e2e の TS）を Write したかの述語。真なら main() が
+ * 「モジュール索引の更新忘れ」を促す WARN を出す。
+ *
+ * 索引整合の判定そのもの（どのファイルが索引に在るべきか）は governance:check が SSOT。
+ * ここで再実装すると drift する（DRY）。ゆえに hook は**索引を検査せず**、「Write された
+ * ソースファイル」という低頻度シグナルで reminder を出すだけに留める（gate ではない）。
+ * Write に絞るのは、既存ファイルの Edit まで拾うと沈黙=合格を壊す頻度になるため——
+ * 新規ファイルは必ず Write で作られる（削除は Edit|Write matcher に届かず、CI の
+ * governance-check が索引の orphan を捕捉する残余）。#629/#630 で src-tauri/CLAUDE.md の
+ * モジュール索引更新漏れが同型再発したことへの、実装中の気づきを増やす手当て。
+ */
+export function isSourceFileWrite(rel, toolName) {
+  if (toolName !== "Write") return false;
+  const isRust = rel.endsWith(".rs");
+  const isUiOrE2eTs = (rel.startsWith("ui/src/") || rel.startsWith("e2e/")) && TS_LIKE.test(rel);
+  return isRust || isUiOrE2eTs;
+}
+
+/**
  * payload から「どのツリーの・どのファイルを・どう検査するか」を一度に決める。
  * main() もテストもここを通ることで、「抽出は正しいが選択へ渡す配線を間違えた」
  * という失敗をユニットテストが捕まえられる（§1 の回帰）。
@@ -381,6 +400,16 @@ function main() {
   const sections = [];
   const warnings = [];
   const errors = [];
+
+  // 新規ソースファイル Write は索引更新の reminder を出す（config-warn と同じインライン WARN・
+  // subprocess は走らせない）。判定は isSourceFileWrite（索引整合の SSOT は governance:check）。
+  if (isSourceFileWrite(rel, payload?.tool_name)) {
+    warnings.push(
+      `WARN: ソースファイル ${rel} を Write しました。新規追加なら該当 CLAUDE.md の` +
+        " モジュール構成節の索引にファイル名を足し、`npm run governance:check` で確認してください" +
+        "（#629/#630 で索引更新漏れが再発）。",
+    );
+  }
 
   for (const id of ids) {
     if (id === "config-warn") {

--- a/.claude/hooks/post-edit.test.mjs
+++ b/.claude/hooks/post-edit.test.mjs
@@ -12,6 +12,7 @@ import {
   toRelative,
   extractFilePath,
   selectChecks,
+  isSourceFileWrite,
   resolveTarget,
   checksForPayload,
   stripProgressLines,
@@ -181,6 +182,38 @@ describe("selectChecks", () => {
   it("ドキュメントは何も発火しない", () => {
     expect(selectChecks("docs/notes.md")).toEqual([]);
     expect(selectChecks("AGENTS.md")).toEqual([]);
+  });
+});
+
+describe("isSourceFileWrite — 新規ソース Write の索引 reminder（#629/#630）", () => {
+  // 真: Write されたソースファイル（.rs はどの crate でも、TS は ui/src・e2e）。
+  it("Write された .rs は真（どの crate でも）", () => {
+    expect(isSourceFileWrite("src-tauri/src/egui_shell/search_state.rs", "Write")).toBe(true);
+    expect(isSourceFileWrite("snotra-core/src/foo.rs", "Write")).toBe(true);
+  });
+
+  it("Write された ui/src・e2e の TS は真", () => {
+    expect(isSourceFileWrite("ui/src/lib/x.ts", "Write")).toBe(true);
+    expect(isSourceFileWrite("ui/src/components/Foo.tsx", "Write")).toBe(true);
+    expect(isSourceFileWrite("e2e/foo.e2e.ts", "Write")).toBe(true);
+  });
+
+  // 偽: Edit は既存ファイル。沈黙=合格を壊さないため Write のみに絞る。
+  it("Edit は偽（新規ではない）", () => {
+    expect(isSourceFileWrite("src-tauri/src/main.rs", "Edit")).toBe(false);
+  });
+
+  it("tool_name が Write でなければ偽（undefined 含む）", () => {
+    expect(isSourceFileWrite("snotra-core/src/foo.rs", undefined)).toBe(false);
+    expect(isSourceFileWrite("snotra-core/src/foo.rs", "Read")).toBe(false);
+  });
+
+  // 偽: 索引を持たない場所・非ソース。ui/ 直下（ui/src/ 外）や scripts/ は対象外。
+  it("非ソース・索引外は偽（負例）", () => {
+    expect(isSourceFileWrite("docs/notes.md", "Write")).toBe(false);
+    expect(isSourceFileWrite("ui/vite.config.ts", "Write")).toBe(false); // ui/src/ 外
+    expect(isSourceFileWrite("scripts/gen.ts", "Write")).toBe(false);
+    expect(isSourceFileWrite("Cargo.toml", "Write")).toBe(false);
   });
 });
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -39,9 +39,10 @@ allowed-tools:
 
 ## Step 3 — 実装
 
-- `snotra-core` の純ロジック変更: 先に失敗する `#[cfg(test)]` テストを書き（Red）、次に実装して通す（Green）
+- **純粋核（crate を問わず egui/Win32 非依存でテスト可能なロジック）の追加・変更: 先に失敗する `#[cfg(test)]` テストを書き（Red）、次に実装して通す（Green）**。`snotra-core` に限らず `src-tauri` 等の純粋モジュール（`lifecycle.rs`・`search_state.rs` 等）も対象（`view`/Win32 依存はテスト前提にしない）
 - 計画に沿って変更を行う
-- 新しい純ロジックには `snotra-core` に `#[cfg(test)]` ユニットテストを追加する
+- 新しい純ロジックには、それが属する crate に `#[cfg(test)]` ユニットテストを追加する
+- **ソースファイル（`.rs`/`.ts`/`.tsx`）を新規追加・削除したら、同じ変更で該当 `CLAUDE.md` のモジュール構成節の索引（ファイル名）を更新する**（責務散文は各ファイルの `//!`/TSDoc が正本・#562。索引漏れは `governance:check` が捕捉するが PR まで漏らさない）
 - `SPEC.md` に記載された挙動に影響する変更の場合、`SPEC.md` も更新する（`AGENTS.md` の3層分担に従う）
 
 ## Step 4 — 検証（最大5サイクル）
@@ -49,6 +50,8 @@ allowed-tools:
 `docs/build-commands.md` の「変更後の検証チェックリスト」を SSOT として、変更したファイルの種類に該当するカテゴリ A〜E をすべて実行する。失敗した場合、修正して失敗したステップから再実行する。
 
 - カテゴリ A（Rust 変更）の clippy・`cargo test -p snotra-core` も SSOT 上「必須」（最初の失敗で停止するチェーン実行を推奨）
+- **ソースファイルを追加/削除した場合、カテゴリ F（`npm run governance:check`）も実行する**（モジュール索引・参照・スキル表の整合。#629/#630 で索引更新漏れが CI まで再発した）
+- 状態でゲートされた挙動（分岐表示・エラー経路・cold path）は build/test が通っても検証済みとは限らない——その状態を実際に発生させて確認する（`docs/development-principles.md` デバッグ節）
 - 具体的なコマンド文字列は `docs/build-commands.md` を参照（二重メンテを避けるためこの SKILL に書かない）
 
 5サイクル後もエラーが残る場合、中止して診断サマリーを書く:
@@ -60,16 +63,7 @@ allowed-tools:
 
 ### 5a. check スキルの実行
 
-変更内容に応じて該当する check スキルを実行する。発見事項があれば修正してから 5b に進む。
-
-| スキル | トリガー条件 |
-|---|---|
-| `/symmetric-check` | コードパスの変更・バグ修正（ほぼ常に該当） |
-| `/dry-check` | 関数を新規定義または変更した |
-| `/race-check` | async 関数を追加・変更した（diff に `async` が含まれる） |
-| `/cache-check` | キャッシュ・インクリメンタル再利用ロジックに触れた |
-| `/persistence-check` | シリアライズ・on-disk 形式（index.bin / config.toml / history / window.bin）を変更した |
-| `/state-check` | UI モード・状態遷移・ガード条件を追加・変更した |
+変更の種類に応じた check スキル（`/symmetric-check`・`/dry-check`・`/race-check`・`/cache-check`・`/persistence-check`・`/state-check`）を、**`AGENTS.md`「条件別チェック（トリガー → 参照先）」表に従って**実行する（トリガー→検査の写像の SSOT はその表。二重管理を避けるためここに再掲しない）。`/symmetric-check` はコードパス変更・バグ修正でほぼ常に該当。発見事項があれば修正してから 5b に進む。
 
 ### 5b. code-reviewer エージェント
 


### PR DESCRIPTION
## 概要

`/implement` と PostToolUse hook を微調整し、**モジュール索引更新漏れ**（#629 SU2 → #630 SU3 M1 で同型再発・CI の governance-check まで漏れた）を実装中に気づきやすくする。#532 retrospective の見立て（強制の階梯: 機構 > skill、docs は軽く、DRY）に沿った局所プラグで、書き直しではない。本 PR はどの issue も close しない。

## hook（`.claude/hooks/post-edit.mjs`）

- 新規ソースファイル（`.rs` / ui・e2e の TS）を **Write** したとき、`config-warn` と同じインライン WARN で「該当 `CLAUDE.md` のモジュール構成節の索引を更新し `npm run governance:check` で確認」を促す（新規 export `isSourceFileWrite`）。
- **索引整合の判定は再実装しない**（SSOT は `governance:check`・DRY）。hook は「Write されたソースファイル」という低頻度シグナルで reminder を出すだけで、gate ではない。**Write に絞る**のは、既存ファイルの Edit まで拾うと「沈黙=合格」を壊す頻度になるため（新規ファイルは必ず Write で作られる。削除は Edit|Write matcher に届かず、CI の governance-check が索引の orphan を捕捉する残余）。
- 検証: `isSourceFileWrite` の unit テスト（正/負）+ **フォールトインジェクション**（`.claude/rules/safety-nets.md` の作法）— Write `.rs` で WARN が `systemMessage` に発火、Edit `.rs` では非発火を実プロセスで実測。BUDGETS 完全性カナリアは selectChecks の id のみを見るため無影響。hook-selftest **147 pass**。

## `/implement`（`.claude/skills/implement/SKILL.md`）

- **Step 3**: TDD トリガーを「`snotra-core` の純ロジック」→「**crate を問わず egui/Win32 非依存の純粋核**」へ拡張（SU3 M1 の純粋核 `SearchState`/`interpret`/`layout` は `src-tauri` に在り、現行トリガーに載らなかった）。**新規/削除ファイルは同じ変更で該当 `CLAUDE.md` 索引を更新**を明記。
- **Step 4**: **ファイル追加/削除時はカテゴリ F（`npm run governance:check`）も実行**。加えて状態でゲートされた挙動（分岐表示・cold path）は build/test 通過≠検証済みの注意を development-principles へポインタ。
- **Step 5a**: check スキルのトリガー表を**再掲やめ、`AGENTS.md`「条件別チェック（トリガー → 参照先）」表への SSOT ポインタ**に（DRY・skill 軽量化。retrospective の「docs が軽くなることを検収条件に」）。

## 検証

- `npm run governance:check` G1..G10 passed
- hook-selftest（`vitest run .claude/hooks`）147 pass
- フォールトインジェクション両方向（Write=発火 / Edit=非発火）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
