### PR TITLE
SU7 PR1: egui 自動回帰 smoke 新設（#532）

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,6 +16,7 @@ on:
       - '.github/workflows/e2e.yml'
       # E2E workflow の各ステップが直接呼ぶスクリプト/設定（変更で自己検証する）
       - 'scripts/smoke-startup.ps1'      # "Run startup smoke" ステップ
+      - 'scripts/smoke-egui.ps1'         # smoke-egui job（egui 経路の自動回帰・#532 SU7）
       - 'scripts/prepare-sidecar.ps1'    # "Build app and setup E2E"（e2e:tauri:setup → prepare:sidecar）
       - 'playwright.tauri.config.ts'     # "Run E2E tests"（e2e:tauri = Playwright ランナー）
       - 'vite.config.ts'                 # tauri build のフロントバンドル入力
@@ -67,3 +68,44 @@ jobs:
 
       - name: Run E2E tests
         run: npm run e2e:tauri
+
+  # egui 経路の自動回帰 smoke（#532 SU7 PR1・e2e/ 撤去後の後継の最低線）。
+  # e2e job とは独立にビルドする（e2e:tauri:setup は flip PR2 で消えるため依存しない）。
+  # npm 工程が要るのは tauri の context codegen が frontendDist（dist/）の実在を要求するため
+  # （PR3 の frontendDist 撤去までの過渡）。
+  smoke-egui:
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build frontend assets (tauri codegen input)
+        run: npm run build
+
+      - name: Build release binary
+        run: cargo build --release -p snotra
+
+      - name: Run egui smoke
+        run: npm run smoke:egui -- -ExePath target/release/snotra.exe -SeedConfig
+        env:
+          # flip（PR2）でこの env を外し、「既定が egui であること」自体を検証対象へ変える（spec 決定 3）
+          SNOTRA_EGUI_MAIN: "1"

--- a/docs/build-commands.md
+++ b/docs/build-commands.md
@@ -114,7 +114,7 @@ npm run tauri build              # リリースビルド（フロント+Rust 一
 ## E2E/スモーク運用メモ
 
 - `scripts/smoke-startup.ps1` は `SNOTRA_TRACE=1` で起動し、`*:error` トレースイベントが不在であることを検証する
-- `scripts/smoke-egui.ps1` は egui 経路の自動回帰の最低線（#532 SU7・e2e/ 撤去後の後継）: `SNOTRA_TRACE=1` で起動 → keybd_event で Alt+Q（既定 hotkey・Alt 解放込み）→ `egui_show:done` 観測 → Escape → `egui_hide:done` 観測 → `msedgewebview2` のグローバル増分 0 を検証する。`-SeedConfig` は CI 用（config.toml 不在時のみ空 seed して first-run 経路を回避。既存 config は上書きしない）。実行中の snotra を kill するためローカル実行時は注意。網羅は担わず、視覚・操作列は手動 GUI smoke（カテゴリ D）が補完する
+- `scripts/smoke-egui.ps1` は egui 経路の自動回帰の最低線（#532 SU7・e2e/ 撤去後の後継）: `SNOTRA_TRACE=1` で起動 → keybd_event で Alt+Q（既定 hotkey・Alt 解放込み）→ `egui_show:done` 観測 → Escape → `egui_hide:done` 観測 → `msedgewebview2` のグローバル増分 0 を検証する。`-SeedConfig` は CI 用（config.toml 不在時のみ最小の有効 TOML を seed して first-run 経路を回避。既存 config は上書きしない。空 TOML は必須セクション欠落で parse 失敗し破損復旧経路を踏むため使わない）。実行中の snotra を kill するためローカル実行時は注意。網羅は担わず、視覚・操作列は手動 GUI smoke（カテゴリ D）が補完する
 - `e2e/tauri.slash.e2e.ts` は Playwright runner 上で `tauri-driver + selenium-webdriver + edgedriver` を使い、起動入力・`/o` の動作を検証する
 - **E2E は `SNOTRA_DISABLE_SUSPEND=1` で app を起動する**（`spawnTauriDriver` が注入）。WebDriver は非表示中のレンダラーに `executeScript` で触り続けるため、hide 時の WebView2 suspend（TrySuspend）とは非互換（suspend されたレンダラーは script に応答せず 30s タイムアウトする）。suspend 経路自体は E2E では検証されない（ホットキー同様、実機計測でカバー）
 - E2E セットアップは `npx tauri build --no-bundle --features e2e-webview-automation` を使う（`cargo build --release` は `localhost` 向きバイナリになり `ERR_CONNECTION_REFUSED` で失敗する）。feature はテスト用バイナリにだけ WebView2 の trusted application API 経由で `--remote-debugging-port=0` を設定可能にする。実際の有効化にはハーネスが生成する `SNOTRA_E2E_WEBVIEW_DATA_DIR` も必要で、通常配布ビルドや startup smoke に remote debugging を持ち込まない

