### PR TITLE
feat(egui): SU3 M3 instant + slash コマンド（#532 Phase 2）

### DIFF
--- a/docs/superpowers/plans/2026-07-23-su3-m3-instant-slash.md
+++ b/docs/superpowers/plans/2026-07-23-su3-m3-instant-slash.md
@@ -1,0 +1,536 @@
+# SU3 M3 instant + slash Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** egui/softbuffer メインウィンドウに、WebView2(SolidJS) と parity なインスタントコマンド（`@`前方一致・同期直フィルタ・実行）とスラッシュコマンド（`/r /o /s /q`・完全一致即実行）を直 Engine で足す。
+
+**Architecture:** 設計 SSOT は `docs/superpowers/specs/2026-07-22-su3-search-experience-design.md`「M3 実装確定」節。instant fetch は 30ms debounce を撤廃し `filter_instant_commands` を毎打鍵同期実行、instant 実行は同期直呼び（`launch_item_core`/`launch_exec_core`・ブロックリスクは #631）。slash は TextEdit changed エッジで edge-trigger（`/r` のみ結果注入型で `run_search` の Command 分岐が冪等に扱う）。Enter/クリックの activate は changed 処理より**後**で interp 判定する（codex 発見 4）。Escape ラダーは M2 の 2 段のまま（ClearMode 段は parity 乖離ゆえ削除済み）。
+
+**Tech Stack:** Rust / egui 0.35 / Tauri v2 / snotra-core（`instant.rs`）/ arboard。
+
+## Global Constraints
+
+- **flag OFF（`SNOTRA_EGUI_MAIN` 未設定）で WebView2 経路・IPC コマンド・E2E 注入は完全不変（G1）。** IPC の `get_instant_commands`/`execute_instant_command` は触らない。egui 経路は crate 内の core fn（`filter_instant_commands`/`expand_instant_command`/`launch_*_core`）を直接呼ぶだけ（additive）。
+- **instant 実行は同期直呼び**（spec M3 実装確定）。`run_launch_blocking`（spawn_blocking + 4s）は通さない——SPEC §19.6 乖離は受容済み残余（#631 コメント 2026-07-23 に記録済み）。
+- **失敗通知は M1 同型**: hide しない + `trace_main` のみ。通知 UI を建てない（#631 一本化）。`/s` の indexing 中 Err は無音（#434 parity）。
+- **純粋核（`search_state.rs`/`layout.rs`）はユニットテスト。view.rs はユニットテスト前提にしない**（clippy + trace スモーク・`.claude/rules/src-tauri.md`）。
+- **各 green でコミット。** `cargo test -p snotra` / `cargo clippy -p snotra --all-targets -- -D warnings`（`docs/build-commands.md`）。実機スモークは flag ON で `msedgewebview2.exe` 子孫 0。
+
+---
+
+## File Structure
+
+- `src-tauri/src/egui_shell/search_state.rs`（Modify）: `SlashCmd` enum + `find_slash_command` 純関数（trim 後完全一致・§15.3 判定の SSOT）、`SearchState::reset_selection`（毎打鍵 selected=0 の SolidJS parity・M1 持ち越し gap の是正）。ユニットテスト対象。
+- `src-tauri/src/egui_shell/layout.rs`（Modify）: `Debouncer::cancel`（instant/command 突入時に armed trailing を掃除する・SolidJS `cancelDebounce` parity）。ユニットテスト対象。
+- `src-tauri/src/egui_shell/mod.rs`（Modify）: `SlashCmd`/`find_slash_command` の re-export 1 行。
+- `src-tauri/src/egui_shell/view.rs`（Modify）: `run_search` の Command/Instant 分岐、changed エッジ dispatch 再構成、`execute_slash`/`execute_instant_selected`/`activate_or_execute`、Enter 後置、← の instant ガード。clippy + trace スモーク検証。
+
+---
+
+## Task 1: 純粋核（`search_state.rs` + `layout.rs`）
+
+**Files:**
+- Modify: `src-tauri/src/egui_shell/search_state.rs`
+- Modify: `src-tauri/src/egui_shell/layout.rs`
+- Modify: `src-tauri/src/egui_shell/mod.rs`（re-export）
+- Test: 各ファイルの `#[cfg(test)] mod tests`
+
+**Interfaces:**
+- Consumes: 既存 `SearchState`（`selected` field・`clamp_selected`）、既存 `Debouncer`（`armed` field）。
+- Produces:
+  - `SlashCmd { History, OpenSettings, RebuildIndex, Quit }`（`Debug, Clone, Copy, PartialEq, Eq`）
+  - `find_slash_command(query: &str) -> Option<SlashCmd>`（trim 後完全一致・大文字小文字区別）
+  - `SearchState::reset_selection(&mut self)`（selected=0）
+  - `Debouncer::cancel(&mut self)`（disarm・trailing 取り消し）
+  - `mod.rs` re-export: `pub(crate) use search_state::{SlashCmd, find_slash_command};`
+
+- [ ] **Step 1: `find_slash_command` の failing test を書く**
+
+`search_state.rs` の tests に追加（`ui/src/lib/commands.ts` の `findCommand`（`c.command === trimmed`）parity）:
+
+```rust
+#[test]
+fn find_slash_command_exact_match_with_trim() {
+    assert_eq!(find_slash_command("/r"), Some(SlashCmd::History));
+    assert_eq!(find_slash_command(" /o "), Some(SlashCmd::OpenSettings)); // trim 後一致
+    assert_eq!(find_slash_command("/s"), Some(SlashCmd::RebuildIndex));
+    assert_eq!(find_slash_command("/q"), Some(SlashCmd::Quit));
+}
+
+#[test]
+fn find_slash_command_rejects_partial_case_and_args() {
+    assert_eq!(find_slash_command("/"), None);        // 部分入力
+    assert_eq!(find_slash_command("/x"), None);       // 未知コマンド
+    assert_eq!(find_slash_command("/O"), None);       // 大文字は不一致（findCommand === parity）
+    assert_eq!(find_slash_command("/o extra"), None); // 引数付きは不一致（完全一致のみ）
+    assert_eq!(find_slash_command(""), None);
+}
+```
+
+- [ ] **Step 2: 落ちるのを確認**
+
+Run: `cargo test -p snotra find_slash_command`
+Expected: FAIL（`find_slash_command` 未定義でコンパイルエラー）
+
+- [ ] **Step 3: `SlashCmd` + `find_slash_command` を実装 + re-export**
+
+`search_state.rs` に追加（`EscapeOutcome` の近く）:
+
+```rust
+/// slash コマンドの写像（§15.2）。History(`/r`) だけは結果注入型（履歴を表示して留まる）で、
+/// driver が run_search の Command 分岐へ振る。他 3 つは fire-once の副作用型。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlashCmd {
+    History,
+    OpenSettings,
+    RebuildIndex,
+    Quit,
+}
+
+/// trim 後の完全一致で slash コマンドを引く（§15.3 即実行の判定・commands.ts findCommand parity・
+/// 大文字小文字は区別する）。部分入力・引数付きは None（候補表示なし・§15.3）。
+pub fn find_slash_command(query: &str) -> Option<SlashCmd> {
+    match query.trim() {
+        "/r" => Some(SlashCmd::History),
+        "/o" => Some(SlashCmd::OpenSettings),
+        "/s" => Some(SlashCmd::RebuildIndex),
+        "/q" => Some(SlashCmd::Quit),
+        _ => None,
+    }
+}
+```
+
+`mod.rs` の既存 `pub(crate) use search_state::{interpret, is_instant_prefix};` の近くに追加:
+
+```rust
+pub(crate) use search_state::{SlashCmd, find_slash_command};
+```
+
+- [ ] **Step 4: 通るのを確認**
+
+Run: `cargo test -p snotra find_slash_command`
+Expected: PASS
+
+- [ ] **Step 5: `reset_selection` の failing test を書く**
+
+```rust
+#[test]
+fn reset_selection_returns_to_top() {
+    // SolidJS parity: 毎打鍵 setSelected(0)（handlePlainQueryInput / instant fetch / slash とも）。
+    // M1 は set_results の clamp のみで、打鍵後も旧 selected が残っていた（M3 で是正）。
+    let mut s = SearchState::new();
+    s.set_results(vec![res("a"), res("b"), res("c")]);
+    s.move_selection(2);
+    assert_eq!(s.selected(), 2);
+    s.reset_selection();
+    assert_eq!(s.selected(), 0);
+}
+```
+
+- [ ] **Step 6: 落ちるのを確認 → 実装 → 通す**
+
+Run: `cargo test -p snotra reset_selection_returns_to_top`
+Expected: FAIL（未定義）
+
+`SearchState` impl に追加:
+
+```rust
+    /// 選択を先頭へ戻す。driver が打鍵（changed エッジ）ごとに呼ぶ（SolidJS の毎打鍵
+    /// setSelected(0) parity・#532 SU3 M3）。
+    pub fn reset_selection(&mut self) {
+        self.selected = 0;
+    }
+```
+
+Run: `cargo test -p snotra reset_selection_returns_to_top`
+Expected: PASS
+
+- [ ] **Step 7: `Debouncer::cancel` の failing test を書く**
+
+`layout.rs` の tests に追加:
+
+```rust
+    #[test]
+    fn cancel_disarms_pending_trailing() {
+        let mut d = Debouncer::new(Duration::from_millis(50), true);
+        d.on_input();
+        assert!(d.is_armed());
+        d.cancel();
+        assert!(!d.is_armed());
+        assert!(!d.poll(Duration::from_millis(100)), "cancel 後は trailing 発火しない");
+        // cancel 後の次入力はバースト先頭扱い（leading 再発火）
+        assert!(d.on_input());
+    }
+```
+
+- [ ] **Step 8: 落ちるのを確認 → 実装 → 通す**
+
+Run: `cargo test -p snotra cancel_disarms_pending_trailing`
+Expected: FAIL（`cancel` 未定義）
+
+`Debouncer` impl に追加:
+
+```rust
+    /// armed を解除し予約済み trailing を取り消す（SolidJS cancelDebounce parity・#532 SU3 M3）。
+    /// instant/command モード突入時に driver が呼ぶ——モード外で予約された検索が
+    /// モード中に遅延発火する経路を塞ぐ（run_search は再導出ゆえ実害は無いが無駄撃ちを消す）。
+    pub fn cancel(&mut self) {
+        self.armed = false;
+    }
+```
+
+Run: `cargo test -p snotra cancel_disarms_pending_trailing`
+Expected: PASS
+
+- [ ] **Step 9: clippy + 全テスト**
+
+Run: `cargo clippy -p snotra --all-targets -- -D warnings && cargo test -p snotra egui_shell`
+Expected: clean + PASS（既存 M1/M2 テスト含め全緑）
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src-tauri/src/egui_shell/search_state.rs src-tauri/src/egui_shell/layout.rs src-tauri/src/egui_shell/mod.rs
+git commit -m "feat(egui): M3 純粋核（SlashCmd/find_slash_command・reset_selection・Debouncer::cancel）#532 SU3 M3"
+```
+
+---
+
+## Task 2: driver 配線（`view.rs`）
+
+**注**: `view.rs` は egui/Win32 依存ゆえユニットテスト前提にしない（`.claude/rules/src-tauri.md`）。検証は `cargo clippy` + flag ON の trace スモーク。各ステップは concrete edit。
+
+**Files:**
+- Modify: `src-tauri/src/egui_shell/view.rs`
+
+**Interfaces:**
+- Consumes: Task 1（`SlashCmd`/`find_slash_command`/`reset_selection`/`Debouncer::cancel`）、既存 `QueryIntent`（`interp`）、`snotra_core::instant::{filter_instant_commands, expand_instant_command}`、`snotra_core::config::InstantAction`、`crate::commands::launch::{InstantCommandDto, launch_item_core, launch_exec_core, LaunchStatus}`、`crate::commands::{open_settings, rebuild_index}`（`main.rs:setup_open_settings_listener` の直呼び前例と同型）、`Engine::recent_history`。
+
+- [ ] **Step 1: import を追加**
+
+`view.rs` 冒頭の `use crate::egui_shell::{...}` に `SlashCmd, find_slash_command` を追加:
+
+```rust
+use crate::egui_shell::{
+    Debouncer, EscapeOutcome, HeightParams, QueryIntent, SearchState, SlashCmd, ViewKind,
+    // …既存の他項目は不変…
+    find_slash_command,
+};
+```
+
+- [ ] **Step 2: `run_search` の Command/Instant 分岐を実装**
+
+現 `run_search` の `// command/instant は M3。M1/M2 では結果を出さない（空維持）。` の `_ =>` 腕を削除し、明示 2 腕へ置換:
+
+```rust
+                    QueryIntent::Instant { filter_name, .. } => {
+                        // §19.5: 前方一致フィルタ。毎打鍵同期（30ms debounce 撤廃・spec M3 実装確定）。
+                        // indexing を見ない（§19.7: instant はインデックス非依存ゆえ構築中でも使用可）。
+                        let rows = {
+                            let state = match self.app_handle.try_state::<crate::AppState>() {
+                                Some(s) => s,
+                                None => return,
+                            };
+                            let engine = state.engine.lock().unwrap();
+                            snotra_core::instant::filter_instant_commands(
+                                &engine.config().instant_commands,
+                                &filter_name,
+                            )
+                            .into_iter()
+                            .map(|c| {
+                                let dto = crate::commands::launch::InstantCommandDto::from(c);
+                                SearchResult {
+                                    name: dto.name,
+                                    // §19.5: description 設定時は優先、無ければ display（URL / exe args）
+                                    path: if dto.description.is_empty() { dto.display } else { dto.description },
+                                    is_folder: false,
+                                    is_error: false,
+                                }
+                            })
+                            .collect::<Vec<_>>()
+                        }; // lock 解放
+                        self.state.set_results(rows);
+                    }
+                    QueryIntent::Command => {
+                        // §15.2 /r: 履歴を注入して留まる（冪等ゆえ trailing 再発火も無害）。
+                        // 他（部分入力・実行済み直後）は候補なしクリア（§15.3: command 中は検索しない）。
+                        if matches!(find_slash_command(self.state.query()), Some(SlashCmd::History)) {
+                            let rows = {
+                                let state = match self.app_handle.try_state::<crate::AppState>() {
+                                    Some(s) => s,
+                                    None => return,
+                                };
+                                let engine = state.engine.lock().unwrap();
+                                engine.recent_history()
+                            };
+                            self.state.set_results(rows);
+                        } else {
+                            self.state.set_results(Vec::new());
+                        }
+                    }
+```
+
+（`recent_history` が `&mut self` を要求してコンパイルエラーになる場合は `let mut engine` にする——`commands/search.rs:get_history_results` と同じ呼び方に合わせる。）
+
+- [ ] **Step 3: `execute_slash` を追加**
+
+`SearchWindowView` impl に追加（`activate` の近く）:
+
+```rust
+    /// slash コマンドを実行する（§15.3 即実行・#532 SU3 M3）。SolidJS handleCommandQueryInput と
+    /// 同順: クエリ/結果クリア（clearCommandModeState 相当）→ action。`/r`（History）は結果注入型で
+    /// ここへ来ない（changed ハンドラが run_search へ振る）。失敗通知は建てない（trace のみ・#631 一本化）。
+    fn execute_slash(&mut self, cmd: SlashCmd) {
+        crate::trace_main("egui_slash", serde_json::json!({ "cmd": format!("{cmd:?}") }));
+        self.state.set_query(String::new());
+        self.state.set_results(Vec::new());
+        self.search_debounce.cancel();
+        let app = self.app_handle.clone();
+        match cmd {
+            SlashCmd::History => {} // 到達しない（呼び出し側 match が run_search へ振る）
+            SlashCmd::OpenSettings => {
+                // indexing 中の Err（ERR_INDEXING_IN_PROGRESS）は trace のみ（spec M3 実装確定・
+                // クエリクリア後は検索バーの indexing hint が可視＝degraded な理由提示）。
+                if let Err(e) = crate::commands::open_settings(app.state(), app.clone()) {
+                    crate::trace_main("egui_slash_error", serde_json::json!({ "cmd": "/o", "error": e }));
+                }
+            }
+            SlashCmd::RebuildIndex => {
+                // SolidJS /s parity: hide してから rebuild（hide は emit 合流・順序は視覚のみで
+                // rebuild は backend スレッド）。indexing 中の Err は意図的無音（#434 parity）。
+                self.emit_hide();
+                if let Err(e) = crate::commands::rebuild_index(app.state(), app.clone()) {
+                    crate::trace_main("egui_slash_error", serde_json::json!({ "cmd": "/s", "error": e }));
+                }
+            }
+            SlashCmd::Quit => {
+                // quit_app（commands/system.rs）と同一実体: exit-requested listener が
+                // history/icon flush → exit（main.rs）。egui 経路も同じ合流点を使う。
+                let _ = app.emit("exit-requested", ());
+            }
+        }
+    }
+```
+
+- [ ] **Step 4: `execute_instant_selected` を追加**
+
+```rust
+    /// 選択中の instant コマンドを同期実行する（§19.6・#532 SU3 M3）。IPC の
+    /// execute_instant_command（spawn_blocking + 4s）と同じ手順（action 抽出をロック内・
+    /// clipboard 読みをロック外）を、イベントループで同期直呼びに畳む（spec M3 実装確定・
+    /// ブロックリスクは #631 スコープ）。instant は履歴を記録しない（IPC 経路 parity）。
+    /// 成功: クエリ/結果クリア + hide（§19.6）。失敗: 据え置き + trace（M1 起動失敗と同型）。
+    fn execute_instant_selected(&mut self, index: usize, instant_query: &str) {
+        use crate::commands::launch::{LaunchStatus, launch_exec_core, launch_item_core};
+        use snotra_core::config::InstantAction;
+        use snotra_core::instant::expand_instant_command;
+        let Some(sel) = self.state.results().get(index) else { return };
+        if sel.is_error {
+            return;
+        }
+        let name = sel.name.clone();
+        let Some(state) = self.app_handle.try_state::<crate::AppState>() else { return };
+        let Some(action) = ({
+            let engine = state.engine.lock().unwrap();
+            engine
+                .config()
+                .instant_commands
+                .iter()
+                .find(|c| c.name == name)
+                .map(|c| c.action.clone())
+        }) else {
+            return;
+        };
+        // clipboard 読み（Win32）はロック外（commands/instant.rs と同順）。
+        let clipboard = arboard::Clipboard::new()
+            .and_then(|mut cb| cb.get_text())
+            .unwrap_or_default();
+        let outcome = match action {
+            InstantAction::Url { url } => {
+                launch_item_core(&expand_instant_command(&url, instant_query, &clipboard))
+            }
+            InstantAction::Exec { exe, args } => {
+                launch_exec_core(&exe, &args, instant_query, &clipboard)
+            }
+            // load 後は移行済みで到達しないが、防御的に Url 扱い（IPC 経路と同じ）
+            InstantAction::Legacy { command } => {
+                launch_item_core(&expand_instant_command(&command, instant_query, &clipboard))
+            }
+        };
+        crate::trace_main(
+            "egui_instant",
+            serde_json::json!({ "name": name, "status": format!("{:?}", outcome.status) }),
+        );
+        if matches!(outcome.status, LaunchStatus::Ok) {
+            self.state.set_query(String::new());
+            self.state.set_results(Vec::new());
+            self.search_debounce.cancel();
+            self.emit_hide();
+        }
+    }
+
+    /// Enter/クリックの単一 dispatch（§19.6/§4.8・#532 SU3 M3）。instant モード中は選択コマンドを
+    /// 実行、それ以外（plain・/r 履歴・folder）は通常起動（activate）。行 index で参照
+    /// （パス文字列を使わない・ui ルール踏襲）。Shift+Enter も同じ Enter として届くため
+    /// §19.6「Shift+Enter=Enter」は追加コードなしで成立する（tool-selection は SU3.5）。
+    fn activate_or_execute(&mut self, index: usize) {
+        let prefix = self.instant_prefix();
+        if let QueryIntent::Instant { instant_query, .. } = self.state.interp(&prefix) {
+            self.execute_instant_selected(index, &instant_query);
+        } else {
+            self.activate(index);
+        }
+    }
+```
+
+- [ ] **Step 5: changed エッジの dispatch を interp 分岐へ再構成**
+
+現 `if response.changed() { ... }` の else（Results）側を置換:
+
+```rust
+        if response.changed() {
+            if in_folder {
+                self.state.set_folder_filter(buf);
+                self.run_search(); // folder は同期フィルタ（debounce 不要・I/O 無し）
+            } else {
+                self.state.set_query(buf);
+                self.state.reset_selection(); // SolidJS parity: 毎打鍵 selected=0（M1 gap 是正）
+                let prefix = self.instant_prefix();
+                match self.state.interp(&prefix) {
+                    QueryIntent::Plain => {
+                        self.last_input_at = Instant::now();
+                        if self.search_debounce.on_input() {
+                            self.run_search(); // leading
+                        }
+                        ctx.request_repaint_after(self.search_debounce.interval());
+                    }
+                    QueryIntent::Instant { .. } => {
+                        // 同期直フィルタ（30ms debounce 撤廃・spec M3 実装確定）。
+                        // plain 由来の armed trailing は掃除（cancelDebounce parity）。
+                        self.search_debounce.cancel();
+                        self.run_search();
+                    }
+                    QueryIntent::Command => {
+                        // §15.3: debounce をキャンセルして即実行（changed エッジ＝query 変化時
+                        // のみゆえ immediate-mode でも fire-once）。/r と部分入力は run_search の
+                        // Command 分岐（冪等: /r=履歴注入・他=結果クリア）。
+                        self.search_debounce.cancel();
+                        match find_slash_command(self.state.query()) {
+                            Some(SlashCmd::History) | None => self.run_search(),
+                            Some(cmd) => self.execute_slash(cmd),
+                        }
+                    }
+                }
+            }
+        }
+```
+
+- [ ] **Step 6: Enter 処理を changed 処理の後へ移し dispatch を統一**
+
+現在 TextEdit より前にある Enter ブロック（`// Enter: 選択項目を起動（結果があるとき）。TextEdit の Enter より先に ctx で拾う。` + `if ctx.input(...Enter...) { self.activate(...) }`）を**削除**し、trailing debounce ブロック（`self.search_debounce.poll(...)` と `is_armed()` の再要求）の**直後**（`let show_results = ...` の前）に挿入:
+
+```rust
+        // Enter: 選択項目を起動/実行。TextEdit の changed 処理より後で判定する——同一フレームに
+        // 入力確定（貼り付け・IME 確定）と Enter が入ったとき、旧 state の interp/選択で起動
+        // しないため（codex 発見 4・spec M3 実装確定）。egui の input はフレーム内で不変
+        // （読む順序は消費に影響しない）ため後置しても Enter は取りこぼさない。
+        if ctx.input(|i| i.key_pressed(egui::Key::Enter)) && !self.state.results().is_empty() {
+            self.activate_or_execute(self.state.selected());
+        }
+```
+
+クリック合流点 `if let Some(i) = clicked { self.activate(i); }` を差し替え:
+
+```rust
+        if let Some(i) = clicked {
+            self.activate_or_execute(i);
+        }
+```
+
+- [ ] **Step 7: ← の instant ガードを追加**
+
+ArrowLeft の `ViewKind::Results` 腕の条件に interp ガードを足す（§19.7: instant 中の ←→ 無効。
+→ は instant 行が `is_folder=false` ゆえ既存ガードで構造的に無反応・追加不要）:
+
+```rust
+                ViewKind::Results => {
+                    // instant/command 中は ← 無効（§19.7）。instant 行の path は description/display
+                    // ゆえ compute_parent_dir が偶然 Some を返して bogus folder 突入しうるのを塞ぐ。
+                    if matches!(self.state.interp(&self.instant_prefix()), QueryIntent::Plain)
+                        && let Some(sel) = self.state.results().get(self.state.selected())
+                        && !sel.is_error
+                        && let Some(parent) = compute_parent_dir(&sel.path)
+                    {
+                        let tok = self.state.enter_folder(parent.clone());
+                        // ← from Results は enterFolderExpansion(parent) 相当・記録する。
+                        self.record_folder_expansion(&parent);
+                        self.folder_cache = None;
+                        self.folder_error = None;
+                        self.spawn_folder_load(tok, parent, ctx.clone());
+                    }
+                }
+```
+
+- [ ] **Step 8: clippy**
+
+Run: `cargo clippy -p snotra --all-targets -- -D warnings`
+Expected: clean
+
+- [ ] **Step 9: flag OFF 完全不変（G1）確認**
+
+Run: `cargo test -p snotra && cargo test -p snotra-core`（flag 未設定）
+Expected: 既存テスト全緑（WebView2 経路・IPC・core とも不変。M3 の追加は egui view と純粋核のみ）
+
+- [ ] **Step 10: trace スモーク（flag ON・実機）**
+
+Run: `$env:SNOTRA_EGUI_MAIN=1; $env:SNOTRA_TRACE=1; cargo run -p snotra --release`（`docs/build-commands.md` の起動手順に従う）
+確認（目視 + trace）:
+
+- `@` のみ → 登録コマンド全件表示（既定 `g`/`gh`）・アイコンスロット無しでも行が読める
+- `@g` → 前方一致絞り込み・**打鍵と同フレームで候補更新**（30ms 遅延なし）
+- `@g rust` + Enter → 既定ブラウザで Google 検索・クエリクリア・hide（trace `egui_instant` status=Ok）
+- `@unknown` → 結果空（noResults 表示なし・§19.5）
+- instant 中 `←`/`→` 無反応（folder 突入しない）・Shift+Enter=Enter
+- instant 行クリック → Enter と同じ実行
+- `/s` 直後（indexing 中）に `@g` が使える（§19.7）・plain 検索は空のまま
+- `/r` → 履歴表示・**留まる**（クエリは `/r` のまま）・↑↓ 選択 + Enter で履歴項目起動
+- `/o` → 設定起動 + クエリクリア。indexing 中は開かず、空クエリの bar に indexing hint が可視（trace `egui_slash_error`）
+- `/s` → hide + 再構築開始（trace `egui_slash` cmd=RebuildIndex）
+- `/x`（部分入力） → 結果空・検索走らず
+- instant/command 中の Escape → **即 hide**（ClearMode なし・SolidJS/SPEC §8.6 parity）
+- 打鍵で selected が先頭へ戻る（plain でも・M1 gap 是正の確認）
+- `/q` → 終了（trace で flush 経路確認）※最後に実行
+- `msedgewebview2.exe` 子孫 0（`/q` 前に確認）
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src-tauri/src/egui_shell/view.rs
+git commit -m "feat(egui): instant+slash driver 配線（同期直フィルタ・edge-trigger 即実行・Enter 後置 dispatch）#532 SU3 M3"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage（spec「M3 実装確定」節 + §15/§19 → タスク）:**
+- instant 同期直呼び + #631 残余 → Task 2 Step 4（`execute_instant_selected` doc に明記）。
+- 30ms debounce 撤廃 → Task 2 Step 2/5（同期直フィルタ・`Debouncer::cancel` は Task 1 Step 7-8）。
+- ClearMode 削除 → コード変更なし（M2 の `on_escape` のまま）。スモーク Step 10 で「instant/command 中 Escape=即 hide」を明示確認。
+- 失敗通知 M1 同型 + `/o` indexing hint 緩和 → Task 2 Step 3（trace のみ・hint はクエリクリアで自然可視）。
+- dispatch 再構成（changed → Enter）→ Task 2 Step 5/6。クリックも `activate_or_execute` へ統一（Step 6）。
+- slash edge-trigger・`/r` 注入・`/o` `/s` `/q` 写像 → Task 2 Step 2/3/5。`/q` は `emit("exit-requested")`（`quit_app` と同一実体）。
+- instant フィルタ/DTO 変換/アイコンスキップ（§19.5）→ Task 2 Step 2（アイコンは M1 から placeholder スロットのみ＝スキップ相当。SU4 で instant 非表示を実装）。
+- ←→ 無効（§19.7）→ Task 2 Step 7（← ガード・→ は is_folder=false で構造的無反応）。Shift+Enter=Enter（§19.6）→ egui は修飾キー無視で Enter が届くため追加コードなし（Step 4 doc に記載）。
+- indexing 非対称（§19.7）→ run_search の Plain 分岐のみ indexing ガード（既存・Step 2 は見ない）。
+- selected リセット parity → Task 1 Step 5-6 + Task 2 Step 5（受け入れ条件に含める・スモークで確認）。
+- resetForShow の instant 解除（§19.7）→ 既存 `reset()`（query クリアで interp が Plain に戻る・追加不要）。
+
+**Placeholder scan:** なし（全ステップ concrete code / command / 期待値付き）。
+
+**Type consistency:** `SlashCmd`/`find_slash_command` は Task 1 定義 → mod.rs re-export → Task 2 が `crate::egui_shell` 経由で消費。`execute_instant_selected(index: usize, instant_query: &str)` は `activate_or_execute` からのみ呼ばれ、`instant_query` は `QueryIntent::Instant { instant_query, .. }`（owned String）から借用。`Debouncer::cancel` は `search_debounce`（既存 field）に対して呼ぶ。`InstantCommandDto::from(&InstantCommand)` は既存 impl（launch.rs:376）。
+
+**実装時確認点（着手時に潰す）:**
+- `recent_history` の `&self`/`&mut self`（Step 2 の注記どおり呼び方を合わせる）。
+- `open_settings`/`rebuild_index` の `app.state()` 直呼びが view から通るか（`main.rs:setup_open_settings_listener` 前例あり。`use tauri::Manager` が view.rs に既存か確認）。
+- `arboard` は `commands/instant.rs` で使用済み（同一 crate 依存・追加不要）。

