### PR TITLE
docs: SU7 配布・検証方針 spec（#580 消化計画・#532）

### DIFF
--- a/docs/superpowers/specs/2026-07-24-su7-distribution-verification-design.md
+++ b/docs/superpowers/specs/2026-07-24-su7-distribution-verification-design.md
@@ -1,71 +1,78 @@
 # SU7: 配布・検証方針（#580 消化計画）設計
 
-日付: 2026-07-24 / 対象: #532 Phase 2 SU7 のうち配布検証（flip 基準 4 の「#580 核心」）/ 先行: SU6.5（PR #655・ゲート G1〜G4 全合格・retrospective は PR #656）
+日付: 2026-07-24 / 対象: #532 Phase 2 SU7 のうち配布検証（flip 基準 4 の「#580 核心」）とリリース構成 / 先行: SU6.5（PR #655・ゲート G1〜G4 合格。G4 は PR CI green＝#655 マージを根拠とする）
 ロードマップ: `2026-07-21-phase2-softbuffer-migration-roadmap.md` の SU7 行
-スコープ確定: brainstorm で「署名鍵の CI 方針」を出発点に検討し、**鍵管理は現状維持・残る設計対象は検証手順と環境**と確定。e2e 後継方針と flip 実装は本 spec の対象外（別設計）。
+スコープ確定: brainstorm で「署名鍵の CI 方針」を出発点に検討し、**鍵管理は現状維持・設計対象は検証手順とリリース構成**と確定。初版はマルチパースペクティブレビュー（事実照合 / 手順実行シミュレーション / 完全性・整合 / codex 敵対探索の 4 レンズ）を経て、決定 2・4 を含む本改訂版へ更新した。e2e 後継方針の設計と flip 実装の設計は本 spec の対象外（別設計。ただし順序制約は「リスクと受容」に記す）。
 
 ## 背景と言語化
 
-brainstorm の裏取りで、#580 の前提が 3 点更新された。
+brainstorm とレビューの裏取りで、前提が次のとおり更新された。
 
 - **署名鍵は既に CI に在る**。`release.yml` が `secrets.TAURI_SIGNING_PRIVATE_KEY`（+ password）で署名付き NSIS と `latest.json` を生成し、`.sig` 存在検証・起動スモークを経て draft release へ上げる経路が現役（v0.18.3・2026-07-20 まで実績）。#580 の「鍵がローカルに無い」は正しいが、それは是正すべき欠落ではなく維持すべき状態である。
-- **旧版の updater は publish 済みの Latest しか見ない**。endpoint は `releases/latest/download/latest.json` 固定（`src-tauri/tauri.conf.json`）で、draft / prerelease はこの URL に現れない。publish 前に「旧版 → 新版」の実更新を試すには endpoint を差し替えた旧版を別途ビルドする仕掛けが要る。
-- **実行環境は Windows 11 Home**。Windows Sandbox / Hyper-V は使えず、素の環境検証にはサードパーティ VM の導入が要る。
+- **旧版の updater は publish 済みの Latest しか見ない**。endpoint は `releases/latest/download/latest.json` 固定（`src-tauri/tauri.conf.json`）で、draft / prerelease はこの URL に現れない。一方、**検証する側の旧版に署名鍵は不要**——updater が署名検証するのは「ダウンロードした成果物」であり、焼き込み済み本番 pubkey で足りる。ゆえに endpoint を 1 行差し替えた旧版のローカルビルド（`--no-bundle`・portable 起動)で、publish 前に実更新を実弾検証できる（決定 2 の rig）。
+- **`create-release.yml` はタグ push が先行する**。workflow 開始時に `v<version>` タグを push してから draft をビルドするため、検証 NG でも同一版番号では焼き直せない。NG 時の扱いは手順に含める必要がある（決定 2 の NG 分岐）。
+- **実行環境は Windows 11 Home**。Windows Sandbox / Hyper-V は使えず、素の環境検証にはサードパーティ VM の導入が要る。また検証実機は開発機と同一で、per-user AppData（config / history / index / window）を開発ビルドと共有する。
 - 補足: #580 コメント（2026-07-21）の「portable ZIP が生成されない」gap は `bundle.targets` 視点の指摘。`release.yml` は `Compress-Archive` で ZIP（snotra.exe + snotra-settings.exe）を手動生成しており、項目 3 の生成機構は既存。残るは成果物の動作確認のみ。
 
 ## 決定事項
 