--- a/docs/build-commands.md
+++ b/docs/build-commands.md
@@ -45,6 +45,7 @@ npm run docs:check   # 必須（TSDoc {@link} を含む doc コメント編集�
 ```bash
 npm test                 # 必須: フロントユニットテスト（Vitest）
 npm run smoke:startup    # 必須: 起動時ウィンドウ生成スモーク（trace 検証）
+npm run smoke:egui       # 必須（egui 経路に触れた場合）: egui show/hide スモーク（Alt+Q 注入 + trace 検証・要 SNOTRA_EGUI_MAIN=1）
 npm run e2e:tauri        # 必須: Playwright + Tauri Driver E2E
 ```
 
@@ -102,6 +103,7 @@ cargo run -p snotra-egui-mvp     # Issue #532 egui MVP（WebViewなし・非配�
 cargo run -p snotra              # 製品メインウィンドウの egui 経路（要 SNOTRA_EGUI_MAIN=1・#532・WebView2 と並行。視覚スモークはこれ）
 npm run verify                   # Rust + フロントエンド一括検証（cargo check + npm run build）
 npm run smoke:startup             # 起動時ウィンドウ生成スモーク（trace検証）
+npm run smoke:egui                # egui 経路の show/hide スモーク（keybd_event 注入 + trace検証・#532 SU7。既定 ExePath = target/release）
 npm run measure:memory            # メモリ実測（PrivWS 軸・ツリー合算・#532 flip 基準 3）
 npm run e2e:tauri:setup           # Tauri Driver E2E 用セットアップ
 npm run e2e:tauri                 # Playwright + Tauri Driver E2E
@@ -112,6 +114,7 @@ npm run tauri build              # リリースビルド（フロント+Rust 一
 ## E2E/スモーク運用メモ
 
 - `scripts/smoke-startup.ps1` は `SNOTRA_TRACE=1` で起動し、`*:error` トレースイベントが不在であることを検証する
+- `scripts/smoke-egui.ps1` は egui 経路の自動回帰の最低線（#532 SU7・e2e/ 撤去後の後継）: `SNOTRA_TRACE=1` で起動 → keybd_event で Alt+Q（既定 hotkey・Alt 解放込み）→ `egui_show:done` 観測 → Escape → `egui_hide:done` 観測 → `msedgewebview2` のグローバル増分 0 を検証する。`-SeedConfig` は CI 用（config.toml 不在時のみ空 seed して first-run 経路を回避。既存 config は上書きしない）。実行中の snotra を kill するためローカル実行時は注意。網羅は担わず、視覚・操作列は手動 GUI smoke（カテゴリ D）が補完する
 - `e2e/tauri.slash.e2e.ts` は Playwright runner 上で `tauri-driver + selenium-webdriver + edgedriver` を使い、起動入力・`/o` の動作を検証する
 - **E2E は `SNOTRA_DISABLE_SUSPEND=1` で app を起動する**（`spawnTauriDriver` が注入）。WebDriver は非表示中のレンダラーに `executeScript` で触り続けるため、hide 時の WebView2 suspend（TrySuspend）とは非互換（suspend されたレンダラーは script に応答せず 30s タイムアウトする）。suspend 経路自体は E2E では検証されない（ホットキー同様、実機計測でカバー）
 - E2E セットアップは `npx tauri build --no-bundle --features e2e-webview-automation` を使う（`cargo build --release` は `localhost` 向きバイナリになり `ERR_CONNECTION_REFUSED` で失敗する）。feature はテスト用バイナリにだけ WebView2 の trusted application API 経由で `--remote-debugging-port=0` を設定可能にする。実際の有効化にはハーネスが生成する `SNOTRA_E2E_WEBVIEW_DATA_DIR` も必要で、通常配布ビルドや startup smoke に remote debugging を持ち込まない