--- a/docs/superpowers/specs/2026-07-22-su3-search-experience-design.md
+++ b/docs/superpowers/specs/2026-07-22-su3-search-experience-design.md
@@ -61,6 +61,19 @@ folder（M2）の実装方針を確定。以下は上の決定 4/5 と §状態�
 - **staleness は全離脱経路で失効。** `begin_folder_request` に加え Escape/hide/reset/親子遷移でも `folder_gen` を進め、`apply_folder_result` は token 一致 ∧ view_kind==Folder のときだけ適用する（遅延到着した旧ナビ結果が通常検索を轢く経路を塞ぐ）。channel は毎フレーム drain して最新 token だけ反映し、列挙完了時は現 `folder_filter` で再フィルタする。
 - **B の非対称を parity 対象外と明記。** キャッシュは folder 滞在中の fs 変化・隠し項目/フォルダ検索方式の config 変更を反映しない（SolidJS は filter ごと再列挙で反映）。巨大 dir の保持は上限 or 明示受容 + 計測を M2 の受け入れ条件に入れる。
 
+### M3 実装確定（brainstorm 2026-07-23・codex 反証レビュー反映）
+
+instant + slash（M3）の実装方針を確定。以下は決定 7 の instant 部分・§Escape ラダーの段 2・§milestone M3 行・§テスト計画の「Escape ラダー 3 段」（→ 2 段）の該当箇所を **supersede** する。細目の実装要件（関数署名・テスト名・手順）は M3 plan を SSOT とする。
+
+- **instant 実行は同期直呼び。** driver が action 抽出（ロック内・即解放）→ clipboard 読み → 種別ディスパッチ（`launch_item_core` / `launch_exec_core`）をイベントループスレッドで同期実行する（M1 の `activate` と同型。IPC の `execute_instant_command` は触らない＝G1）。**SPEC §19.6 の spawn_blocking + 4 秒保護は egui 経路では一時的に満たさない**——ブロックリスク（dead UNC・シェル拡張停留）は #631（通知 UI + single-flight とセットで flip 前に解消）へ instant を追記して defer する（受容済み残余・codex 発見 1）。
+- **instant fetch の 30ms trailing debounce は撤廃**（決定 7 の instant 部分と milestone M3 行の「30ms trailing debounce」を supersede）。debounce が守っていたコスト（IPC 往復の coalescing）は直 Engine で消滅し、`filter_instant_commands`（config 内数件の前方一致）は毎打鍵同期で走らせる。search の 50ms debounce（インデックス全走査の保護）は維持。決定 1 と同じ「IPC 起因の機構は egui 経路へ移植しない」論法。
+- **Escape ラダーの ClearMode 段（段 2）を削除**（§Escape ラダーと milestone M3 行の「Escape ラダー完成（instant/command 解除段）」を supersede）。SolidJS（`SearchWindow.tsx`: `exitToolSelection` → `exitFolderExpansion` → `hideMainWindow`）にも SPEC §8.6（InstantCommandMode/CommandMode に Escape 遷移なし・hide をブロックするのは tool/folder のみ）にも instant/command 中のモード解除は存在せず、ClearMode は本 spec が発明した parity 乖離だった。「移行の内側で仕様変更を折り込まない」原則に従い削除。`EscapeOutcome` は M2 の 2 段（RestoredSearch/Hide）で完成——instant/command は results ビューとして自然に Hide 段へ落ちる（M3 の Escape 作業は本訂正のみ）。
+- **失敗通知は M1 同型（hide しない + trace のみ）。** instant 実行失敗・`/o` の indexing 中 Err に通知 UI を建てず、#631 の通知設計へ一本化する。parity gap（SolidJS の launchNotice 3 秒表示）は明示受容。緩和: `/o` は SolidJS と同順の「クエリクリア → action」ゆえ、失敗後は空クエリの検索バーに M1 の indexing hint（「インデックス構築中...」）が可視で、開けない理由は degraded ながら見える。`/s` の indexing 中無音は SolidJS（#434）と一致。
+- **dispatch を「TextEdit changed 処理 → Enter/クリック判定」の順に再構成**（codex 発見 4）。現 M1 は Enter 処理が TextEdit の changed 処理より前（`view.rs`）にあり、同一フレームに入力確定と Enter が入ると旧 state の interp/選択で起動しうる。M3 で Enter が interp 分岐（activate / instant 実行）の判定点になるため、TextEdit 処理後に Enter/クリックを判定し、そのフレームの最新 state を唯一の判定入力とする。
+- **slash は changed エッジで edge-trigger**（§15.3 の「debounce キャンセル + 即実行」の egui 再現。immediate-mode でも query 変化時のみゆえ毎フレーム再実行は構造的に起きない）。`interp()==Command` かつ trim 完全一致で debounce を迂回して即実行。SolidJS と同順の「クエリクリア（+結果クリア）→ action」。`/r` は `engine.recent_history()` を `set_results` して**留まる**（冪等・選択起動可・クエリは `/r` のまま）。`/o` は `commands::open_settings` 直呼び（`main.rs` の listener 前例と同型）。`/s` は `emit_hide` → `rebuild_index` 直呼び（indexing 中 Err は無音）。`/q` は `emit("exit-requested")`（`quit_app` の実体と同一・history/icon flush 経路を共有）。部分入力は結果クリア（候補表示なし・検索しない）。
+- **instant は dispatch 内で同期フィルタ。** `interp()==Instant{filter_name}` で `filter_instant_commands` → DTO→`SearchResult` 変換（name=コマンド名・path 欄=`description` 優先/無ければ `display`・is_folder=false・is_error=false・§19.5）→ `set_results` + selected=0。indexing を見ない（§19.7・Plain 分岐のみ indexing ガード）。instant 中の ←→ 無効・Shift+Enter=Enter。実行成功でクエリクリア + hide、失敗は据え置き + trace。
+- **selected リセットの parity 確認を M3 受け入れに含める。** SolidJS は毎打鍵 `setSelected(0)`（plain/instant/slash とも）だが、egui は `set_results` の clamp のみの疑いがある（M1 持ち越し）。plan で検証し、gap なら M3 で是正する。
+
 ### 検証済み（この設計の前提・一次証拠）
 
 1. **`engine.search()` は同期。** `commands/search.rs:19` が `state.engine.lock().unwrap().search(&query)` を同期呼びし `Vec<SearchResult>` を即返す。egui view も同じ `AppState.engine` を掴んで同期呼びできる。