-### 決定 1: 鍵管理は現状維持。検証用の新機構は作らない
+### 決定 1: 鍵管理は現状維持。恒久的な新機構は作らない
 
-GitHub Actions secret + draft ゲート（人手検証後に手動 publish）を維持し、鍵をローカルへ持ち出さない。endpoint override 機構・検証専用チャネル・prerelease 経由の事前実更新検証は**作らない**——一回限りの仕掛けのコストに対し、既存機構＋下記の梯子で全項目が埋まるため。
+GitHub Actions secret + draft ゲート（人手検証後に手動 publish）を維持し、鍵をローカルへ持ち出さない。検証専用の恒久チャネルや endpoint override の製品機構は作らない。決定 2 の rig は「旧版ローカルビルドの設定 1 行差し替え」という使い捨ての検証治具であり、製品コード・CI への変更を伴わない。
 
-### 決定 2: 項目 1（旧版 → egui 版の実更新）は publish 後に実機で検証する
+### 決定 2: 項目 1（旧版 → egui 版の実更新）は publish（Latest 化）の**前**に rig で実弾検証する
 
-draft の NSIS を install 系検証で先に潰してから publish し、実機の旧版から実更新する。v0.18.3 への実更新（SU6.5 スモーク）で同じ列の実績がある。publish 後に壊れていた場合の回復は次 patch ＋ WebView2 フォールバックフラグ（決定 4）。
+初版は「publish 後に実機で検証」としたが、レビュー 3 レンズが独立に同じ欠陥へ収束したため改めた——(a) flip 基準 4「#580 核心を満たしてから切替」に対し、flip リリース自身が検証手段になる循環が生じる、(b) 手動 install 検証は updater ハンドオフ固有の条件（`latest.json` 解決・バージョン比較・署名の暗号学的検証・既存プロセス終了・installer 起動）を一切検証しないため「残余は僅か」という受容根拠が誤り、(c) 検証者が最初の被験者である保証がない。
 
-### 決定 3: install 系検証（項目 2・3・6）は実機のみで回す。VM は見送る
+rig の形: v0.19.0 を **prerelease として publish**（Latest にならず既存ユーザーの updater から不可視）→ worktree に v0.18.3 を checkout し `tauri.conf.json` の endpoint を固定 URL（`releases/download/v0.19.0/latest.json`）へ 1 行差し替え → `--no-bundle` ビルドの旧版 exe を portable 起動 → 実更新を完走させる。これで署名検証を含むハンドオフ全段が publish 前に実弾になり、flip 基準 4 の循環も解ける。検証されない残余は `/releases/latest` リダイレクト 1 点のみ（→「リスクと受容」）。
 
-config / history をバックアップした上で、上書き install → uninstall → 新規 install の列で 3 項目を代替する。実機には残留 AppData がありうるため「完全に素の環境」ではない——この純度低下は受容する（→「リスクと受容」）。素の環境整備が将来必要になれば別 issue とする。
+**NG 時の分岐**: タグは既に push されているため付け替えない。prerelease を破棄（または prerelease のまま放置）し、修正後は**次の版番号で焼き直す**。Latest は v0.18.3 のまま動かないので、ユーザー影響はない。
 
-### 決定 4: flip と WebView2 撤去は 1 リリース分離する
+### 決定 3: install 系検証（項目 6 と、項目 2・3 の成果物接地）は実機のみで回す。VM は見送る
 
