### PR TITLE
docs: SU4 retrospective + egui 視覚スモーク起動の明記（#532）

### DIFF
--- a/RETROSPECTIVE.md
+++ b/RETROSPECTIVE.md
@@ -1,23 +1,25 @@
-# Retrospective — #532 SU3.5（tool-selection + #638）+ ロードマップ改訂 + #634 実測
+# Retrospective — #532 Phase 2 SU4（アイコン + 視覚 pass + §11 テーマ消費）
 
 ## よかったこと
 
-### 計測を建設より先に置く順序原理が機能した
-ロードマップ見直しで #634（G-SYNC 実測）を SU3.5 より先に置き、要石命題（同期直 Engine）の最後の未検証部分を先に確定した（10k 最悪 p50 < 1ms・100k でも 5ms 以下）。仮に詰まっていれば view 設計の変更が SU3.5/SU4 の上物に波及していた。「荷重仮定の検証は上に建てる前」の順序判断が、以降の全タスクを迷いなく進めた。
+### 着手前に 2 プローブで設計フォークを実測確定した
+worker 要否と font_family honor 可否という 2 つの設計の分岐を、実装前に使い捨てプローブで測って閉じた（#634 が SU3.5 前に G-SYNC を測ったのと同じ刻み・ユーザーの「まず測る」流儀）。**両方とも仮説を実測が覆した**: (1) Probe 1 は 8 件アイコンバッチ warm 合計 p50=8ms/max=11.7ms を出し「update() 内同期で足りる」を否定 → worker を数字で正当化。(2) Probe 2 は Segoe+YuGothic でベースラインずれが**出ない**ことを示し「honor は #579 を再発させる」という advisor+自分の仮説を覆した（ずれはフォントの組で決まり、MS システムフォント同士は揃う）。土俵を疑ってから設計に入ったことで、間違ったアーキテクチャを作らずに済んだ。
 
-### plan-review（偵察 3 + 独立導出 1）が実装前に 7 件を捕捉し、横断非対称クラスを初めて予防できた
-EscapeOutcome の 4 つ目の網羅 match（見落とせば Task 2 のコミット時点でビルド断）、入力欄のファイル名表示（フルパスは parity 違反）、SPEC §19.2 同期漏れ、settings 書き戻し経路の意思決定を、すべて実装前に plan へ反映した。独立導出は今回も plan が漏らした SPEC 同期を唯一検出——導入以来の的中が続いている。結果、M2/M3 では最終 whole-branch レビューでしか捕まらなかった read-without-write 型の横断非対称が、今回は **Critical/Important ゼロ**で「予防済み」と肯定的に裏取りされた。教訓の前送り（履歴記録サイトの明示・record_and_save doc の呼び出し元列挙）が効いた。
+### task-scoped review が実バグを捕捉し、whole-branch はほぼ空だった
+subagent-driven の各タスク review が Task 3（name 折り返し・CJK 幅過小評価）と Task 5（per-repaint thread pileup）という**実挙動バグ**を捕まえ、修正 → 再レビュー Approved で閉じた。最終 whole-branch review（opus）の指摘は stale doc 1 行のみ——M2/M3 では whole-branch だけが read-without-write 横断非対称を拾っていたが、今回はそのクラスが task 段階で予防できていた。多段レビューが機能した。
 
-### controller の一次確認と「cargo が一次証拠」の規律が cheap-tier リスクを一貫管理した
-SDD 各タスクで controller が cargo test/clippy を毎回再実行し、rust-analyzer の mid-edit stale 診断（E0004/E0599 の嵐）に 3 回とも惑わされず実測を優先した。ブリーフの不備（統合テスト TOML の `[paths]` 欠落）を実装者が既存テストパターン参照で自己修正し、reviewer が実コードで裏取りする流れも健全だった。
+### controller が毎タスク cargo build/test で接地した
+この環境の LSP diagnostics が編集途中の stale を出し、実装者の「DONE・green」報告と矛盾する事象がほぼ全タスクで起きた。報告も diagnostics も鵜呑みにせず、毎回 `cargo build/test` の実行結果で接地したことで、幻の欠陥を追わず・実際の破損も見逃さずに済んだ。
+
+---
 
 ## 伸びしろ
 
-### 計画に書いたテスト fixture を代表入力で検証していなかった
-plan の統合テスト TOML は必須セクション欠落で parse 不能だった（実装者が捕捉・修正）。「計画に書いた判定ロジックは実装前に代表入力で実行して測る」規範は在ったが、**テスト fixture は「判定ロジック」と読まれず適用漏れした**。→ AGENTS.md「検証の作法」の当該項目に fixture を明示的に含めた（本サイクルで反映済み）。
+### 視覚スモークの起動対象を誤り、ユーザーに検出された
+視覚スモークのコマンドを `cargo run --release`（`-p` 欠落）で渡し、ワークスペースの別 bin `snotra-egui-mvp`（Phase 1 スパイク・SU 実装を含まない）が起動した。ユーザーの「MVP が対象で良いのか」で発覚。**構造的原因は、`docs/build-commands.md` のカテゴリ D（UI 視覚スモークのトリガー）が `npm run tauri dev`（WebView2 経路）しか書いておらず、egui 経路の起動コマンドを欠いていたこと**。製品 egui 経路 `SNOTRA_EGUI_MAIN=1; cargo run -p snotra` をカテゴリ D と単独起動リストに明記して塞いだ（コマンドの SSOT を接地させる方が、注意書きより効く）。
 