@@ -143,6 +146,7 @@ npm run tauri build              # リリースビルド（フロント+Rust 一
 | `npm run governance:check`（#587・ガバナンス文書検査） | `ci.yml`（governance-check） | PR 自動（**`skip-ci` 非対象** — if ガードを持たず常時実行） |
 | `npm run smoke:startup`（注） | `e2e.yml`（E2E & Smoke） | 対象 paths を含む PR（自動）/ 手動 dispatch |
 | `npm run e2e:tauri` | `e2e.yml`（E2E & Smoke） | 対象 paths を含む PR（自動）/ 手動 dispatch |
+| `npm run smoke:egui`（#532 SU7・egui 経路の自動回帰） | `e2e.yml`（smoke-egui job・`SNOTRA_EGUI_MAIN=1`） | 対象 paths を含む PR（自動）/ 手動 dispatch |
 
 （注）CI では `e2e:tauri:setup` が生成した release バイナリを共有するため、`npm run smoke:startup`（既定 ExePath = debug）ではなく `scripts/smoke-startup.ps1 -ExePath target/release/snotra.exe` を直接実行する。検証する起動経路は同じ（release バイナリの起動 trace に `*:error` が無いこと）。これは E2E 用ビルドの起動健全性検証であり、配布バンドル（`tauri build`）の検証ではない。
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "clean:worktrees": "node scripts/clean-worktrees.mjs",
     "governance:check": "node scripts/governance-check.mjs",
     "smoke:startup": "pwsh -NoProfile -File scripts/smoke-startup.ps1",
+    "smoke:egui": "pwsh -NoProfile -File scripts/smoke-egui.ps1",
     "measure:memory": "pwsh -NoProfile -File scripts/measure-memory.ps1",
     "prepare:sidecar": "pwsh -NoProfile -File scripts/prepare-sidecar.ps1 -Release",
     "e2e:tauri:setup": "cargo install tauri-driver --locked && npm run prepare:sidecar && npx tauri build --no-bundle --features e2e-webview-automation",