-v0.19.0 で flip（既定 egui。WebView2 経路はフォールバック用フラグで温存）、実運用 soak を経て次版で撤去。分離の対価（二経路並行維持の 1 リリース延長）より、次の 2 つを取る:
+署名付き NSIS / ZIP の**生成**は CI（`release.yml`）が担い、実機が担うのは**実 install での接地**である。config / history をバックアップした上で、上書き install → uninstall → 新規 install の列で検証し、**列の完了後にバックアップを復元してから**後続手順へ進む。実機には残留 AppData がありうるため「完全に素の環境」ではなく、検証中に開発ビルドを並走させると同じ AppData を読み書きして汚染する——この 2 点は手順上の禁止（検証中は開発ビルドを起動しない）と受容で扱う（→「リスクと受容」）。素の環境整備が将来必要になれば別 issue とする。
 
-- **ロールバック手段**: 既定 egui で重大不具合が出ても、フラグで WebView2 へ退避できる。
-- **egui 側 updater の実弾検証**: 項目 1 は「旧版 **から** egui 版へ」しか検証しない。「egui 版 **から** 次版へ」——egui 経路の check → toast → Installing 表示（両ボタン disabled・#580 コメント 2026-07-23 の追記）→ `on_before_exit` 保存 → installer passive 起動 → 再起動——は、v0.19.0 → 次版の更新で初めて実弾になる。撤去リリースがこの検証機会をちょうど供給する。
+### 決定 4: v0.18.3 を WebView2 最終版とし、v0.19.0 で flip + WebView2 経路撤去を同一リリースで完結する
 
-## リリース梯子（実施手順）
+初版は「1 リリース分離（フラグ温存 = ロールバック手段）」としたが、レビュー 2 レンズが「フラグの実体は環境変数であり、一般ユーザーが操作できる回復手段ではない」と指摘した。フラグ退避をロールバックの柱に据える主張は撤回し、開き直って構成を単純化する:
 
-### 一段目: v0.19.0（flip・WebView2 温存）
+- **v0.18.3 = WebView2 最終版**（公開されたまま残る）。**v0.19.0 以降 = egui**。
+- ロールバックの実体は「v0.18.3 の NSIS を入れ直す」+ 次 patch。アプリ内のフォールバック経路は主張しない。
+- 二経路並行維持のコストは即時に消え、ロードマップ「並行期間を短く」に最も忠実な形になる。
+- 初版の分離案が担っていた「egui 側 updater の実弾検証機会」は、**flip 後最初の自然なリリース**（v0.19.x）への更新が同じ機会を提供するため、失われない（手順 7）。
 
-1. `create-release.yml`（workflow_dispatch）で draft build。CI が署名・`latest.json` 生成・`.sig` 検証・起動スモークまで自動実行する。
-2. **draft 検証（実機・publish 前）**: config / history をバックアップ → draft の NSIS で上書き install → 動作スモーク → uninstall → 新規 install → 動作スモーク → portable ZIP の展開・起動確認。ここで項目 2・3・6 が埋まる。
-3. v0.18.3（公開済み NSIS）を入れ直してから publish（Latest 化）→ 旧版の updater から**実更新** → egui 既定で起動・動作確認。ここで項目 1 が埋まる。
+## リリース手順（v0.19.0）
 