--- a/src-tauri/src/commands/instant.rs
+++ b/src-tauri/src/commands/instant.rs
@@ -45,27 +45,39 @@ pub async fn execute_instant_command(
         .and_then(|mut cb| cb.get_text())
         .unwrap_or_default();
 
-    // 変数展開: URL テンプレートは自動エンコード、それ以外は生展開。
-    // セキュリティモデル: コマンドテンプレートはユーザーが config.toml で
-    // 自身で定義したものであり、信頼済みコンテンツとして扱う。
-    let result = run_launch_blocking(move || {
-        use snotra_core::config::InstantAction;
-        match action {
-            InstantAction::Url { url } => {
-                let expanded = expand_instant_command(&url, &query, &clipboard);
-                super::launch::launch_item_core(&expanded)
-            }
-            InstantAction::Exec { exe, args } => {
-                super::launch::launch_exec_core(&exe, &args, &query, &clipboard)
-            }
-            // load 後は移行済みで到達しないが、防御的に Url 扱い
-            InstantAction::Legacy { command } => {
-                let expanded = expand_instant_command(&command, &query, &clipboard);
-                super::launch::launch_item_core(&expanded)
-            }
-        }
-    })
-    .await;
+    let result =
+        run_launch_blocking(move || execute_instant_action_core(action, &query, &clipboard)).await;
 
     Ok(result)
+}
+
+/// instant action の種別ディスパッチ共有核（IPC 経路 = 上の `execute_instant_command` /
+/// egui 経路 = `egui_shell::view::execute_instant_selected` の両方が呼ぶ・#532 SU3 M3
+/// /code-review）。二重実装だと展開/エンコードや Legacy fallback の将来修正が片側にだけ
+/// 当たり、同じ config に対し WebView2 と egui が別のコマンドを起動する drift を生むため集約。
+/// clipboard は呼び出し側がエンジンロック外で読んで渡す（Win32 がブロックしうるため）。
+///
+/// 変数展開: URL テンプレートは自動エンコード、それ以外は生展開。
+/// セキュリティモデル: コマンドテンプレートはユーザーが config.toml で
+/// 自身で定義したものであり、信頼済みコンテンツとして扱う。
+pub(crate) fn execute_instant_action_core(
+    action: snotra_core::config::InstantAction,
+    query: &str,
+    clipboard: &str,
+) -> super::launch::LaunchResult {
+    use snotra_core::config::InstantAction;
+    match action {
+        InstantAction::Url { url } => {
+            let expanded = expand_instant_command(&url, query, clipboard);
+            super::launch::launch_item_core(&expanded)
+        }
+        InstantAction::Exec { exe, args } => {
+            super::launch::launch_exec_core(&exe, &args, query, clipboard)
+        }
+        // load 後は移行済みで到達しないが、防御的に Url 扱い
+        InstantAction::Legacy { command } => {
+            let expanded = expand_instant_command(&command, query, clipboard);
+            super::launch::launch_item_core(&expanded)
+        }
+    }
 }