--- a/scripts/smoke-egui.ps1
+++ b/scripts/smoke-egui.ps1
@@ -13,7 +13,7 @@ param(
 # 起動 → keybd_event で Alt+Q（既定 hotkey）注入 → trace `egui_show:done` 観測 → Escape 注入 →
 # `egui_hide:done` 観測 → msedgewebview2 のグローバル増分 0 確認、で 1 シナリオ。
 # - hotkey は Alt 解放を含めて送る（Alt 押下中は ShowAfterAltRelease で最大 350ms 遅延するため）。
-# - -SeedConfig（CI 用）: config.toml 不在時のみ空ファイルを seed し first-run 経路
+# - -SeedConfig（CI 用）: config.toml 不在時のみ最小の有効 TOML を seed し first-run 経路
 #   （snotra-settings --first-run の spawn がフォーカスを奪う）を回避する。既存 config は決して上書きしない。
 # - egui/WebView2 の経路選択は呼び出し側の env（SNOTRA_EGUI_MAIN）に従う。flip（PR2）後は env なしが既定。
 
@@ -29,9 +29,24 @@ if ($SeedConfig) {
   $cfgPath = Join-Path $cfgDir "config.toml"
   if (-not (Test-Path $cfgPath)) {
     New-Item -ItemType Directory -Force -Path $cfgDir | Out-Null
-    # 空 TOML は全セクション serde default で解釈される（config.rs の既定値補完）
-    Set-Content -Path $cfgPath -Value "" -Encoding utf8
-    Write-Host "Seeded empty config: $cfgPath"
+    # 最小の有効 TOML。[hotkey]/[appearance]/[paths] は #[serde(default)] 無しの必須セクションで、
+    # 空 TOML は parse 失敗し「破損復旧」経路（stderr 診断 + config.toml.bak 退避 + 復旧バルーン）を
+    # 毎回踏んでしまう（PR #659 レビューで検出）。値は config.rs の既定と同一
+    # （hotkey Alt+Q = 本スクリプト既定の -HotkeyVks 18,81 と一致）。scan 空 = インデックス対象なし
+    # （smoke は show/hide のみで索引不要・CI のスキャンを省く）。
+    $seedToml = @'
+[hotkey]
+modifier = "Alt"
+key = "Q"
+
+[appearance]
+window_width = 600
+
+[paths]
+scan = []
+'@
+    Set-Content -Path $cfgPath -Value $seedToml -Encoding utf8
+    Write-Host "Seeded minimal config: $cfgPath"
   } else {
     Write-Host "Config already exists, seed skipped: $cfgPath"
   }

--- a/scripts/smoke-egui.ps1
+++ b/scripts/smoke-egui.ps1
@@ -1,0 +1,153 @@
+param(
+  [string]$ExePath = "target/release/snotra.exe",
+  [int]$StartupWaitMs = 4000,
+  [int]$ObserveTimeoutMs = 8000,
+  [switch]$SeedConfig,
+  # hotkey の仮想キーコード列（カンマ区切り・押下順・解放は逆順）。既定は Alt(18)+Q(81) = config.rs の既定 hotkey。
+  # hotkey は config.toml 依存のため、実 config を持つ実機ではその値を渡す（例: Ctrl+K は "17,75"）。
+  # pwsh -File / npm 経由で配列引数が壊れないよう文字列で受けて内部で分割する。
+  [string]$HotkeyVks = "18,81"
+)
+
+# egui 経路の自動回帰 smoke（#532 SU7 PR1・spec: docs/superpowers/specs/2026-07-24-su7-flip-implementation-design.md 決定 3）。
+# 起動 → keybd_event で Alt+Q（既定 hotkey）注入 → trace `egui_show:done` 観測 → Escape 注入 →
+# `egui_hide:done` 観測 → msedgewebview2 のグローバル増分 0 確認、で 1 シナリオ。
+# - hotkey は Alt 解放を含めて送る（Alt 押下中は ShowAfterAltRelease で最大 350ms 遅延するため）。
+# - -SeedConfig（CI 用）: config.toml 不在時のみ空ファイルを seed し first-run 経路
+#   （snotra-settings --first-run の spawn がフォーカスを奪う）を回避する。既存 config は決して上書きしない。
+# - egui/WebView2 の経路選択は呼び出し側の env（SNOTRA_EGUI_MAIN）に従う。flip（PR2）後は env なしが既定。
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path $ExePath)) {
+  throw "Executable not found: $ExePath"
+}
+
+if ($SeedConfig) {
+  $cfgDir = Join-Path $env:APPDATA "Snotra"
+  $cfgPath = Join-Path $cfgDir "config.toml"
+  if (-not (Test-Path $cfgPath)) {
+    New-Item -ItemType Directory -Force -Path $cfgDir | Out-Null
+    # 空 TOML は全セクション serde default で解釈される（config.rs の既定値補完）
+    Set-Content -Path $cfgPath -Value "" -Encoding utf8
+    Write-Host "Seeded empty config: $cfgPath"
+  } else {
+    Write-Host "Config already exists, seed skipped: $cfgPath"
+  }
+}
+
+Add-Type -Namespace SmokeInput -Name Native -MemberDefinition @'
+[DllImport("user32.dll")]
+public static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, UIntPtr dwExtraInfo);
+'@
+
+$KEYEVENTF_KEYUP = 0x2
+$VK_ESCAPE = 0x1B
+
+function Send-Key {
+  param([byte]$Vk, [switch]$Up)
+  $flags = if ($Up) { $KEYEVENTF_KEYUP } else { 0 }
+  [SmokeInput.Native]::keybd_event($Vk, 0, $flags, [UIntPtr]::Zero)
+}
+
+function Wait-TraceEvent {
+  param([string]$Path, [string]$EventName, [int]$TimeoutMs)
+  $deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMs)
+  $pattern = '"event":"' + $EventName + '"'
+  while ([DateTime]::UtcNow -lt $deadline) {
+    try {
+      if ((Test-Path $Path) -and (Select-String -Path $Path -Pattern $pattern -SimpleMatch -Quiet)) {
+        return $true
+      }
+    } catch {
+      # 書き込み中のファイル読取り競合は無視して再試行
+    }
+    Start-Sleep -Milliseconds 200
+  }
+  return $false
+}
+
+# 既存インスタンスは single-instance 転送で smoke を汚すため停止（smoke-startup.ps1 と同じ前提）
+Get-Process snotra -ErrorAction SilentlyContinue | Stop-Process -Force
+Start-Sleep -Milliseconds 300
+
+$webviewBefore = @(Get-Process msedgewebview2 -ErrorAction SilentlyContinue).Count
+
+$errPath = Join-Path $env:TEMP "snotra_smoke_egui.err"
+$outPath = Join-Path $env:TEMP "snotra_smoke_egui.out"
+Remove-Item $errPath, $outPath -Force -ErrorAction SilentlyContinue
+
+$savedTraceEnv = $env:SNOTRA_TRACE
+$env:SNOTRA_TRACE = "1"
+$proc = Start-Process -FilePath $ExePath -PassThru -RedirectStandardError $errPath -RedirectStandardOutput $outPath
+if ($null -eq $savedTraceEnv) {
+  Remove-Item Env:SNOTRA_TRACE -ErrorAction SilentlyContinue
+} else {
+  $env:SNOTRA_TRACE = $savedTraceEnv
+}
+
+$failures = @()
+try {
+  # 起動完了（hotkey 登録含む）待ち。既定は hidden 起動（show_on_startup=false）。
+  Start-Sleep -Milliseconds $StartupWaitMs
+  if ($proc.HasExited) {
+    throw "Process exited during startup (exit code $($proc.ExitCode))"
+  }
+
+  # hotkey 注入（押下順 → 逆順で解放。Alt を含む場合、Alt up が最後に来ることで
+  # ShowAfterAltRelease〔Alt 押下中は show を最大 350ms 繰り延べる〕が解決する）
+  $vks = @($HotkeyVks -split ',' | ForEach-Object { [byte]([int]$_.Trim()) })
+  if ($vks.Count -lt 1) { throw "HotkeyVks must contain at least one VK code" }
+  foreach ($vk in $vks) {
+    Send-Key $vk
+    Start-Sleep -Milliseconds 50
+  }
+  [array]::Reverse($vks)
+  foreach ($vk in $vks) {
+    Send-Key $vk -Up
+    Start-Sleep -Milliseconds 50
+  }
+
+  if (-not (Wait-TraceEvent -Path $errPath -EventName "egui_show:done" -TimeoutMs $ObserveTimeoutMs)) {
+    $failures += "egui_show:done not observed within ${ObserveTimeoutMs}ms after hotkey ($HotkeyVks)"
+  }
+
+  # 表示中に WebView2 プロセスが増えていないこと（グローバル before/after・SU2 G4 と同じ測り方）
+  $webviewAfter = @(Get-Process msedgewebview2 -ErrorAction SilentlyContinue).Count
+  if ($webviewAfter -gt $webviewBefore) {
+    $failures += "msedgewebview2 count increased: $webviewBefore -> $webviewAfter"
+  }
+
+  if ($failures.Count -eq 0) {
+    # Escape 注入（表示中の egui 窓がフォーカスを持つ前提）
+    Send-Key $VK_ESCAPE
+    Start-Sleep -Milliseconds 50
+    Send-Key $VK_ESCAPE -Up
+
+    if (-not (Wait-TraceEvent -Path $errPath -EventName "egui_hide:done" -TimeoutMs $ObserveTimeoutMs)) {
+      $failures += "egui_hide:done not observed within ${ObserveTimeoutMs}ms after Escape"
+    }
+  }
+} finally {
+  if (-not $proc.HasExited) {
+    Stop-Process -Id $proc.Id -Force
+  }
+}
+
+if ($failures.Count -gt 0) {
+  Write-Host ""
+  Write-Host "egui smoke failed:" -ForegroundColor Red
+  foreach ($f in $failures) {
+    Write-Host " - $f" -ForegroundColor Red
+  }
+  if (Test-Path $errPath) {
+    Write-Host ""
+    Write-Host "--- trace tail ---"
+    Get-Content $errPath -Tail 40
+  }
+  exit 1
+}
+
+Write-Host ""
+Write-Host "egui smoke passed (show/hide observed, webview delta 0)." -ForegroundColor Green