-### 二段目: 次版（WebView2 撤去）
-
-4. v0.19.0 の egui 経路 updater で実更新: check → toast → [今すぐ更新] → Installing 表示（両ボタン disabled を目視）→ `on_before_exit` 保存（history flush・icon cache・設定サイドカー終了）→ installer passive → 再起動。ここで項目 4 が実弾になり、完走で #580 を close する。
+0. **事前確認**: 永続形式（index.bin / history.bin / window.bin / config.toml）の v0.18.3 比差分を確認する。本 spec 作成時点の実測では形式バージョン・フィールドとも差分なし（index v4 / history v3 / window v5）。flip までに永続形式を変える変更が入った場合はこの前提が崩れるため、リリース直前に再確認する（`/persistence-check` の領分）。config / history をバックアップする。
+1. `create-release.yml`（workflow_dispatch）で v0.19.0 の draft build。CI が署名・`latest.json` 生成・`.sig` 存在検証・起動スモークまで自動実行する。タグはこの時点で push される（NG 時は決定 2 の分岐）。
+2. **draft 検証（実機・検証中は開発ビルドを起動しない）**: draft の NSIS で上書き install → 動作スモーク → uninstall → 新規 install → 動作スモーク → portable ZIP を展開し snotra.exe 起動 + 設定画面（サイドカー snotra-settings.exe）が開くことを確認。動作スモークの合否は「起動・ホットキー表示/非表示・検索と結果選択・設定画面起動・更新チェックが更新なしを返す」の 5 点とする。ここで項目 2・3・6 が埋まる。完了後、バックアップを復元する。
+3. draft を **prerelease として publish**（Latest 不変・既存ユーザー不可視）。
+4. **rig による実更新検証（決定 2）**: endpoint を v0.19.0 の固定 URL へ差し替えた v0.18.3 ローカルビルド（portable）から実更新 → 署名検証・プロセス終了・NSIS passive・再起動を完走 → egui 既定で起動・スモーク合格。ここで項目 1 が埋まる。
+5. 合格したら prerelease を解除して **Latest 化**。一般ユーザーへ開放。
+6. 公開後の接地: 公開済み asset（NSIS / ZIP / `latest.json`）を Release ページから取り直し、ダウンロード可能なこと・`latest.json` の url が公開 asset を指すことを確認する。
+7. **flip 後最初の自然なリリース（v0.19.x）で egui 側 updater を実弾検証**: check → toast → [今すぐ更新] → Installing 表示（両ボタン disabled を目視・#580 コメント 2026-07-23 の追記）→ `on_before_exit` 保存（history flush・icon cache・設定サイドカー終了）→ installer passive → 再起動。ここで項目 4 が実弾になり、完走で #580 を close する。
 
 ### #580 チェックリストとの対応
 
 | #580 項目 | 埋まる場所 |
 |---|---|
-| 1. 旧署名版 → softbuffer 版の実更新 | 一段目 手順 3 |
-| 2. 署名付き NSIS 生成 | 一段目 手順 1（CI）+ 手順 2（実 install で接地） |
-| 3. portable ZIP | 一段目 手順 2（既存 `Compress-Archive` 成果物の動作確認） |
-| 4. `on_before_exit` 保存・再起動 | コード検証済（#580 コメント 2026-07-21）→ 二段目 手順 4 で実弾 |
-| 5. 3 更新モード維持 | 検証済（同コメント + SU6.5 スモーク）。一段目で full モードが再接地 |
-| 6. 新規 / 上書き / uninstall | 一段目 手順 2 |
-| 追記: Installing 目視列（#647） | 二段目 手順 4 |
+| 1. 旧署名版 → softbuffer 版の実更新 | 手順 4（rig・publish 前） |
+| 2. 署名付き NSIS 生成 | 手順 1（CI 生成）+ 手順 2（実 install で接地） |
+| 3. portable ZIP | 手順 2（既存 `Compress-Archive` 成果物の動作確認） |
+| 4. `on_before_exit` 保存・再起動 | コード検証済（SU5・PR #647 の `on_before_exit` hook）→ 手順 7 で実弾 |
+| 5. 3 更新モード維持 | 検証済（SU5・PR #647 + #580 コメント 2026-07-21）。手順 4 で full モードが再接地 |
+| 6. 新規 / 上書き / uninstall | 手順 2 |
+| 追記: Installing 目視列（#647） | 手順 7 |
 
 ## スコープ外
 
-- **e2e 後継方針**（WebView2 撤去による `e2e/` 基盤喪失・#567 との順序整理・egui 自動回帰 smoke の定式化）——SU7 受け入れ条件だが独立のトピックとして別途設計する。
-- **flip 実装そのもの**（既定反転の方式・フォールバックフラグの形・撤去の範囲）——別 spec。
+- **e2e 後継方針の設計**（`e2e/` 基盤喪失への対応・#567 との順序整理・egui 自動回帰 smoke の中身）——独立のトピックとして別途設計する。ただし決定 4 により撤去が v0.19.0 に入るため、**「egui 自動回帰 smoke 最低 1 本 CI」（SU7 受け入れ条件）は撤去 PR と同時か先行**という順序制約が生じる（→「リスクと受容」）。
+- **flip 実装そのもの**（既定反転の方式・撤去の範囲・二経路の畳み方）——本 spec の後続として別途 brainstorm する。
 - **VM / 素の環境の整備**——見送り。必要が生じたら別 issue。
 
 ## リスクと受容
 
