### PR TITLE
chore(#634): egui_search:dispatch trace + search フレームコスト実測ハーネス

### DIFF
--- a/snotra-core/CLAUDE.md
+++ b/snotra-core/CLAUDE.md
@@ -43,6 +43,7 @@
 - `window_data.rs`: ウィンドウ位置（`window.bin`）の保存/復元
 - `instant.rs` — インスタントコマンド（プレフィックス起動の URL/コマンド）の展開。公開関数の署名・契約と変数展開の中核（修飾子パイプ・encoding-as-sink・`{{X}}` エスケープ・date/uuid 純粋性・`format_date` の panic 安全 #394）は `//!` と各 `///` を正とする
 - `ui_types.rs`: フロントエンドとの IPC 用データ型
+- `tests/search_frame_cost.rs`（crate ルート統合テスト）: #634 G-SYNC の `Engine::search` facade フレームコスト実測ハーネス（`#[ignore]`・手元 release 実行専用。`search/tests/performance.rs` との層の区別は `//!`）
 
 ## 開発ルール
 

--- a/snotra-core/tests/search_frame_cost.rs
+++ b/snotra-core/tests/search_frame_cost.rs
@@ -1,0 +1,141 @@
+//! #634 G-SYNC: egui 直 `Engine` 同期 search のフレームコスト実測ハーネス。
+//!
+//! egui 経路（`src-tauri/src/egui_shell/view.rs` の `run_search_with`）は trailing
+//! debounce 1 回の `engine.search` を UI スレッド同期で呼ぶ。本ハーネスはその
+//! フレーム占有の支配項 `Engine::search` を、合成インデックスの規模別に実測する。
+//!
+//! タイミング測定は CI 共有ランナーで不安定なため `#[ignore]`。手元で release 実行する:
+//! `cargo test -p snotra-core --release --test search_frame_cost -- --ignored --nocapture`
+//!
+//! 合成インデックスの生成規則はスパイク（`snotra-egui-mvp` の
+//! `build_verification_engine`）と同系: 実在風の固定 6 件 + 連番エントリ + 履歴
+//! ブースト 5 件。CJK クエリも規模に比例させるため、連番の 1/8 を日本語名にする
+//! （スパイクからの意図的拡張）。
+//!
+//! `src/search/tests/performance.rs` の `bench_search` とは測る層が異なる（重複でない）:
+//! あちらは `SearchEngine::search`（下層 API・固定 limit 10・空履歴・Fuzzy 固定）の
+//! スケーリング、こちらは `Engine::search`（facade・config 実効 limit・履歴ブースト込み）
+//! ＝ egui view の実呼び出し形のフレームコスト。
+
+use std::time::Instant;
+
+use snotra_core::{config::Config, engine::Engine, history::HistoryStore, indexer::AppEntry};
+
+fn build_engine(entry_count: usize) -> Engine {
+    let mut entries = vec![
+        AppEntry {
+            name: "Visual Studio Code".to_owned(),
+            target_path: "C:/Program Files/Microsoft VS Code/Code.exe".to_owned(),
+            is_folder: false,
+        },
+        AppEntry {
+            name: "Windows Terminal".to_owned(),
+            target_path: "C:/Program Files/WindowsApps/wt.exe".to_owned(),
+            is_folder: false,
+        },
+        AppEntry {
+            name: "ドキュメント".to_owned(),
+            target_path: "C:/Users/User/Documents".to_owned(),
+            is_folder: true,
+        },
+        AppEntry {
+            name: "ダウンロード".to_owned(),
+            target_path: "C:/Users/User/Downloads".to_owned(),
+            is_folder: true,
+        },
+        AppEntry {
+            name: "Snotra Settings".to_owned(),
+            target_path: "snotra-settings.exe".to_owned(),
+            is_folder: false,
+        },
+        AppEntry {
+            name: "日本語入力テスト".to_owned(),
+            target_path: "C:/Snotra/Verification/JapaneseInput.exe".to_owned(),
+            is_folder: false,
+        },
+    ];
+    for index in entries.len()..entry_count {
+        let (name, path) = if index % 8 == 0 {
+            (
+                format!("日本語ツール {index:05}"),
+                format!("C:/Snotra/Verification/長いパス/サブフォルダ/ツール{index:05}.exe"),
+            )
+        } else {
+            (
+                format!("Benchmark App {index:05}"),
+                format!("C:/Snotra/Verification/App{index:05}.exe"),
+            )
+        };
+        entries.push(AppEntry {
+            name,
+            target_path: path,
+            is_folder: false,
+        });
+    }
+
+    let history_path = std::env::temp_dir().join(format!(
+        "snotra-search-frame-cost-{}-unused",
+        std::process::id()
+    ));
+    let history = HistoryStore::load_in(&history_path);
+    let mut engine = Engine::new(entries, history, Config::normalized_default());
+    for path in [
+        "C:/Program Files/Microsoft VS Code/Code.exe",
+        "C:/Program Files/WindowsApps/wt.exe",
+        "C:/Users/User/Documents",
+        "C:/Users/User/Downloads",
+        "snotra-settings.exe",
+    ] {
+        engine.record_launch(path, "");
+    }
+    engine
+}
+
+/// クエリ別に warmup 2 回 + 計測 20 回を回し、min/p50/max（µs）を採取する。
+fn measure(engine: &mut Engine, query: &str) -> (usize, u64, u64, u64) {
+    for _ in 0..2 {
+        let _ = engine.search(query);
+    }
+    let mut samples_us = Vec::with_capacity(20);
+    let mut result_count = 0usize;
+    for _ in 0..20 {
+        let started = Instant::now();
+        let results = engine.search(query);
+        samples_us.push(started.elapsed().as_micros() as u64);
+        result_count = results.len();
+    }
+    samples_us.sort_unstable();
+    (
+        result_count,
+        samples_us[0],
+        samples_us[samples_us.len() / 2],
+        samples_us[samples_us.len() - 1],
+    )
+}
+
+#[test]
+#[ignore = "タイミング測定（#634 G-SYNC）。手元 release 実行専用: --ignored --nocapture"]
+fn measure_search_frame_cost() {
+    // クエリの狙い: 全件級マッチ（a/app＝スコアリング+ソートの最悪系）、
+    // 部分マッチ（99）、CJK 大量マッチ（ツール）、CJK 少数（ドキュメント）、
+    // 完全ミス（zzz）、長クエリ。
+    let queries = [
+        "a",
+        "app",
+        "99",
+        "ツール",
+        "ドキュメント",
+        "zzz_no_match",
+        "benchmark app 099",
+    ];
+    for &entry_count in &[1_000usize, 10_000, 50_000, 100_000] {
+        let mut engine = build_engine(entry_count);
+        eprintln!("=== entries={entry_count} ===");
+        for query in queries {
+            let (results, min_us, p50_us, max_us) = measure(&mut engine, query);
+            eprintln!(
+                "query={query:<18} results={results:>5}  min={min_us:>6}µs  p50={p50_us:>6}µs  max={max_us:>6}µs"
+            );
+        }
+    }
+}

--- a/src-tauri/src/egui_shell/view.rs
+++ b/src-tauri/src/egui_shell/view.rs
@@ -428,6 +428,8 @@ impl SearchWindowView {
                             return;
                         }
                         let query = self.state.query().to_string();
+                        // 計測は lock 取得込み（フレームを塞ぐ全区間・#634 G-SYNC）。
+                        let search_started = std::time::Instant::now();
                         let results = {
                             let state = match self.app_handle.try_state::<crate::AppState>() {
                                 Some(s) => s,
@@ -436,6 +438,14 @@ impl SearchWindowView {
                             let mut engine = state.engine.lock().unwrap();
                             engine.search(&query)
                         }; // lock 解放
+                        crate::trace::trace(
+                            "egui_search:dispatch",
+                            serde_json::json!({
+                                "query_chars": query.chars().count(),
+                                "results": results.len(),
+                                "elapsed_us": search_started.elapsed().as_micros() as u64,
+                            }),
+                        );
                         self.state.set_results(results);
                     }
                     QueryIntent::Instant { filter_name, instant_query } => {


### PR DESCRIPTION
## 概要

#634（G-SYNC: egui 直 Engine 同期 search のフレームコスト実測）の計測基盤と実測。

## 変更点

- **`egui_search:dispatch` trace 追加**（`src-tauri/src/egui_shell/view.rs`）— Plain 検索の同期 `Engine` 呼びを `SNOTRA_TRACE` ゲートで観測（`query_chars` / `results` / `elapsed_us`）。計測区間は **lock 取得込み**（フレームを塞ぐ全区間）。issue #634 が名指す観測点の実装
- **`snotra-core/tests/search_frame_cost.rs` 新設** — 合成インデックス規模別（1k/10k/50k/100k）に `Engine::search`（facade・config 実効 limit 200・履歴ブースト込み＝view.rs の実呼び出し形）を release 実測する `#[ignore]` ハーネス。生成規則はスパイク `build_verification_engine` と同系 + CJK 連番 1/8。既存 `search/tests/performance.rs` の `bench_search` は `SearchEngine` 下層（固定 limit 10・空履歴）で層が異なる（重複でない・`//!` に明記)
- **`snotra-core/CLAUDE.md`** — モジュール索引に `tests/` 行を追加

## 実測結果（要旨）

release・20 iter・warmup 2。最悪系（全件級マッチ）:

| entries | 最悪クエリ p50 | 最悪 max |
|---:|---:|---:|
| 10,000 | 0.83 ms | 1.6 ms |
| 50,000 | 1.5 ms | 3.1 ms |
| 100,000 | 3.5 ms | 5.0 ms |

フレーム予算 16.7ms・softbuffer raster 実測 ~30ms（#628）に対し、実データ規模 10k で 1ms 未満・10× の 100k でも 5ms 以下。**同期 + debounce のままで確定**が結論（詳細は #634 コメント）。

## 検証

- `cargo test -p snotra-core --release --test search_frame_cost -- --ignored --nocapture` — 上記実測
- PostToolUse hook（clippy + 各 crate テスト）沈黙 = 合格
- `npm run governance:check` — G1..G10 合格

Refs #634, #532（closing keyword は意図的に不使用・#634 の完了判断はコメント記録とレビュー後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