### PR DESCRIPTION
## 概要

SU7 flip 実装 spec（PR #658）の **PR1: egui 自動回帰 smoke 新設**。`e2e/` 撤去（PR2）後の自動回帰の最低線を、flip より先に CI へ立てる。#567 は spec 決定 2 に基づき obsolete としてクローズ済み。

## 内容

- **`scripts/smoke-egui.ps1`**（新規）: `SNOTRA_TRACE=1` で release バイナリを起動 → keybd_event で hotkey 注入（押下順 → 逆順解放。Alt を含む場合は Alt up が最後になり ShowAfterAltRelease〔最大 350ms〕が解決）→ trace `egui_show:done` 観測 → Escape 注入 → `egui_hide:done` 観測 → `msedgewebview2` のグローバル増分 0 検証
  - `-SeedConfig`（CI 用）: config.toml 不在時のみ空 seed し first-run 経路（settings サイドカー spawn のフォーカス奪取）を回避。既存 config は決して上書きしない
  - `-HotkeyVks`（カンマ区切り VK 列・既定 "18,81" = Alt+Q）: hotkey は config 依存のため注入キーをパラメータ化（実機検証で必要と実証・下記）
- **`e2e.yml`**: `smoke-egui` job 新設。e2e job と独立の自前 release ビルド（`e2e:tauri:setup` は PR2 で消えるため依存しない）。npm build 工程は tauri context codegen が `dist/` を要するため（PR3 の frontendDist 撤去までの過渡）。`SNOTRA_EGUI_MAIN=1` は **PR2 で外して「既定が egui」自体を検証対象へ変える**（spec 決定 3）。paths 自己参照に `scripts/smoke-egui.ps1` を追加
- **`package.json`**: `smoke:egui` script
- **`docs/build-commands.md`**: カテゴリ C・コマンド一覧・E2E/スモーク運用メモ・CI 対応表へ配線（governance G5/G6 の三体結合を同一 PR で同期）

## 検証

- **ローカル実測 Red → Green**: 誤 hotkey（既定 Alt+Q vs 実機 config の Ctrl+K）で `egui_show:done not observed` の診断付き exit 1 → `-HotkeyVks "17,75"` で **passed（show/hide 観測・webview delta 0）**。release（windows_subsystem）バイナリの trace が Start-Process リダイレクトで観測できることも実証
- 実装過程の発見: trace はイベント駆動のみで**起動時は無音**（hidden 起動 + 無操作 = 0 バイトが正常）。hotkey 注入が空振りすると無出力になるため、失敗時は trace tail を診断として出力する
- `npm run governance:check` G1..G10 合格
- **CI での keybd_event 到達実測は本 PR の CI run が兼ねる**（spec リスク節。不達なら縮退案あり）

Refs: #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)