-- **実機は素の環境ではない**: uninstall 直後でも AppData 等の残留がありうるため、新規 install 検証の純度は VM に劣る。受容する（uninstall → install の列で代替。決定 3）。
-- **publish 後検証の窓**: 実更新が壊れていた場合、次 patch を出すまで Latest が壊れた状態で晒される。draft 検証で install 系を先に潰すため、残余は updater ハンドオフのみ——この経路は v0.18.3 実更新で近縁の実績があり、回復手段（次 patch + フォールバックフラグ）も持つ。受容する（決定 2）。
-- **soak 期間の二経路並行維持**: v0.19.0 と撤去リリースの間、WebView2 経路の保守が 1 リリース分残る。フラグ境界はウィンドウ生成時に限定済み（ロードマップ「リスク」節）で薄い。受容する（決定 4）。
+- **`/releases/latest` リダイレクト経路は rig で検証されない**: rig は固定 URL を直指しするため、Latest 化後に旧版が辿る `releases/latest/download/latest.json` の解決だけは実弾にならない。v0.18 系の更新で長期に実績のある GitHub 側機構であり、受容する（決定 2）。
+- **実機は素の環境ではない**: uninstall 後の AppData 残留があり、新規 install 検証の純度は VM に劣る。加えて実機は開発機でもある——「検証中は開発ビルドを起動しない」の手順制約で能動汚染は避け、残留による純度低下は受容する（決定 3）。
+- **egui 側 updater の実弾が flip 後最初の更新まで遅延する**: 項目 4 の実弾（手順 7）は v0.19.0 リリース時点では未完走。コードは SU5 で検証済み・旧版→新版のハンドオフは rig で実弾済みであることを根拠に受容する。手順 7 の更新が万一失敗した場合、WebView2 撤去済みゆえアプリ内の退避は無く、回復は「v0.19.0 の NSIS を Release から入れ直す」+ 次 patch である（決定 4）。
+- **`e2e/` の即時喪失**: 撤去が v0.19.0 に入るため、自動回帰の空白が生じうる。上記スコープ外の順序制約（smoke を撤去 PR と同時か先行）で塞ぐことを SU7 の受け入れに含め、本 spec では受容しない（塞ぐ側に置く)。