-### 「書き戻さない」の全称 overclaim が spec→plan→実装→タスクレビューを素通りした
-#638 の不変条件は「dedup が唯一の変更のとき」に限って成立する（兄弟 migration が同時に true を返せば、その正当な書き戻しに dedup 済み内容が含まれる）のに、spec 起草時に無前提の絶対として書き、4 段の検査を素通りして最終 whole-branch レビューでようやく捕捉された。「全称表現は前提条件とセットで書く」は常時ロードに既在の規範——**規範の存在と、書く瞬間に発火することは別**である。全称を書いたら、その場で「これが破れる隣接経路（同居する機構・並走する呼び出し元）は何か」を一度問う。
+### dispatch を narrate しonly で tool 呼び出しを発行し忘れた
+Task 5 で「実装者を起動します」と述べたが Agent 呼び出しを実際に発行せず、ユーザーの「実装者は活動中か」で発覚。行動を述べたら**実際に発行したか確認する**——[[confabulating-tool-results]] の隣接失敗（行動を語ることと行うことの混同）。メモリ `lsp-diagnostics-stale-mid-edit` に addendum として記録。
 
-### name 付きサブエージェントの報告なし idle が 2 回起きた
-plan-review の独立導出と最終レビューが、成果物を SendMessage しないまま idle 通知だけを寄越した（4 体中 2 体・確率的）。SendMessage での催促で 2 回とも回収できたが、往復ぶんの待ちが生じた。→ memory（subagent-must-sendmessage-to-main）へ「name 付き起動時はプロンプトに報告義務を明記・idle だけ来たら催促」を追記した。
+### メモリ本文更新時に索引行を同期し忘れた
+SU4 完了を issue-532 メモリ本文に書いたが `MEMORY.md` の索引行を更新せず、サイクル末 health-check の 7b（索引↔本文一致）が検出。メモリ書き込み規律「本文更新時に一行ポインタも更新」の取りこぼし。retrospective の Step 6 で同期済み。**本文と索引は同じ編集で揃える**。

--- a/docs/build-commands.md
+++ b/docs/build-commands.md
@@ -55,6 +55,8 @@ npm run e2e:tauri        # 必須: Playwright + Tauri Driver E2E
 
 `npm run tauri dev` で起動し、目視で overflow／clipping／フォントレンダリングを確認する。PR 作成前に必須。
 
+- **egui 経路（#532・softbuffer メインウィンドウ）の視覚スモークは `cargo run -p snotra`（要 `SNOTRA_EGUI_MAIN=1`）で起動する**——`npm run tauri dev` は WebView2 経路。`snotra-egui-mvp`（下記「その他」の単独起動）は **Phase 1 の技術スパイクで SU 実装を一切含まない**ため、起動しても製品の egui 変更（アイコン・テーマ・行視覚等）は映らない。`cargo run`（`-p` 欠落）はワークスペースの別 bin を起動しうるので必ず `-p snotra` を付ける
+
 ### E. git hook（`.githooks/**`）を変更した場合
 
 ```bash
@@ -96,7 +98,8 @@ cargo test --release -p snotra-core bench_ -- --ignored --nocapture  # 検索パ
 cargo check --workspace          # Rust 全 crate 型チェック
 cargo clippy --workspace --all-targets -- -D warnings  # lint チェック（カテゴリ A と同じ）
 cargo run -p snotra-settings     # snotra-settings（egui ネイティブ設定 GUI）の単独起動
-cargo run -p snotra-egui-mvp     # Issue #532 egui MVP（WebViewなし・非配布）の単独起動
+cargo run -p snotra-egui-mvp     # Issue #532 egui MVP（WebViewなし・非配布の Phase 1 スパイク・SU 実装は含まない）
+cargo run -p snotra              # 製品メインウィンドウの egui 経路（要 SNOTRA_EGUI_MAIN=1・#532・WebView2 と並行。視覚スモークはこれ）
 npm run verify                   # Rust + フロントエンド一括検証（cargo check + npm run build）
 npm run smoke:startup             # 起動時ウィンドウ生成スモーク（trace検証）
 npm run e2e:tauri:setup           # Tauri Driver E2E 用セットアップ


### PR DESCRIPTION
## 概要

#532 Phase 2 SU4（PR #644 マージ済）のサイクル末 retrospective。

## 変更

- **`RETROSPECTIVE.md`**: SU4 サイクルで上書き（2 セクション）。よかったこと（実測プローブで設計フォークを閉じた・task-scoped review が実バグ捕捉・毎タスク cargo 接地）/ 伸びしろ（視覚スモーク対象誤り・narrate だけで tool 未発行・メモリ索引同期漏れ）。
- **`docs/build-commands.md`**: 伸びしろの構造的原因を塞ぐ。カテゴリ D（UI 視覚スモークのトリガー）が `npm run tauri dev`（WebView2 経路）しか書いておらず egui 経路の起動を欠いていたため、**製品 egui 経路 `SNOTRA_EGUI_MAIN=1; cargo run -p snotra`** をカテゴリ D と単独起動リストに明記（`snotra-egui-mvp` は Phase 1 スパイクで SU 実装を含まない旨も）。

メモリ（repo 外）: `lsp-diagnostics-stale-mid-edit` 新設・`MEMORY.md` 索引の SU4 反映・`issue-532-softbuffer-pivot` 本文更新。

Part of #532。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