--- a/src-tauri/src/egui_shell/layout.rs
+++ b/src-tauri/src/egui_shell/layout.rs
@@ -69,7 +69,6 @@ impl Debouncer {
     /// armed を解除し予約済み trailing を取り消す（SolidJS cancelDebounce parity・#532 SU3 M3）。
     /// instant/command モード突入時に driver が呼ぶ——モード外で予約された検索が
     /// モード中に遅延発火する経路を塞ぐ（run_search は再導出ゆえ実害は無いが無駄撃ちを消す）。
-    #[allow(dead_code)]
     pub fn cancel(&mut self) {
         self.armed = false;
     }

--- a/src-tauri/src/egui_shell/layout.rs
+++ b/src-tauri/src/egui_shell/layout.rs
@@ -65,6 +65,14 @@ impl Debouncer {
         }
         false
     }
+
+    /// armed を解除し予約済み trailing を取り消す（SolidJS cancelDebounce parity・#532 SU3 M3）。
+    /// instant/command モード突入時に driver が呼ぶ——モード外で予約された検索が
+    /// モード中に遅延発火する経路を塞ぐ（run_search は再導出ゆえ実害は無いが無駄撃ちを消す）。
+    #[allow(dead_code)]
+    pub fn cancel(&mut self) {
+        self.armed = false;
+    }
 }
 
 #[cfg(test)]
@@ -116,5 +124,17 @@ mod tests {
         let mut d = Debouncer::new(Duration::from_millis(30), false);
         assert!(!d.on_input(), "leading なしは即時発火しない");
         assert!(d.poll(Duration::from_millis(30)), "trailing のみ発火");
+    }
+
+    #[test]
+    fn cancel_disarms_pending_trailing() {
+        let mut d = Debouncer::new(Duration::from_millis(50), true);
+        d.on_input();
+        assert!(d.is_armed());
+        d.cancel();
+        assert!(!d.is_armed());
+        assert!(!d.poll(Duration::from_millis(100)), "cancel 後は trailing 発火しない");
+        // cancel 後の次入力はバースト先頭扱い（leading 再発火）
+        assert!(d.on_input());
     }
 }