--- a/docs/superpowers/specs/2026-07-24-su7-distribution-verification-design.md
+++ b/docs/superpowers/specs/2026-07-24-su7-distribution-verification-design.md
@@ -1,0 +1,71 @@
+# SU7: 配布・検証方針（#580 消化計画）設計
+
+日付: 2026-07-24 / 対象: #532 Phase 2 SU7 のうち配布検証（flip 基準 4 の「#580 核心」）/ 先行: SU6.5（PR #655・ゲート G1〜G4 全合格・retrospective は PR #656）
+ロードマップ: `2026-07-21-phase2-softbuffer-migration-roadmap.md` の SU7 行
+スコープ確定: brainstorm で「署名鍵の CI 方針」を出発点に検討し、**鍵管理は現状維持・残る設計対象は検証手順と環境**と確定。e2e 後継方針と flip 実装は本 spec の対象外（別設計）。
+
+## 背景と言語化
+
+brainstorm の裏取りで、#580 の前提が 3 点更新された。
+
+- **署名鍵は既に CI に在る**。`release.yml` が `secrets.TAURI_SIGNING_PRIVATE_KEY`（+ password）で署名付き NSIS と `latest.json` を生成し、`.sig` 存在検証・起動スモークを経て draft release へ上げる経路が現役（v0.18.3・2026-07-20 まで実績）。#580 の「鍵がローカルに無い」は正しいが、それは是正すべき欠落ではなく維持すべき状態である。
+- **旧版の updater は publish 済みの Latest しか見ない**。endpoint は `releases/latest/download/latest.json` 固定（`src-tauri/tauri.conf.json`）で、draft / prerelease はこの URL に現れない。publish 前に「旧版 → 新版」の実更新を試すには endpoint を差し替えた旧版を別途ビルドする仕掛けが要る。
+- **実行環境は Windows 11 Home**。Windows Sandbox / Hyper-V は使えず、素の環境検証にはサードパーティ VM の導入が要る。
+- 補足: #580 コメント（2026-07-21）の「portable ZIP が生成されない」gap は `bundle.targets` 視点の指摘。`release.yml` は `Compress-Archive` で ZIP（snotra.exe + snotra-settings.exe）を手動生成しており、項目 3 の生成機構は既存。残るは成果物の動作確認のみ。
+
+## 決定事項
+
+### 決定 1: 鍵管理は現状維持。検証用の新機構は作らない
+
+GitHub Actions secret + draft ゲート（人手検証後に手動 publish）を維持し、鍵をローカルへ持ち出さない。endpoint override 機構・検証専用チャネル・prerelease 経由の事前実更新検証は**作らない**——一回限りの仕掛けのコストに対し、既存機構＋下記の梯子で全項目が埋まるため。
+
+### 決定 2: 項目 1（旧版 → egui 版の実更新）は publish 後に実機で検証する
+
+draft の NSIS を install 系検証で先に潰してから publish し、実機の旧版から実更新する。v0.18.3 への実更新（SU6.5 スモーク）で同じ列の実績がある。publish 後に壊れていた場合の回復は次 patch ＋ WebView2 フォールバックフラグ（決定 4）。
+
+### 決定 3: install 系検証（項目 2・3・6）は実機のみで回す。VM は見送る
+
+config / history をバックアップした上で、上書き install → uninstall → 新規 install の列で 3 項目を代替する。実機には残留 AppData がありうるため「完全に素の環境」ではない——この純度低下は受容する（→「リスクと受容」）。素の環境整備が将来必要になれば別 issue とする。
+
+### 決定 4: flip と WebView2 撤去は 1 リリース分離する
+
+v0.19.0 で flip（既定 egui。WebView2 経路はフォールバック用フラグで温存）、実運用 soak を経て次版で撤去。分離の対価（二経路並行維持の 1 リリース延長）より、次の 2 つを取る:
+
+- **ロールバック手段**: 既定 egui で重大不具合が出ても、フラグで WebView2 へ退避できる。
+- **egui 側 updater の実弾検証**: 項目 1 は「旧版 **から** egui 版へ」しか検証しない。「egui 版 **から** 次版へ」——egui 経路の check → toast → Installing 表示（両ボタン disabled・#580 コメント 2026-07-23 の追記）→ `on_before_exit` 保存 → installer passive 起動 → 再起動——は、v0.19.0 → 次版の更新で初めて実弾になる。撤去リリースがこの検証機会をちょうど供給する。
+
+## リリース梯子（実施手順）
+
+### 一段目: v0.19.0（flip・WebView2 温存）
+
+1. `create-release.yml`（workflow_dispatch）で draft build。CI が署名・`latest.json` 生成・`.sig` 検証・起動スモークまで自動実行する。
+2. **draft 検証（実機・publish 前）**: config / history をバックアップ → draft の NSIS で上書き install → 動作スモーク → uninstall → 新規 install → 動作スモーク → portable ZIP の展開・起動確認。ここで項目 2・3・6 が埋まる。
+3. v0.18.3（公開済み NSIS）を入れ直してから publish（Latest 化）→ 旧版の updater から**実更新** → egui 既定で起動・動作確認。ここで項目 1 が埋まる。
+
+### 二段目: 次版（WebView2 撤去）
+
+4. v0.19.0 の egui 経路 updater で実更新: check → toast → [今すぐ更新] → Installing 表示（両ボタン disabled を目視）→ `on_before_exit` 保存（history flush・icon cache・設定サイドカー終了）→ installer passive → 再起動。ここで項目 4 が実弾になり、完走で #580 を close する。
+
+### #580 チェックリストとの対応
+
+| #580 項目 | 埋まる場所 |
+|---|---|
+| 1. 旧署名版 → softbuffer 版の実更新 | 一段目 手順 3 |
+| 2. 署名付き NSIS 生成 | 一段目 手順 1（CI）+ 手順 2（実 install で接地） |
+| 3. portable ZIP | 一段目 手順 2（既存 `Compress-Archive` 成果物の動作確認） |
+| 4. `on_before_exit` 保存・再起動 | コード検証済（#580 コメント 2026-07-21）→ 二段目 手順 4 で実弾 |
+| 5. 3 更新モード維持 | 検証済（同コメント + SU6.5 スモーク）。一段目で full モードが再接地 |
+| 6. 新規 / 上書き / uninstall | 一段目 手順 2 |
+| 追記: Installing 目視列（#647） | 二段目 手順 4 |
+
+## スコープ外
+
+- **e2e 後継方針**（WebView2 撤去による `e2e/` 基盤喪失・#567 との順序整理・egui 自動回帰 smoke の定式化）——SU7 受け入れ条件だが独立のトピックとして別途設計する。
+- **flip 実装そのもの**（既定反転の方式・フォールバックフラグの形・撤去の範囲）——別 spec。
+- **VM / 素の環境の整備**——見送り。必要が生じたら別 issue。
+
+## リスクと受容
+
+- **実機は素の環境ではない**: uninstall 直後でも AppData 等の残留がありうるため、新規 install 検証の純度は VM に劣る。受容する（uninstall → install の列で代替。決定 3）。
+- **publish 後検証の窓**: 実更新が壊れていた場合、次 patch を出すまで Latest が壊れた状態で晒される。draft 検証で install 系を先に潰すため、残余は updater ハンドオフのみ——この経路は v0.18.3 実更新で近縁の実績があり、回復手段（次 patch + フォールバックフラグ）も持つ。受容する（決定 2）。
+- **soak 期間の二経路並行維持**: v0.19.0 と撤去リリースの間、WebView2 経路の保守が 1 リリース分残る。フラグ境界はウィンドウ生成時に限定済み（ロードマップ「リスク」節）で薄い。受容する（決定 4）。


### PR DESCRIPTION
## 概要

SU7（#532 Phase 2 最終ユニット）のうち配布検証（flip 基準 4 の「#580 核心」）とリリース構成の方針 spec を追加する。ドキュメントのみの変更。

## 内容

`docs/superpowers/specs/2026-07-24-su7-distribution-verification-design.md`

- **決定 1**: 署名鍵管理は現状維持（GitHub Actions secret + draft ゲート）。恒久的な新機構は作らない
- **決定 2**: #580 項目 1（旧版 → egui 版の実更新）は Latest 化の前に rig（prerelease + endpoint 1 行差し替えの v0.18.3 portable ビルド）で実弾検証する。タグ先行 push への NG 分岐も定義
- **決定 3**: install 系検証は実機のみ（バックアップ→上書き→uninstall→新規→復元の列・検証中は開発ビルド並走禁止）。VM は見送り
- **決定 4**: v0.18.3 を WebView2 最終版とし、v0.19.0 で flip + WebView2 撤去を同一リリース完結。ロールバックは v0.18.3 入れ直し + 次 patch（フラグ退避は主張しない）

## 経緯

brainstorm（4 決定の対話確定）→ 初版 commit → マルチパースペクティブレビュー（事実照合 / 手順実行シミュレーション / 完全性・整合 / codex 敵対探索の 4 レンズ並列)→ 収束した本命指摘（publish 後検証の flip 基準 4 循環・フォールバックフラグの未成立）を受けて決定 2・4 を改訂。細部指摘（復元手順・永続形式の事前差分確認・スモーク合否定義・引用先修正・公開後 asset 接地・e2e 順序制約）も全反映。

## 検証

- `npm run governance:check` G1..G10 合格（初版・改訂版とも）
- 事実照合レンズ: spec の事実主張は release.yml / tauri.conf.json / #580 / ロードマップの実物と全一致

Refs: #532, #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)