--- a/src-tauri/src/egui_shell/mod.rs
+++ b/src-tauri/src/egui_shell/mod.rs
@@ -14,9 +14,7 @@ pub(crate) use search_state::{
 // 直接呼び出しは無いため re-export としては未使用（M3 の command/instant 分岐まで橋渡し）。
 #[allow(unused_imports)]
 pub(crate) use search_state::{interpret, is_instant_prefix};
-// SlashCmd/find_slash_command は driver（view.rs）の command 分岐配線待ち（#532 SU3 M3 Task 2）。
-// 純粋核のみ先行追加のため re-export は現時点で未使用。
-#[allow(unused_imports)]
+// SlashCmd/find_slash_command は driver（view.rs）が command 分岐・slash 実行で消費する（#532 SU3 M3 Task 2）。
 pub(crate) use search_state::{SlashCmd, find_slash_command};
 pub(crate) use layout::{Debouncer, HeightParams, compute_window_height};
 

--- a/src-tauri/src/egui_shell/mod.rs
+++ b/src-tauri/src/egui_shell/mod.rs
@@ -10,10 +10,6 @@ pub(crate) use lifecycle::{HotkeyPlan, blur_should_hide, plan_hotkey};
 pub(crate) use search_state::{
     EscapeOutcome, QueryIntent, SearchState, ViewKind, compute_parent_dir, folder_load_pending,
 };
-// interpret/is_instant_prefix は search_state 内部（interp() 経由）でのみ使われ、view.rs からの
-// 直接呼び出しは無いため re-export としては未使用（M3 の command/instant 分岐まで橋渡し）。
-#[allow(unused_imports)]
-pub(crate) use search_state::{interpret, is_instant_prefix};
 // SlashCmd/find_slash_command は driver（view.rs）が command 分岐・slash 実行で消費する（#532 SU3 M3 Task 2）。
 pub(crate) use search_state::{SlashCmd, find_slash_command};
 pub(crate) use layout::{Debouncer, HeightParams, compute_window_height};

--- a/src-tauri/src/egui_shell/mod.rs
+++ b/src-tauri/src/egui_shell/mod.rs
@@ -14,6 +14,10 @@ pub(crate) use search_state::{
 // 直接呼び出しは無いため re-export としては未使用（M3 の command/instant 分岐まで橋渡し）。
 #[allow(unused_imports)]
 pub(crate) use search_state::{interpret, is_instant_prefix};
+// SlashCmd/find_slash_command は driver（view.rs）の command 分岐配線待ち（#532 SU3 M3 Task 2）。
+// 純粋核のみ先行追加のため re-export は現時点で未使用。
+#[allow(unused_imports)]
+pub(crate) use search_state::{SlashCmd, find_slash_command};
 pub(crate) use layout::{Debouncer, HeightParams, compute_window_height};
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};

--- a/src-tauri/src/egui_shell/search_state.rs
+++ b/src-tauri/src/egui_shell/search_state.rs
@@ -85,8 +85,7 @@ pub enum EscapeOutcome {
 
 /// slash コマンドの写像（§15.2）。History(`/r`) だけは結果注入型（履歴を表示して留まる）で、
 /// driver が run_search の Command 分岐へ振る。他 3 つは fire-once の副作用型。
-/// driver（view.rs）の配線は #532 SU3 M3 Task 2 で行うため、現時点では未消費（純粋核先行追加）。
-#[allow(dead_code)]
+/// driver（view.rs）が消費する（#532 SU3 M3 Task 2）。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SlashCmd {
     History,
@@ -97,8 +96,7 @@ pub enum SlashCmd {
 
 /// trim 後の完全一致で slash コマンドを引く（§15.3 即実行の判定・commands.ts findCommand parity・
 /// 大文字小文字は区別する）。部分入力・引数付きは None（候補表示なし・§15.3）。
-/// driver の配線は #532 SU3 M3 Task 2 で行うため、現時点では未消費（純粋核先行追加）。
-#[allow(dead_code)]
+/// driver（view.rs）が消費する（#532 SU3 M3 Task 2）。
 pub fn find_slash_command(query: &str) -> Option<SlashCmd> {
     match query.trim() {
         "/r" => Some(SlashCmd::History),
@@ -154,9 +152,7 @@ impl SearchState {
     }
 
     /// 選択を先頭へ戻す。driver が打鍵（changed エッジ）ごとに呼ぶ（SolidJS の毎打鍵
-    /// setSelected(0) parity・#532 SU3 M3）。driver の配線は Task 2 で行うため、現時点では
-    /// テストからのみ呼ばれる（純粋核先行追加）。
-    #[allow(dead_code)]
+    /// setSelected(0) parity・#532 SU3 M3）。
     pub fn reset_selection(&mut self) {
         self.selected = 0;
     }

--- a/src-tauri/src/egui_shell/search_state.rs
+++ b/src-tauri/src/egui_shell/search_state.rs
@@ -83,6 +83,32 @@ pub enum EscapeOutcome {
     Hide,
 }
 
+/// slash コマンドの写像（§15.2）。History(`/r`) だけは結果注入型（履歴を表示して留まる）で、
+/// driver が run_search の Command 分岐へ振る。他 3 つは fire-once の副作用型。
+/// driver（view.rs）の配線は #532 SU3 M3 Task 2 で行うため、現時点では未消費（純粋核先行追加）。
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlashCmd {
+    History,
+    OpenSettings,
+    RebuildIndex,
+    Quit,
+}
+
+/// trim 後の完全一致で slash コマンドを引く（§15.3 即実行の判定・commands.ts findCommand parity・
+/// 大文字小文字は区別する）。部分入力・引数付きは None（候補表示なし・§15.3）。
+/// driver の配線は #532 SU3 M3 Task 2 で行うため、現時点では未消費（純粋核先行追加）。
+#[allow(dead_code)]
+pub fn find_slash_command(query: &str) -> Option<SlashCmd> {
+    match query.trim() {
+        "/r" => Some(SlashCmd::History),
+        "/o" => Some(SlashCmd::OpenSettings),
+        "/s" => Some(SlashCmd::RebuildIndex),
+        "/q" => Some(SlashCmd::Quit),
+        _ => None,
+    }
+}
+
 /// 検索ウィンドウの純粋状態。results 軸に加え folder 軸（folder / folder_filter / folder_gen）を持つ（M2 で追加・#532 SU3 M2）。
 pub struct SearchState {
     query: String,
@@ -125,6 +151,14 @@ impl SearchState {
 
     pub fn selected(&self) -> usize {
         self.selected
+    }
+
+    /// 選択を先頭へ戻す。driver が打鍵（changed エッジ）ごとに呼ぶ（SolidJS の毎打鍵
+    /// setSelected(0) parity・#532 SU3 M3）。driver の配線は Task 2 で行うため、現時点では
+    /// テストからのみ呼ばれる（純粋核先行追加）。
+    #[allow(dead_code)]
+    pub fn reset_selection(&mut self) {
+        self.selected = 0;
     }
 
     /// 軸1。folder モードなら Folder、それ以外 Results（tool は SU3.5）。
@@ -491,6 +525,35 @@ mod tests {
         // Results モードでは folder cache/error に依らず常に false（前ビュー残存物問題は起きない）。
         assert!(!folder_load_pending(ViewKind::Results, false, false));
         assert!(!folder_load_pending(ViewKind::Results, true, false));
+    }
+
+    #[test]
+    fn find_slash_command_exact_match_with_trim() {
+        assert_eq!(find_slash_command("/r"), Some(SlashCmd::History));
+        assert_eq!(find_slash_command(" /o "), Some(SlashCmd::OpenSettings)); // trim 後一致
+        assert_eq!(find_slash_command("/s"), Some(SlashCmd::RebuildIndex));
+        assert_eq!(find_slash_command("/q"), Some(SlashCmd::Quit));
+    }
+
+    #[test]
+    fn find_slash_command_rejects_partial_case_and_args() {
+        assert_eq!(find_slash_command("/"), None); // 部分入力
+        assert_eq!(find_slash_command("/x"), None); // 未知コマンド
+        assert_eq!(find_slash_command("/O"), None); // 大文字は不一致（findCommand === parity）
+        assert_eq!(find_slash_command("/o extra"), None); // 引数付きは不一致（完全一致のみ）
+        assert_eq!(find_slash_command(""), None);
+    }
+
+    #[test]
+    fn reset_selection_returns_to_top() {
+        // SolidJS parity: 毎打鍵 setSelected(0)（handlePlainQueryInput / instant fetch / slash とも）。
+        // M1 は set_results の clamp のみで、打鍵後も旧 selected が残っていた（M3 で是正）。
+        let mut s = SearchState::new();
+        s.set_results(vec![res("a"), res("b"), res("c")]);
+        s.move_selection(2);
+        assert_eq!(s.selected(), 2);
+        s.reset_selection();
+        assert_eq!(s.selected(), 0);
     }
 
     #[test]

--- a/src-tauri/src/egui_shell/view.rs
+++ b/src-tauri/src/egui_shell/view.rs
@@ -12,8 +12,8 @@ use snotra_egui_runtime::{EguiView, RuntimeFrame};
 use tauri::{Emitter, Manager};
 
 use crate::egui_shell::{
-    Debouncer, EscapeOutcome, HeightParams, QueryIntent, SearchState, ViewKind,
-    compute_parent_dir, compute_window_height, folder_load_pending,
+    Debouncer, EscapeOutcome, HeightParams, QueryIntent, SearchState, SlashCmd, ViewKind,
+    compute_parent_dir, compute_window_height, find_slash_command, folder_load_pending,
 };
 
 static JP_FONT_BYTES: OnceLock<Box<[u8]>> = OnceLock::new();
@@ -157,6 +157,107 @@ impl SearchWindowView {
             }
             // 起動成功時のみ hide（SU2 の hide 合流点へ・view から window を直接触らない）。
             self.emit_hide();
+        }
+    }
+
+    /// slash コマンドを実行する（§15.3 即実行・#532 SU3 M3）。SolidJS handleCommandQueryInput と
+    /// 同順: クエリ/結果クリア（clearCommandModeState 相当）→ action。`/r`（History）は結果注入型で
+    /// ここへ来ない（changed ハンドラが run_search へ振る）。失敗通知は建てない（trace のみ・#631 一本化）。
+    fn execute_slash(&mut self, cmd: SlashCmd) {
+        crate::trace_main("egui_slash", serde_json::json!({ "cmd": format!("{cmd:?}") }));
+        self.state.set_query(String::new());
+        self.state.set_results(Vec::new());
+        self.search_debounce.cancel();
+        let app = self.app_handle.clone();
+        match cmd {
+            SlashCmd::History => {} // 到達しない（呼び出し側 match が run_search へ振る）
+            SlashCmd::OpenSettings => {
+                // indexing 中の Err（ERR_INDEXING_IN_PROGRESS）は trace のみ（spec M3 実装確定・
+                // クエリクリア後は検索バーの indexing hint が可視＝degraded な理由提示）。
+                if let Err(e) = crate::commands::open_settings(app.state(), app.clone()) {
+                    crate::trace_main("egui_slash_error", serde_json::json!({ "cmd": "/o", "error": e }));
+                }
+            }
+            SlashCmd::RebuildIndex => {
+                // SolidJS /s parity: hide してから rebuild（hide は emit 合流・順序は視覚のみで
+                // rebuild は backend スレッド）。indexing 中の Err は意図的無音（#434 parity）。
+                self.emit_hide();
+                if let Err(e) = crate::commands::rebuild_index(app.state(), app.clone()) {
+                    crate::trace_main("egui_slash_error", serde_json::json!({ "cmd": "/s", "error": e }));
+                }
+            }
+            SlashCmd::Quit => {
+                // quit_app（commands/system.rs）と同一実体: exit-requested listener が
+                // history/icon flush → exit（main.rs）。egui 経路も同じ合流点を使う。
+                let _ = app.emit("exit-requested", ());
+            }
+        }
+    }
+
+    /// 選択中の instant コマンドを同期実行する（§19.6・#532 SU3 M3）。IPC の
+    /// execute_instant_command（spawn_blocking + 4s）と同じ手順（action 抽出をロック内・
+    /// clipboard 読みをロック外）を、イベントループで同期直呼びに畳む（spec M3 実装確定・
+    /// ブロックリスクは #631 スコープ）。instant は履歴を記録しない（IPC 経路 parity）。
+    /// 成功: クエリ/結果クリア + hide（§19.6）。失敗: 据え置き + trace（M1 起動失敗と同型）。
+    fn execute_instant_selected(&mut self, index: usize, instant_query: &str) {
+        use crate::commands::launch::{LaunchStatus, launch_exec_core, launch_item_core};
+        use snotra_core::config::InstantAction;
+        use snotra_core::instant::expand_instant_command;
+        let Some(sel) = self.state.results().get(index) else { return };
+        if sel.is_error {
+            return;
+        }
+        let name = sel.name.clone();
+        let Some(state) = self.app_handle.try_state::<crate::AppState>() else { return };
+        let Some(action) = ({
+            let engine = state.engine.lock().unwrap();
+            engine
+                .config()
+                .instant_commands
+                .iter()
+                .find(|c| c.name == name)
+                .map(|c| c.action.clone())
+        }) else {
+            return;
+        };
+        // clipboard 読み（Win32）はロック外（commands/instant.rs と同順）。
+        let clipboard = arboard::Clipboard::new()
+            .and_then(|mut cb| cb.get_text())
+            .unwrap_or_default();
+        let outcome = match action {
+            InstantAction::Url { url } => {
+                launch_item_core(&expand_instant_command(&url, instant_query, &clipboard))
+            }
+            InstantAction::Exec { exe, args } => {
+                launch_exec_core(&exe, &args, instant_query, &clipboard)
+            }
+            // load 後は移行済みで到達しないが、防御的に Url 扱い（IPC 経路と同じ）
+            InstantAction::Legacy { command } => {
+                launch_item_core(&expand_instant_command(&command, instant_query, &clipboard))
+            }
+        };
+        crate::trace_main(
+            "egui_instant",
+            serde_json::json!({ "name": name, "status": format!("{:?}", outcome.status) }),
+        );
+        if matches!(outcome.status, LaunchStatus::Ok) {
+            self.state.set_query(String::new());
+            self.state.set_results(Vec::new());
+            self.search_debounce.cancel();
+            self.emit_hide();
+        }
+    }
+
+    /// Enter/クリックの単一 dispatch（§19.6/§4.8・#532 SU3 M3）。instant モード中は選択コマンドを
+    /// 実行、それ以外（plain・/r 履歴・folder）は通常起動（activate）。行 index で参照
+    /// （パス文字列を使わない・ui ルール踏襲）。Shift+Enter も同じ Enter として届くため
+    /// §19.6「Shift+Enter=Enter」は追加コードなしで成立する（tool-selection は SU3.5）。
+    fn activate_or_execute(&mut self, index: usize) {
+        let prefix = self.instant_prefix();
+        if let QueryIntent::Instant { instant_query, .. } = self.state.interp(&prefix) {
+            self.execute_instant_selected(index, &instant_query);
+        } else {
+            self.activate(index);
         }
     }
 
@@ -309,9 +410,50 @@ impl SearchWindowView {
                         }; // lock 解放
                         self.state.set_results(results);
                     }
-                    // command/instant は M3。M1/M2 では結果を出さない（空維持）。
-                    _ => {
-                        self.state.set_results(Vec::new());
+                    QueryIntent::Instant { filter_name, .. } => {
+                        // §19.5: 前方一致フィルタ。毎打鍵同期（30ms debounce 撤廃・spec M3 実装確定）。
+                        // indexing を見ない（§19.7: instant はインデックス非依存ゆえ構築中でも使用可）。
+                        let rows = {
+                            let state = match self.app_handle.try_state::<crate::AppState>() {
+                                Some(s) => s,
+                                None => return,
+                            };
+                            let engine = state.engine.lock().unwrap();
+                            snotra_core::instant::filter_instant_commands(
+                                &engine.config().instant_commands,
+                                &filter_name,
+                            )
+                            .into_iter()
+                            .map(|c| {
+                                let dto = crate::commands::launch::InstantCommandDto::from(c);
+                                SearchResult {
+                                    name: dto.name,
+                                    // §19.5: description 設定時は優先、無ければ display（URL / exe args）
+                                    path: if dto.description.is_empty() { dto.display } else { dto.description },
+                                    is_folder: false,
+                                    is_error: false,
+                                }
+                            })
+                            .collect::<Vec<_>>()
+                        }; // lock 解放
+                        self.state.set_results(rows);
+                    }
+                    QueryIntent::Command => {
+                        // §15.2 /r: 履歴を注入して留まる（冪等ゆえ trailing 再発火も無害）。
+                        // 他（部分入力・実行済み直後）は候補なしクリア（§15.3: command 中は検索しない）。
+                        if matches!(find_slash_command(self.state.query()), Some(SlashCmd::History)) {
+                            let rows = {
+                                let state = match self.app_handle.try_state::<crate::AppState>() {
+                                    Some(s) => s,
+                                    None => return,
+                                };
+                                let engine = state.engine.lock().unwrap();
+                                engine.recent_history()
+                            };
+                            self.state.set_results(rows);
+                        } else {
+                            self.state.set_results(Vec::new());
+                        }
                     }
                 }
             }
@@ -479,7 +621,10 @@ impl EguiView for SearchWindowView {
                     }
                 }
                 ViewKind::Results => {
-                    if let Some(sel) = self.state.results().get(self.state.selected())
+                    // instant/command 中は ← 無効（§19.7）。instant 行の path は description/display
+                    // ゆえ compute_parent_dir が偶然 Some を返して bogus folder 突入しうるのを塞ぐ。
+                    if matches!(self.state.interp(&self.instant_prefix()), QueryIntent::Plain)
+                        && let Some(sel) = self.state.results().get(self.state.selected())
                         && !sel.is_error
                         && let Some(parent) = compute_parent_dir(&sel.path)
                     {
@@ -492,11 +637,6 @@ impl EguiView for SearchWindowView {
                     }
                 }
             }
-        }
-
-        // Enter: 選択項目を起動（結果があるとき）。TextEdit の Enter より先に ctx で拾う。
-        if ctx.input(|i| i.key_pressed(egui::Key::Enter)) && !self.state.results().is_empty() {
-            self.activate(self.state.selected());
         }
 
         // 検索入力欄。state.query を編集し、変化があれば debounce leading で同期検索。
@@ -526,12 +666,33 @@ impl EguiView for SearchWindowView {
                 self.run_search(); // folder は同期フィルタ（debounce 不要・I/O 無し）
             } else {
                 self.state.set_query(buf);
-                self.last_input_at = Instant::now();
-                if self.search_debounce.on_input() {
-                    self.run_search(); // leading
+                self.state.reset_selection(); // SolidJS parity: 毎打鍵 selected=0（M1 gap 是正）
+                let prefix = self.instant_prefix();
+                match self.state.interp(&prefix) {
+                    QueryIntent::Plain => {
+                        self.last_input_at = Instant::now();
+                        if self.search_debounce.on_input() {
+                            self.run_search(); // leading
+                        }
+                        ctx.request_repaint_after(self.search_debounce.interval());
+                    }
+                    QueryIntent::Instant { .. } => {
+                        // 同期直フィルタ（30ms debounce 撤廃・spec M3 実装確定）。
+                        // plain 由来の armed trailing は掃除（cancelDebounce parity）。
+                        self.search_debounce.cancel();
+                        self.run_search();
+                    }
+                    QueryIntent::Command => {
+                        // §15.3: debounce をキャンセルして即実行（changed エッジ＝query 変化時
+                        // のみゆえ immediate-mode でも fire-once）。/r と部分入力は run_search の
+                        // Command 分岐（冪等: /r=履歴注入・他=結果クリア）。
+                        self.search_debounce.cancel();
+                        match find_slash_command(self.state.query()) {
+                            Some(SlashCmd::History) | None => self.run_search(),
+                            Some(cmd) => self.execute_slash(cmd),
+                        }
+                    }
                 }
-                // trailing 発火のため interval 後に再描画を要求する（SU2 blur と同じ egui idiom）。
-                ctx.request_repaint_after(self.search_debounce.interval());
             }
         }
         // 窓に focus があるのに入力欄が focus を持たないなら移す（Alt+Q 表示直後に打てる）。
@@ -554,6 +715,14 @@ impl EguiView for SearchWindowView {
             ctx.request_repaint_after(remaining);
         }
 
+        // Enter: 選択項目を起動/実行。TextEdit の changed 処理より後で判定する——同一フレームに
+        // 入力確定（貼り付け・IME 確定）と Enter が入ったとき、旧 state の interp/選択で起動
+        // しないため（codex 発見 4・spec M3 実装確定）。egui の input はフレーム内で不変
+        // （読む順序は消費に影響しない）ため後置しても Enter は取りこぼさない。
+        if ctx.input(|i| i.key_pressed(egui::Key::Enter)) && !self.state.results().is_empty() {
+            self.activate_or_execute(self.state.selected());
+        }
+
         // 結果リスト（shouldShowResults 相当。results 軸〔plain〕と folder 軸を描く。空なら描かない）。
         let show_results = !self.state.results().is_empty();
         let mut clicked: Option<usize> = None;
@@ -572,7 +741,7 @@ impl EguiView for SearchWindowView {
         // シングルクリック＝起動（§4.8 単=起動）。double-click は扱わない（ユーザー決定・
         // as-built でも double-click=選択は到達不能。SPEC §4.8 を as-built へ同期済み）。
         if let Some(i) = clicked {
-            self.activate(i);
+            self.activate_or_execute(i);
         }
 
         // 動的ウィンドウ高さ（§4.5/§4.7）。show_results 可否 × max_results から算出し set_size。

--- a/src-tauri/src/egui_shell/view.rs
+++ b/src-tauri/src/egui_shell/view.rs
@@ -1,5 +1,7 @@
-//! egui メインウィンドウの placeholder view（#532 SU2）。show/hide/focus/位置を視覚検証できる
-//! 最小 chrome を描く。検索本体は SU3。font-first（jp_font を index 0）は SU1 申し送りの義務。
+//! egui メインウィンドウの検索 view（#532 SU2 外殻 + SU3 検索 driver）。SearchState（純粋核）を
+//! 駆動する imperative shell: TextEdit/結果リスト描画・直 Engine 検索（debounce）・↑↓/→←ナビ・
+//! folder 展開（async ロード + staleness）・instant/slash コマンド・起動/実行 dispatch・動的高さ。
+//! font-first（jp_font を index 0）は SU1 申し送りの義務。
 
 use std::sync::OnceLock;
 use std::sync::atomic::Ordering;
@@ -88,6 +90,11 @@ pub(crate) struct SearchWindowView {
     folder_cache: Option<(FolderListContext, Vec<SearchResult>)>,
     /// 列挙失敗時の単一エラー行（filter を無視して表示）。
     folder_error: Option<Vec<SearchResult>>,
+    /// 表示中の results の来歴: instant 候補なら Some(instant_query)。Enter/クリック/← の判定は
+    /// live config の prefix から interp を再導出せず、この snapshot を使う——prefix の hot-change
+    /// 後に stale instant 行（path=description/display）が activate() へ流れて文字列をパスとして
+    /// 起動・履歴汚染するのを防ぐ（/code-review #637 finding 0）。run_search が行と一体で更新する。
+    instant_rows_query: Option<String>,
 }
 
 impl SearchWindowView {
@@ -105,6 +112,7 @@ impl SearchWindowView {
             folder_rx,
             folder_cache: None,
             folder_error: None,
+            instant_rows_query: None,
         }
     }
 
@@ -160,14 +168,23 @@ impl SearchWindowView {
         }
     }
 
+    /// クエリ/結果/armed trailing/instant 来歴をまとめてクリアする単一チョークポイント
+    /// （execute_slash と instant 成功経路が共有）。第 3 のクリアサイト（SU3.5 tool 等）が
+    /// `search_debounce.cancel()` を書き忘れて「クリア後に stale trailing 検索が発火」を
+    /// 再発させないための集約（/code-review #637 finding 6）。
+    fn clear_search(&mut self) {
+        self.state.set_query(String::new());
+        self.state.set_results(Vec::new());
+        self.search_debounce.cancel();
+        self.instant_rows_query = None;
+    }
+
     /// slash コマンドを実行する（§15.3 即実行・#532 SU3 M3）。SolidJS handleCommandQueryInput と
     /// 同順: クエリ/結果クリア（clearCommandModeState 相当）→ action。`/r`（History）は結果注入型で
     /// ここへ来ない（changed ハンドラが run_search へ振る）。失敗通知は建てない（trace のみ・#631 一本化）。
     fn execute_slash(&mut self, cmd: SlashCmd) {
         crate::trace_main("egui_slash", serde_json::json!({ "cmd": format!("{cmd:?}") }));
-        self.state.set_query(String::new());
-        self.state.set_results(Vec::new());
-        self.search_debounce.cancel();
+        self.clear_search();
         let app = self.app_handle.clone();
         match cmd {
             // 到達しない: 呼び出し側（changed ハンドラ）が History を run_search へ振る。
@@ -203,9 +220,7 @@ impl SearchWindowView {
     /// ブロックリスクは #631 スコープ）。instant は履歴を記録しない（IPC 経路 parity）。
     /// 成功: クエリ/結果クリア + hide（§19.6）。失敗: 据え置き + trace（M1 起動失敗と同型）。
     fn execute_instant_selected(&mut self, index: usize, instant_query: &str) {
-        use crate::commands::launch::{LaunchStatus, launch_exec_core, launch_item_core};
-        use snotra_core::config::InstantAction;
-        use snotra_core::instant::expand_instant_command;
+        use crate::commands::launch::LaunchStatus;
         let Some(sel) = self.state.results().get(index) else { return };
         if sel.is_error {
             return;
@@ -221,44 +236,45 @@ impl SearchWindowView {
                 .find(|c| c.name == name)
                 .map(|c| c.action.clone())
         }) else {
+            // config hot-reload で行が stale 化（改名/削除）した場合。IPC 経路の
+            // Err("instant command not found") に相当する痕跡を trace へ残す——silent no-op に
+            // すると Enter が死んで見えても診断不能（/code-review #637 finding 1）。
+            crate::trace_main(
+                "egui_instant_error",
+                serde_json::json!({ "name": name, "error": "not found" }),
+            );
             return;
         };
         // clipboard 読み（Win32）はロック外（commands/instant.rs と同順）。
         let clipboard = arboard::Clipboard::new()
             .and_then(|mut cb| cb.get_text())
             .unwrap_or_default();
-        let outcome = match action {
-            InstantAction::Url { url } => {
-                launch_item_core(&expand_instant_command(&url, instant_query, &clipboard))
-            }
-            InstantAction::Exec { exe, args } => {
-                launch_exec_core(&exe, &args, instant_query, &clipboard)
-            }
-            // load 後は移行済みで到達しないが、防御的に Url 扱い（IPC 経路と同じ）
-            InstantAction::Legacy { command } => {
-                launch_item_core(&expand_instant_command(&command, instant_query, &clipboard))
-            }
-        };
+        // 種別ディスパッチは IPC 経路と共有の core（二重実装の drift 防止・finding 4）。
+        let outcome = crate::commands::instant::execute_instant_action_core(
+            action,
+            instant_query,
+            &clipboard,
+        );
         crate::trace_main(
             "egui_instant",
             serde_json::json!({ "name": name, "status": format!("{:?}", outcome.status) }),
         );
         if matches!(outcome.status, LaunchStatus::Ok) {
-            self.state.set_query(String::new());
-            self.state.set_results(Vec::new());
-            self.search_debounce.cancel();
+            self.clear_search();
             self.emit_hide();
         }
     }
 
-    /// Enter/クリックの単一 dispatch（§19.6/§4.8・#532 SU3 M3）。instant モード中は選択コマンドを
-    /// 実行、それ以外（plain・/r 履歴・folder）は通常起動（activate）。行 index で参照
-    /// （パス文字列を使わない・ui ルール踏襲）。Shift+Enter も同じ Enter として届くため
-    /// §19.6「Shift+Enter=Enter」は追加コードなしで成立する（tool-selection は SU3.5）。
+    /// Enter/クリックの単一 dispatch（§19.6/§4.8・#532 SU3 M3）。判定は live config の prefix
+    /// からの interp 再導出ではなく**表示行の来歴**（`instant_rows_query` snapshot）で行う——
+    /// prefix の hot-change 後に stale instant 行（path=description/display）を activate() へ流し、
+    /// 文字列をパスとして起動・履歴汚染するのを防ぐ（/code-review #637 finding 0）。行と来歴は
+    /// run_search が同一フレームで一体更新するため常に整合する。行 index で参照（パス文字列を
+    /// 使わない・ui ルール踏襲）。Shift+Enter も同じ Enter として届くため §19.6
+    /// 「Shift+Enter=Enter」は追加コードなしで成立する（tool-selection は SU3.5）。
     fn activate_or_execute(&mut self, index: usize) {
-        let prefix = self.instant_prefix();
-        if let QueryIntent::Instant { instant_query, .. } = self.state.interp(&prefix) {
-            self.execute_instant_selected(index, &instant_query);
+        if let Some(iq) = self.instant_rows_query.clone() {
+            self.execute_instant_selected(index, &iq);
         } else {
             self.activate(index);
         }
@@ -383,7 +399,17 @@ impl SearchWindowView {
 
     /// view_kind 先の同期 dispatch（#532 SU3 M2）。folder は cache/error を同期フィルタ、
     /// results は M1 の interp 分岐（plain 検索）。folder 打鍵が engine.search へ漏れない。
+    /// prefix を内部で取得する薄いラッパー（trailing poll・folder drain 用）。changed エッジは
+    /// 取得済み prefix を `run_search_with` へ渡し、毎打鍵の engine lock 回数を減らす
+    /// （/code-review #637 finding 9）。
     fn run_search(&mut self) {
+        let prefix = self.instant_prefix();
+        self.run_search_with(&prefix);
+    }
+
+    fn run_search_with(&mut self, prefix: &str) {
+        // 来歴は行と一体で更新する（Instant 分岐だけが Some を立て直す・finding 0）。
+        self.instant_rows_query = None;
         match self.state.view_kind() {
             ViewKind::Folder => {
                 if let Some(err) = &self.folder_error {
@@ -395,8 +421,7 @@ impl SearchWindowView {
                 // cache 未着（ロード中）は前フレーム結果を保持（フリット無し・set しない）
             }
             ViewKind::Results => {
-                let prefix = self.instant_prefix();
-                match self.state.interp(&prefix) {
+                match self.state.interp(prefix) {
                     QueryIntent::Plain => {
                         if self.state.query().trim().is_empty() || self.indexing() {
                             self.state.set_results(Vec::new());
@@ -413,32 +438,27 @@ impl SearchWindowView {
                         }; // lock 解放
                         self.state.set_results(results);
                     }
-                    QueryIntent::Instant { filter_name, .. } => {
+                    QueryIntent::Instant { filter_name, instant_query } => {
                         // §19.5: 前方一致フィルタ。毎打鍵同期（30ms debounce 撤廃・spec M3 実装確定）。
                         // indexing を見ない（§19.7: instant はインデックス非依存ゆえ構築中でも使用可）。
-                        let rows = {
-                            let state = match self.app_handle.try_state::<crate::AppState>() {
-                                Some(s) => s,
-                                None => return,
-                            };
-                            let engine = state.engine.lock().unwrap();
-                            snotra_core::instant::filter_instant_commands(
-                                &engine.config().instant_commands,
-                                &filter_name,
-                            )
-                            .into_iter()
-                            .map(|c| {
-                                let dto = crate::commands::launch::InstantCommandDto::from(c);
-                                SearchResult {
-                                    name: dto.name,
-                                    // §19.5: description 設定時は優先、無ければ display（URL / exe args）
-                                    path: if dto.description.is_empty() { dto.display } else { dto.description },
-                                    is_folder: false,
-                                    is_error: false,
-                                }
-                            })
-                            .collect::<Vec<_>>()
-                        }; // lock 解放
+                        // 候補取得は IPC コマンドと同一 fn を共有（二重実装の drift 防止・finding 5）。
+                        let rows = crate::commands::instant::get_instant_commands(
+                            filter_name,
+                            self.app_handle.clone(),
+                        )
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|dto| SearchResult {
+                            name: dto.name,
+                            // §19.5: description 設定時は優先、無ければ display（URL / exe args）
+                            path: if dto.description.is_empty() { dto.display } else { dto.description },
+                            is_folder: false,
+                            is_error: false,
+                        })
+                        .collect::<Vec<_>>();
+                        // 来歴 snapshot: この行集合が instant 候補であることと、その時点の
+                        // instant_query を一体で記録する（activate_or_execute が参照・finding 0）。
+                        self.instant_rows_query = Some(instant_query);
                         self.state.set_results(rows);
                     }
                     QueryIntent::Command => {
@@ -514,6 +534,7 @@ impl EguiView for SearchWindowView {
             self.state.reset();
             self.folder_cache = None;
             self.folder_error = None;
+            self.instant_rows_query = None; // §19.7: resetForShow で instant モード解除
             self.search_debounce = Debouncer::new(Duration::from_millis(50), true);
         }
 
@@ -558,9 +579,10 @@ impl EguiView for SearchWindowView {
         if escape {
             match self.state.on_escape() {
                 EscapeOutcome::RestoredSearch => {
-                    // folder 離脱 → cache/error 破棄、復帰済み results を描く
+                    // folder 離脱 → cache/error 破棄、復帰済み results（展開前の plain 行）を描く
                     self.folder_cache = None;
                     self.folder_error = None;
+                    self.instant_rows_query = None;
                     ctx.request_repaint();
                 }
                 EscapeOutcome::Hide => self.emit_hide(),
@@ -624,13 +646,11 @@ impl EguiView for SearchWindowView {
                     }
                 }
                 ViewKind::Results => {
-                    // instant 中のみ ← 無効（§19.7・SolidJS allowsFolderNav parity）。instant 行の
-                    // path は description/display ゆえ compute_parent_dir が偶然 Some を返して bogus
-                    // folder 突入しうるのを塞ぐ。command（/r 履歴）中は許可＝→ と対称・SolidJS 一致。
-                    if !matches!(
-                        self.state.interp(&self.instant_prefix()),
-                        QueryIntent::Instant { .. }
-                    ) && let Some(sel) = self.state.results().get(self.state.selected())
+                    // instant 行表示中のみ ← 無効（§19.7・SolidJS allowsFolderNav parity）。判定は
+                    // interp 再導出でなく行来歴（instant_rows_query・prefix hot-change に頑健）。
+                    // instant 行の path は description/display ゆえ compute_parent_dir が偶然 Some を
+                    // 返して bogus folder 突入しうるのを塞ぐ。command（/r 履歴）中は許可＝→ と対称。
+                    if self.instant_rows_query.is_none() && let Some(sel) = self.state.results().get(self.state.selected())
                         && !sel.is_error
                         && let Some(parent) = compute_parent_dir(&sel.path)
                     {
@@ -673,12 +693,14 @@ impl EguiView for SearchWindowView {
             } else {
                 self.state.set_query(buf);
                 self.state.reset_selection(); // SolidJS parity: 毎打鍵 selected=0（M1 gap 是正）
+                // prefix はこの changed エッジで 1 回だけ取得し run_search_with へ渡す
+                //（interp と合わせ engine lock の毎打鍵多重取得を避ける・finding 9）。
                 let prefix = self.instant_prefix();
                 match self.state.interp(&prefix) {
                     QueryIntent::Plain => {
                         self.last_input_at = Instant::now();
                         if self.search_debounce.on_input() {
-                            self.run_search(); // leading
+                            self.run_search_with(&prefix); // leading
                         }
                         ctx.request_repaint_after(self.search_debounce.interval());
                     }
@@ -686,7 +708,7 @@ impl EguiView for SearchWindowView {
                         // 同期直フィルタ（30ms debounce 撤廃・spec M3 実装確定）。
                         // plain 由来の armed trailing は掃除（cancelDebounce parity）。
                         self.search_debounce.cancel();
-                        self.run_search();
+                        self.run_search_with(&prefix);
                     }
                     QueryIntent::Command => {
                         // §15.3: debounce をキャンセルして即実行（changed エッジ＝query 変化時
@@ -694,7 +716,7 @@ impl EguiView for SearchWindowView {
                         // Command 分岐（冪等: /r=履歴注入・他=結果クリア）。
                         self.search_debounce.cancel();
                         match find_slash_command(self.state.query()) {
-                            Some(SlashCmd::History) | None => self.run_search(),
+                            Some(SlashCmd::History) | None => self.run_search_with(&prefix),
                             Some(cmd) => self.execute_slash(cmd),
                         }
                     }

--- a/src-tauri/src/egui_shell/view.rs
+++ b/src-tauri/src/egui_shell/view.rs
@@ -170,7 +170,10 @@ impl SearchWindowView {
         self.search_debounce.cancel();
         let app = self.app_handle.clone();
         match cmd {
-            SlashCmd::History => {} // 到達しない（呼び出し側 match が run_search へ振る）
+            // 到達しない: 呼び出し側（changed ハンドラ）が History を run_search へ振る。
+            // 将来 execute_slash の呼び出しサイトが増えて誤配線したとき dev/test で loud に
+            // 落とす（release は panic=abort ゆえ unreachable! は採らない）。
+            SlashCmd::History => debug_assert!(false, "History は execute_slash へ来ない（run_search が注入する）"),
             SlashCmd::OpenSettings => {
                 // indexing 中の Err（ERR_INDEXING_IN_PROGRESS）は trace のみ（spec M3 実装確定・
                 // クエリクリア後は検索バーの indexing hint が可視＝degraded な理由提示）。
@@ -621,10 +624,13 @@ impl EguiView for SearchWindowView {
                     }
                 }
                 ViewKind::Results => {
-                    // instant/command 中は ← 無効（§19.7）。instant 行の path は description/display
-                    // ゆえ compute_parent_dir が偶然 Some を返して bogus folder 突入しうるのを塞ぐ。
-                    if matches!(self.state.interp(&self.instant_prefix()), QueryIntent::Plain)
-                        && let Some(sel) = self.state.results().get(self.state.selected())
+                    // instant 中のみ ← 無効（§19.7・SolidJS allowsFolderNav parity）。instant 行の
+                    // path は description/display ゆえ compute_parent_dir が偶然 Some を返して bogus
+                    // folder 突入しうるのを塞ぐ。command（/r 履歴）中は許可＝→ と対称・SolidJS 一致。
+                    if !matches!(
+                        self.state.interp(&self.instant_prefix()),
+                        QueryIntent::Instant { .. }
+                    ) && let Some(sel) = self.state.results().get(self.state.selected())
                         && !sel.is_error
                         && let Some(parent) = compute_parent_dir(&sel.path)
                     {


### PR DESCRIPTION
## 概要

#532 Phase 2 SU3 M3: egui/softbuffer メインウィンドウにインスタントコマンド（`@`前方一致・同期直フィルタ・同期直呼び実行）とスラッシュコマンド（`/r /o /s /q`・完全一致即実行）を直 Engine で追加する。WebView2/SolidJS 経路との parity 再現。Part of #532（auto-close しない）。

設計 SSOT: `docs/superpowers/specs/2026-07-22-su3-search-experience-design.md`「M3 実装確定」節（本 PR で追記・決定 7 の instant 部分と Escape ラダー段 2 を supersede）。実装計画: `docs/superpowers/plans/2026-07-23-su3-m3-instant-slash.md`。

## 主な決定（brainstorm + codex 反証レビュー）

- **instant 実行は同期直呼び**（`launch_item_core`/`launch_exec_core`・`run_launch_blocking` 不使用）。SPEC §19.6（spawn_blocking + 4s）乖離は受容済み残余として #631 に記録済み（通知 UI + single-flight とセットで flip 前に対応）
- **instant fetch の 30ms trailing debounce を撤廃**: debounce が守っていた IPC 往復は直 Engine で消滅。`filter_instant_commands`（config 内数件の前方一致）を毎打鍵同期実行
- **Escape に ClearMode 段を足さない**: SolidJS（`exitToolSelection` → `exitFolderExpansion` → hide）にも SPEC §8.6 にも instant/command 中のモード解除は存在せず、SU3 spec のラダー段 2 は parity 乖離だったため spec を訂正
- **dispatch を「TextEdit changed 処理 → Enter/クリック判定」に再構成**（codex 発見 4）: 同一フレームの入力確定 + Enter が旧 state で起動する race を封じる。Enter 非消費の前提は egui 0.35.0 ソースでレビュアーが検証済み
- **失敗通知は M1 同型**（trace のみ・hide しない・#631 一本化）。`/s` の indexing 中 Err は無音（#434 parity）

## 実装

- 純粋核（ユニットテスト 6 件追加）: `SlashCmd`/`find_slash_command`（trim 後完全一致・大文字小文字区別）・`SearchState::reset_selection`（毎打鍵 selected=0 の M1 gap 是正）・`Debouncer::cancel`
- driver（`view.rs`）: `run_search` の Instant/Command 分岐（`/r` 履歴注入・DTO→SearchResult 変換）・`execute_slash`・`execute_instant_selected`・`activate_or_execute`（Enter/クリック統一 dispatch）・← の instant ガード

## レビュー

- Task 別 review（sonnet）: 両タスク Spec PASS・Approved
- 最終 whole-branch review（opus）: With fixes → 反映済み。**Important 1 件**: ← ガードが Command まで塞ぎ `/r` 中の ← が SolidJS `allowsFolderNav`（tool/instant のみブロック）と乖離 → Instant のみブロックへ緩和（plan コード自体の欠陥・spec parity を優先）
- follow-up（本 PR 非対象・M1 起因の既存挙動）: Plain の 50ms trailing 窓内 Enter は leading 結果で起動しうる（SolidJS は flush-on-Enter）。別途 issue 化を検討

## 検証

- [x] `cargo test -p snotra` 107 passed / `cargo test -p snotra-core` 477 passed（flag OFF = G1 完全不変）
- [x] `cargo clippy -p snotra --all-targets -- -D warnings` clean
- [x] `npm run governance:check` G1..G10 passed
- [x] 実機 GUI smoke（flag ON・全 15 項目 + `/r` 中 ←/→ ナビ）合格・`msedgewebview2.exe` 子孫 0
- [x] `/r` 件数は WebView2 dev と同一（履歴∩インデックスのデータ由来・parity 成立を実測）

## 残（後続）

- SU3.5: tool-selection（`Option<FolderFrame>` → stack 一般化・§18 parity）
- #631: 同期起動ブロックリスク + 通知 UI + single-flight（instant 追記済み・flip 前）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
