### PR TITLE
docs: #646 2 ウィンドウ化 spec + PR1 実装計画

### DIFF
--- a/docs/superpowers/plans/2026-07-24-646-pr1-metrics-two-line-rows.md
+++ b/docs/superpowers/plans/2026-07-24-646-pr1-metrics-two-line-rows.md
@@ -1,0 +1,507 @@
+# #646 PR1: Metrics font 連動 + 結果行 2 行表示 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 固定 30px/52px の行高・バー高・toast 高を config 連動の `Metrics` 純粋核へ置き換え、結果行を 2 行表示(上段=名前・下段=パス)にする。
+
+**Architecture:** spec `docs/superpowers/specs/2026-07-24-646-two-window-ui-design.md` の決定 1・2・9。`snotra-core` の `VisualConfig` に `row_padding` / `bar_padding` を追加(serde default・無移行)し、`src-tauri/src/egui_shell/layout.rs`(純粋核・egui 非依存)に `Metrics` を新設。`view.rs` の固定値 3 箇所と `mod.rs` の show 時高さリセットを `Metrics` 経由へ置換し、`draw_result_row` を 2 行描画に書き換える。窓分離・`window_gap`・実件数フィットは **PR2 であり本計画に含まない**。
+
+**Tech Stack:** Rust / egui 0.3x(softbuffer CPU ラスタ)/ serde / TOML
+
+## Global Constraints
+
+- **main へ直接コミットしない**。作業ブランチ: `feat/646-pr1-metrics-two-line`(spec PR マージ後の main から作成)
+- bash HEREDOC 禁止。複数行コミットメッセージは PowerShell here-string `@'...'@`(閉じ `'@` は行頭)か一時ファイル + `git commit -F`
+- パス区切りは `/` で書く
+- PostToolUse hook が `.rs` 編集ごとに clippy + crate テストを自動実行する。**沈黙 = 合格**(失敗時のみ会話に届く)。ただし計画の Red/Green 確認は明示コマンドで行う
+- `--no-verify` 禁止
+- コミットメッセージ末尾: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+- 式の定数(spec 決定 2 より・変更禁止): `bar_height = font_size + bar_padding` / `path_size = max(font_size × 0.78, 9.0)` / `row_height = max(font_size + path_size + row_padding + 4.0, 24.0)` / `toast_height = bar_height`。config 既定値: `row_padding = 6`・`bar_padding = 28`
+
+---
+
+### Task 1: VisualConfig に row_padding / bar_padding を追加(snotra-core)
+
+**Files:**
+- Modify: `snotra-core/src/config.rs`(`VisualConfig` struct・`Default` impl・default fn 群・tests)
+
+**Interfaces:**
+- Produces: `VisualConfig.row_padding: u32`(既定 6)・`VisualConfig.bar_padding: u32`(既定 28)。Task 3・4 が `engine.config().visual.row_padding` 等で読む
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`snotra-core/src/config.rs` の既存 `#[cfg(test)] mod tests`(`mod tests` を grep で特定)へ追加:
+
+```rust
+    /// #646 PR1: 新キー欠落の旧 config は serde default(6/28)で読める(後方互換・移行不要)。
+    #[test]
+    fn visual_padding_defaults_for_missing_keys() {
+        let toml = r#"
+[hotkey]
+modifiers = ["alt"]
+key = "q"
+[appearance]
+[paths]
+scan_paths = []
+"#;
+        let config: Config = toml::from_str(toml).expect("parse");
+        assert_eq!(config.visual.row_padding, 6);
+        assert_eq!(config.visual.bar_padding, 28);
+        assert_eq!(VisualConfig::default().row_padding, 6);
+        assert_eq!(VisualConfig::default().bar_padding, 28);
+    }
+```
+
+注: 上の TOML fixture が「必須セクション欠落で parse 不能」にならないことを Step 2 の実行が同時に検証する(AGENTS.md 検証の作法: fixture は実行して測る)。既存テストに最小 TOML の先例があればそれを流用し、`[visual]` セクション**なし**を維持すること。
+
+- [ ] **Step 2: 落ちることを確認する(Red)**
+
+Run: `cargo test -p snotra-core visual_padding_defaults_for_missing_keys`
+Expected: FAIL(`no field row_padding` のコンパイルエラー)
+
+- [ ] **Step 3: 最小実装**
+
+`VisualConfig`(config.rs:384 付近)へフィールド追加(`custom_theme` の前):
+
+```rust
+    #[serde(default = "default_row_padding")]
+    pub row_padding: u32,
+    #[serde(default = "default_bar_padding")]
+    pub bar_padding: u32,
+```
+
+default fn 群(`default_font_size` の隣)へ:
+
+```rust
+/// #646 PR1: 行高の余白(row_height = font_size + path_size + row_padding + 4)。
+fn default_row_padding() -> u32 {
+    6
+}
+
+/// #646 PR1: バー高の余白(bar_height = font_size + bar_padding)。28 は現行 52px を
+/// 「font_size=24 でのチューニング結果」と読み直した値(24 + 28 = 52)。
+fn default_bar_padding() -> u32 {
+    28
+}
+```
+
+`impl Default for VisualConfig`(config.rs:405 付近)へ:
+
+```rust
+            row_padding: default_row_padding(),
+            bar_padding: default_bar_padding(),
+```
+
+- [ ] **Step 4: 通ることを確認する(Green)**
+
+Run: `cargo test -p snotra-core`
+Expected: 全 PASS(既存テスト含む)
+
+- [ ] **Step 5: コミット**
+
+```powershell
+git add snotra-core/src/config.rs && git commit -m @'
+feat: VisualConfig に row_padding / bar_padding を追加(#646 PR1)
+
+serde default(6/28)で旧 config 無移行。Metrics 連動式の入力になる。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+'@
+```
+
+---
+
+### Task 2: layout.rs に Metrics 純粋核を新設
+
+**Files:**
+- Modify: `src-tauri/src/egui_shell/layout.rs`(`HeightParams` の前に追加・tests 追記)
+
+**Interfaces:**
+- Consumes: なし(純関数のみ)
+- Produces: `pub fn path_size(font_size: u32) -> f64` / `pub struct Metrics { pub bar_height: f64, pub row_height: f64, pub toast_height: f64 }` / `Metrics::from_config(font_size: u32, row_padding: u32, bar_padding: u32) -> Metrics`。Task 3・4 が使う
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`layout.rs` の `#[cfg(test)] mod tests` へ追加:
+
+```rust
+    /// #646 決定 2: bar_padding=28 は font 24 で現行 52px をピクセル再現する(後方互換の要)。
+    #[test]
+    fn metrics_bar_reproduces_current_at_font24() {
+        let m = Metrics::from_config(24, 6, 28);
+        assert_eq!(m.bar_height, 52.0);
+        assert_eq!(m.toast_height, 52.0);
+    }
+
+    /// #646 決定 2・9: row_height は 2 行積算(name 行 + path 行 + 行間 4 + row_padding)。
+    #[test]
+    fn metrics_row_is_two_line_sum() {
+        let m = Metrics::from_config(15, 6, 28);
+        assert_eq!(m.bar_height, 43.0);
+        // path_size = max(15*0.78, 9) = 11.7 → 15 + 11.7 + 6 + 4 = 36.7
+        assert!((m.row_height - 36.7).abs() < 1e-9, "row={}", m.row_height);
+    }
+
+    /// #646 決定 2: 下限 24(アイコン 16px + 余白)。8 + 9 + 0 + 4 = 21 → 24 へ床上げ。
+    #[test]
+    fn metrics_row_floor_is_24() {
+        assert_eq!(Metrics::from_config(8, 0, 28).row_height, 24.0);
+    }
+
+    /// path_size は RowTheme と同係数(0.78・下限 9)。
+    #[test]
+    fn path_size_matches_row_theme_coefficient() {
+        assert_eq!(path_size(8), 9.0);
+        assert!((path_size(15) - 11.7).abs() < 1e-9);
+    }
+```
+
+- [ ] **Step 2: 落ちることを確認する(Red)**
+
+Run: `cargo test -p snotra --lib metrics_`
+Expected: FAIL(`Metrics` 未定義のコンパイルエラー)
+
+- [ ] **Step 3: 最小実装**
+
+`layout.rs` の `HeightParams` 定義の直前へ:
+
+```rust
+/// path 行のフォントサイズ(#646 決定 9)。view.rs `RowTheme::path_size` と同係数——
+/// 正本はここ(layout の Metrics が同じ値で行高を積算するため。二重定義は行高と描画の
+/// 不一致バグになる)。
+pub fn path_size(font_size: u32) -> f64 {
+    (font_size as f64 * 0.78).max(9.0)
+}
+
+/// 行高・バー高・toast 高の算出値(#646 決定 2)。config `visual` から毎フレーム導出し
+/// キャッシュしない(font_size と同じ live-read 方針)。
+pub struct Metrics {
+    /// font_size + bar_padding。既定(15+28)=43、font 24 で現行 52 を再現。
+    pub bar_height: f64,
+    /// 2 行表示(決定 9)の積算: font_size + path_size + row_padding + 行間 4。下限 24。
+    pub row_height: f64,
+    /// bar_height と同値(§20.3 の toast 行)。
+    pub toast_height: f64,
+}
+
+impl Metrics {
+    pub fn from_config(font_size: u32, row_padding: u32, bar_padding: u32) -> Self {
+        let f = font_size as f64;
+        let bar_height = f + bar_padding as f64;
+        let row_height = (f + path_size(font_size) + row_padding as f64 + 4.0).max(24.0);
+        Self { bar_height, row_height, toast_height: bar_height }
+    }
+}
+```
+
+- [ ] **Step 4: 通ることを確認する(Green)**
+
+Run: `cargo test -p snotra --lib`
+Expected: 全 PASS(`compute_window_height` の既存テストは 52.0/30.0 リテラル注入のため無変更で通る)
+
+- [ ] **Step 5: コミット**
+
+```powershell
+git add src-tauri/src/egui_shell/layout.rs && git commit -m @'
+feat: layout.rs に Metrics 純粋核を追加(#646 PR1・決定 2)
+
+bar/row/toast 高を font_size + config 余白から導出。font 24 で現行値を再現。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+'@
+```
+
+---
+
+### Task 3: view.rs — 2 行描画 + 固定値 3 箇所の Metrics 化
+
+**Files:**
+- Modify: `src-tauri/src/egui_shell/view.rs`
+  - `row_theme()`(1000 行付近)— `path_size` を layout の正本から取る
+  - 新 helper `metrics()` を `row_theme()` の隣に追加
+  - `draw_result_row`(900 行付近)— 2 行描画 + `row_h` 引数化
+  - 結果リストループ(1712-1740 付近)— 呼び出しへ `metrics` を渡す
+  - toast ブロック(1592-1638 付近)— `52.0` と y 定数を `toast_height` 比例へ
+  - `compute_window_height` 呼び出し(1750 付近)— `Metrics` 値を注入
+
+**Interfaces:**
+- Consumes: Task 1 の `visual.row_padding` / `visual.bar_padding`、Task 2 の `Metrics::from_config` / `path_size`
+- Produces: `fn metrics(&self) -> Metrics`(Task 4 は使わない。mod.rs は自前で `Metrics::from_config` を呼ぶ)
+
+- [ ] **Step 1: row_theme の path_size を layout 正本へ寄せる**
+
+`row_theme()` 内(view.rs:1015 付近):
+
+```rust
+            // 変更前: path_size: (size as f32 * 0.78).max(9.0), // WebView2 の name>path 比を踏襲
+            path_size: crate::egui_shell::layout::path_size(size) as f32, // 正本は layout(#646)
+```
+
+- [ ] **Step 2: metrics() helper を追加**
+
+`row_theme()` の直後へ:
+
+```rust
+    /// 実行中 config から Metrics を都度導出する(#646 決定 2)。row_theme と同じ
+    /// live-read 方針(キャッシュしない・config-applied wake で次フレームに反映)。
+    fn metrics(&self) -> crate::egui_shell::layout::Metrics {
+        let (f, rp, bp) = self
+            .app_handle
+            .try_state::<crate::AppState>()
+            .map(|s| {
+                let engine = s.engine.lock().unwrap();
+                let v = &engine.config().visual;
+                (v.font_size, v.row_padding, v.bar_padding)
+            })
+            .unwrap_or((15, 6, 28));
+        crate::egui_shell::layout::Metrics::from_config(f, rp, bp)
+    }
+```
+
+- [ ] **Step 3: draw_result_row を 2 行描画へ書き換える**
+
+シグネチャへ `row_h: f32` を追加し、本体の name/path 部(909-993 行付近)を置換。選択ハイライト・scroll_to_me・アイコン slot は不変:
+
+```rust
+    fn draw_result_row(
+        ui: &mut egui::Ui,
+        result: &SearchResult,
+        selected: bool,
+        scroll: bool,
+        icon: Option<&egui::TextureHandle>,
+        show_icons: bool,
+        theme: &RowTheme,
+        row_h: f32,
+    ) -> bool {
+        let (rect, response) = ui.allocate_exact_size(
+            egui::vec2(ui.available_width(), row_h),
+            egui::Sense::click(),
+        );
+        // …選択ハイライト・scroll_to_me・アイコン描画は現行のまま(row_h = 30.0 の行のみ削除)…
+
+        // 2 行表示(#646 決定 9): 上段 = 名前(全幅・末尾省略)、下段 = パス(全幅・左寄せ・
+        // 幅超過時のみ中間省略)。#632 の「name 60% 制限 + path 右寄せ + 実測幅の重なり回避」は
+        // 2 行化で name と path が幅を取り合わなくなったため廃止。
+        let text_x = rect.left() + slot;
+        let avail = (rect.right() - 8.0 - text_x).max(0.0);
+        let mut name_job = egui::text::LayoutJob::single_section(
+            result.name.clone(),
+            egui::TextFormat {
+                font_id: egui::FontId::proportional(theme.name_size),
+                color: theme.name_color,
+                ..Default::default()
+            },
+        );
+        name_job.wrap = egui::text::TextWrapping::truncate_at_width(avail);
+        let name_galley = ui.painter().layout_job(name_job);
+        // path 空(エラー行等)は名前 1 行を縦中央に単独描画
+        if result.path.is_empty() {
+            ui.painter().galley(
+                egui::pos2(text_x, rect.center().y - name_galley.size().y / 2.0),
+                name_galley,
+                theme.name_color,
+            );
+            return response.clicked();
+        }
+        let path_font = egui::FontId::proportional(theme.path_size);
+        let path_full = ui.painter().layout_no_wrap(
+            result.path.clone(),
+            path_font.clone(),
+            theme.path_color,
+        );
+        let path_str = if path_full.size().x <= avail {
+            result.path.clone()
+        } else {
+            // per-char 幅は実 galley から実測(CJK 過小評価対策・#632 の方針を継承)
+            let per_char_px = path_full.size().x / (result.path.chars().count().max(1) as f32);
+            truncate_middle(&result.path, avail, per_char_px)
+        };
+        let path_galley = ui.painter().layout_no_wrap(path_str, path_font, theme.path_color);
+        // 2 行ブロックを rect 縦中央へ(行間 4.0 は Metrics::row_height の +4.0 と対)
+        let total_h = name_galley.size().y + 4.0 + path_galley.size().y;
+        let top = rect.center().y - total_h / 2.0;
+        let name_h = name_galley.size().y;
+        ui.painter().galley(egui::pos2(text_x, top), name_galley, theme.name_color);
+        ui.painter().galley(
+            egui::pos2(text_x, top + name_h + 4.0),
+            path_galley,
+            theme.path_color,
+        );
+        response.clicked()
+    }
+```
+
+doc コメント(892-899 行)も 2 行表示の記述へ更新する(「name galley の実幅を測って path 開始 x を決める」の一文を「上段名前・下段パス。行高は Metrics::row_height(呼び出し側注入)」へ)。
+
+- [ ] **Step 4: 呼び出し側 3 箇所を Metrics 化**
+
+結果リストループ(1712 付近)— `let theme = self.row_theme();` の隣で `let metrics = self.metrics();` を取り、`draw_result_row(..., &theme)` → `draw_result_row(..., &theme, metrics.row_height as f32)`。
+
+toast ブロック(1592 付近)— `let m = self.metrics();` を取り:
+
+```rust
+            let toast_h = m.toast_height as f32;
+            let (rect, _) = ui.allocate_exact_size(
+                egui::vec2(ui.available_width(), toast_h),
+                egui::Sense::hover(),
+            );
+```
+
+行 1 の y `rect.top() + 13.0` → `rect.top() + toast_h * 0.25`、ボタンの `btn_y = rect.top() + 39.0` → `rect.top() + toast_h * 0.75`(52px 時の 13/39 と同比率)。
+
+`compute_window_height` 呼び出し(1750 付近):
+
+```rust
+        let m = self.metrics();
+        let height = compute_window_height(&HeightParams {
+            show_results,
+            max_results: self.max_results(),
+            has_update_toast: has_toast,
+            search_bar_height: m.bar_height,
+            result_row_height: m.row_height,
+            results_padding: 8.0,
+            update_toast_height: m.toast_height,
+        });
+```
+
+(toast ブロックの `m` とスコープが切れているため再取得。engine lock は毎フレーム複数回取得が既存パターン——`row_theme` / `show_icons` と同じ。)
+
+- [ ] **Step 5: ビルドとテストが通ることを確認する**
+
+Run: `cargo clippy -p snotra --all-targets -- -D warnings` → 警告 0
+Run: `cargo test -p snotra --lib` → 全 PASS
+(PostToolUse hook の沈黙も同じ検査の合格を意味する)
+
+- [ ] **Step 6: コミット**
+
+```powershell
+git add src-tauri/src/egui_shell/view.rs && git commit -m @'
+feat: 結果行を 2 行表示にし固定高 3 箇所を Metrics 連動へ(#646 PR1・決定 2/9)
+
+- draw_result_row: 上段名前(末尾省略)・下段パス(全幅・超過時のみ中間省略)。
+  #632 の name60%/右寄せ/重なり回避の座標計算は 2 行化で廃止
+- toast 行と compute_window_height を Metrics(bar/row/toast)経由に
+- RowTheme::path_size の係数は layout::path_size を正本に
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+'@
+```
+
+---
+
+### Task 4: mod.rs — show 時の高さリセットを bar_height へ
+
+**Files:**
+- Modify: `src-tauri/src/egui_shell/mod.rs:196-209`(`show_egui_main` の高さリセット)と `create()` の `inner_size` コメント(169 行付近)
+
+**Interfaces:**
+- Consumes: Task 1 の config キー・Task 2 の `Metrics::from_config`
+
+- [ ] **Step 1: 高さリセットを Metrics 化**
+
+`show_egui_main` の `set_size` ブロック(201-209 行)を置換:
+
+```rust
+    #[cfg(windows)]
+    {
+        let width = window
+            .inner_size()
+            .ok()
+            .map(|s| s.to_logical::<f64>(window.scale_factor().unwrap_or(1.0)).width)
+            .unwrap_or(600.0);
+        // 折りたたみ高 = bar_height(#646 決定 2)。52 固定だと font 連動後の実バー高と
+        // ずれ、position クランプが誤った高さで効く(コメント 196-200 行の機構と同じ理由)。
+        let bar_h = app
+            .try_state::<crate::AppState>()
+            .map(|s| {
+                let engine = s.engine.lock().unwrap();
+                let v = &engine.config().visual;
+                layout::Metrics::from_config(v.font_size, v.row_padding, v.bar_padding).bar_height
+            })
+            .unwrap_or(52.0);
+        let _ = window.set_size(tauri::LogicalSize::new(width, bar_h));
+    }
+```
+
+`layout` が `mod.rs` スコープに無ければ `use` 追記ではなく `crate::egui_shell::layout::Metrics` のフル修飾で書く(既存の修飾スタイルに合わせる)。196-200 行の既存コメント内の「52px」表現は「bar_height(既定 43px)」へ更新。`create()` の `.inner_size(window_width, 52.0)` は**据え置き**(visible:false の初期値で、初回 show が正すため)——ただしコメントへ「初期値。実高は show 時に Metrics で再設定(#646)」を追記。
+
+- [ ] **Step 2: ビルドとテストを確認する**
+
+Run: `cargo clippy -p snotra --all-targets -- -D warnings` → 警告 0
+Run: `cargo test -p snotra --lib` → 全 PASS
+
+- [ ] **Step 3: コミット**
+
+```powershell
+git add src-tauri/src/egui_shell/mod.rs && git commit -m @'
+feat: show 時の折りたたみ高を bar_height 連動に(#646 PR1)
+
+52 固定のままだと font 連動後の実バー高とずれ、position クランプが誤差で効く。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+'@
+```
+
+---
+
+### Task 5: SPEC.md 同期(仕様変更の文書化)
+
+**Files:**
+- Modify: `SPEC.md:183`(show 時リセット)・`SPEC.md:513`(結果行 1 行表示)・`SPEC.md:517`(バー高 52px 固定)・`SPEC.md:1015-1023`(§20.3 toast 高)
+
+**Interfaces:** なし(文書のみ)
+
+- [ ] **Step 1: 4 箇所を as-built へ同期**
+
+行番号はドリフトしうるため**引用文で grep してから**編集する:
+
+1. 「show 時に毎回検索バー高さ(52px)にリセット」→「show 時に毎回検索バー高さ(`font_size + bar_padding`・既定 43px)にリセットしてから結果に応じて拡張する(#646)」
+2. 「検索結果はフルパスの1行表示」→「検索結果は 2 行表示: 上段 = 表示名(`font_size`・末尾省略)、下段 = フルパス(`font_size × 0.78`・左寄せ・幅超過時のみ中間省略)(#646)」
+3. 「**検索バー高さは 52px 固定**(font_size 非連動の as-built。行高との連動は #646)」→「検索バー高さは `font_size + bar_padding`(既定 15+28=43px)、結果行高は `font_size + path行 + row_padding + 4`(下限 24px)。`row_padding` / `bar_padding` は `[visual]` の config キー(既定 6 / 28・#646)」
+4. §20.3 の「高さ 52px(2行 × 26px)」および「`--update-toast-height` (52px) を加算」「検索バー直下の 52px 行」→ toast 高は `bar_height` と同値(既定 43px)に連動する旨へ(3 文とも。行内の y 配置は高さ比 0.25 / 0.75)
+
+- [ ] **Step 2: governance:check を実行する**
+
+Run: `npm run governance:check`
+Expected: PASS(SPEC § 参照の整合。`*.md` は hook 検査対象外——沈黙は「何も走らなかった」なので明示実行が必須)
+
+- [ ] **Step 3: コミット**
+
+```powershell
+git add SPEC.md && git commit -m @'
+docs: SPEC を Metrics 連動 + 2 行表示の as-built へ同期(#646 PR1)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+'@
+```
+
+---
+
+### Task 6: スモーク検証 + PR 作成
+
+**Files:** なし(検証と PR のみ)
+
+- [ ] **Step 1: egui スモークを実行する**
+
+Run: `npm run smoke:egui`(コマンド実体は `docs/build-commands.md` カテゴリ C を参照)
+Expected: PASS(trace イベント名・hotkey 前提は本 PR で不変)
+
+- [ ] **Step 2: 実機 GUI スモーク(人間ペア)**
+
+ユーザーに依頼: 起動して次を目視 — (a) 既定 font 15 でバー 43px・結果行 2 行(上段名前・下段パス)になっている (b) config.toml の `font_size = 24` でバーが従来と同じ 52px(バー/toast のみのピクセル一致が受け入れ条件・spec 決定 8) (c) `row_padding` / `bar_padding` を書き換えて保存すると再起動なしで反映 (d) toast(`SNOTRA_EGUI_FAKE_UPDATE` の既存流儀)で 2 ボタンが枠内に収まる
+
+- [ ] **Step 3: push して PR を作る**
+
+```powershell
+git push -u origin HEAD && gh pr create --title "#646 PR1: Metrics font 連動 + 結果行 2 行表示" --body-file <一時ファイル>
+```
+
+PR 本文の注意(ルート CLAUDE.md「Git/GitHub 運用」): closing keyword を書かない(`Refs #646` のみ。#646 は PR2 まで OPEN を保つ)。マージ直前に `gh pr view <PR> --json closingIssuesReferences` で閉じる issue が空であることを確認する。
+
+---
+
+## Self-Review(記入済み)
+
+- **Spec coverage**: 決定 1(PR 分割)= 本計画が PR1 のみ担当 ✓ / 決定 2(Metrics + config 2 キー。`window_gap` は PR2)= Task 1・2 ✓ / 決定 9(2 行表示)= Task 3 ✓ / 決定 8 の PR1 受け入れ条件(バー/toast ピクセル一致・行は目視)= Task 6 Step 2 ✓ / SPEC 同期 = Task 5(spec の「計画時に grep で確定」を果たした: 183・513・517・1015-1023)✓
+- **Placeholder scan**: TBD/TODO なし。全コードブロックは実体 ✓
+- **Type consistency**: `Metrics::from_config(u32, u32, u32)` を Task 2 で定義し Task 3・4 が同名同型で消費 ✓ / `path_size(u32) -> f64` を Task 2 で定義し Task 3 Step 1 が `as f32` で消費 ✓ / `draw_result_row` の追加引数 `row_h: f32` と呼び出し側 `metrics.row_height as f32` ✓

--- a/docs/superpowers/plans/2026-07-24-646-pr1-metrics-two-line-rows.md
+++ b/docs/superpowers/plans/2026-07-24-646-pr1-metrics-two-line-rows.md
@@ -38,11 +38,11 @@
     fn visual_padding_defaults_for_missing_keys() {
         let toml = r#"
 [hotkey]
-modifiers = ["alt"]
+modifier = "alt"
 key = "q"
 [appearance]
+window_width = 600
 [paths]
-scan_paths = []
 "#;
         let config: Config = toml::from_str(toml).expect("parse");
         assert_eq!(config.visual.row_padding, 6);
@@ -52,7 +52,7 @@ scan_paths = []
     }
 ```
 
-注: 上の TOML fixture が「必須セクション欠落で parse 不能」にならないことを Step 2 の実行が同時に検証する(AGENTS.md 検証の作法: fixture は実行して測る)。既存テストに最小 TOML の先例があればそれを流用し、`[visual]` セクション**なし**を維持すること。
+注: 必須フィールドは plan-review で実測済み — `hotkey.modifier`(**単数形**・serde default 無し・config.rs:104-107)と `appearance.window_width`(config.rs:308)。`[paths]` は空セクションでよい(`scan`/`additional` とも serde default 持ち)。先例は `deserialize_full_config`(config.rs:1122)。`[visual]` セクション**なし**を維持すること(このテストの主眼)。
 
 - [ ] **Step 2: 落ちることを確認する(Red)**
 
@@ -317,6 +317,17 @@ Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
             truncate_middle(&result.path, avail, per_char_px)
         };
         let path_galley = ui.painter().layout_no_wrap(path_str, path_font, theme.path_color);
+        // 鏡像ケース(folder 列挙エラー行・snotra-core/src/folder.rs の error_result は
+        // name 空・path 非空): 上段を空白にせず path 1 行を縦中央に単独描画
+        //(上の path 空分岐と対称・plan-review scout-egui 指摘)。
+        if result.name.is_empty() {
+            ui.painter().galley(
+                egui::pos2(text_x, rect.center().y - path_galley.size().y / 2.0),
+                path_galley,
+                theme.path_color,
+            );
+            return response.clicked();
+        }
         // 2 行ブロックを rect 縦中央へ(行間 4.0 は Metrics::row_height の +4.0 と対)
         let total_h = name_galley.size().y + 4.0 + path_galley.size().y;
         let top = rect.center().y - total_h / 2.0;
@@ -365,6 +376,13 @@ toast ブロック(1592 付近)— `let m = self.metrics();` を取り:
 ```
 
 (toast ブロックの `m` とスコープが切れているため再取得。engine lock は毎フレーム複数回取得が既存パターン——`row_theme` / `show_icons` と同じ。)
+
+さらに**虚偽化するコメント 2 箇所を同時更新する**(plan-review scout-egui / 独立導出の一致指摘):
+
+- `view.rs:1482-1487`「**バー高さ 52px は据え置く**…(SU6.5 決定 3)」→「#646 決定 2: バー高は `font_size + bar_padding`(Metrics)。SU6.5 決定 3 の 52px 据え置きは WebView2 parity 制約下の判断で、SU7 の WebView2 撤去により失効」の旨へ書き換え
+- `view.rs:1448` 付近「window は 52px のまま」→「window は bar_height のまま」へ
+
+**注意(独立導出の警告)**: `bar_padding` 既定 28 とアイコン slot 幅 `28.0`(view.rs:924)は**無関係な偶然の一致**。grep 置換の対象にしないこと。`view.rs:207` の `last_set_height: 52.0` 初期値は据え置き(初回フレームの diff 検知で是正される設計・view.rs:1759-1760 コメントに明記)。indexing overlay の `FontId 15.0`(view.rs:1587)は pre-existing の別軸でスコープ外(PR 本文に follow-up 候補として記す)。
 
 - [ ] **Step 5: ビルドとテストが通ることを確認する**
 
@@ -447,7 +465,9 @@ Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
 ### Task 5: SPEC.md 同期(仕様変更の文書化)
 
 **Files:**
-- Modify: `SPEC.md:183`(show 時リセット)・`SPEC.md:513`(結果行 1 行表示)・`SPEC.md:517`(バー高 52px 固定)・`SPEC.md:1015-1023`(§20.3 toast 高)
+- Modify: `SPEC.md:183`(show 時リセット)・`SPEC.md:513-514`(結果行 1 行表示 + 中間省略の子 bullet)・`SPEC.md:517`(バー高 52px 固定)・`SPEC.md:1015-1023`(§20.3 toast 高)
+- Modify: `docs/architecture.md:89`(show 時 52px リセット)・`docs/architecture.md:147`(トースト 52px)— plan-review で scout-docs と独立導出が独立に一致した漏れ
+- Modify: `src-tauri/CLAUDE.md`「show の操作順序制約」節(「高さリセット(52px)」の具体値)— 規範文書は自動配送されないため見出し語で grep して特定する
 
 **Interfaces:** なし(文書のみ)
 
@@ -456,9 +476,12 @@ Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
 行番号はドリフトしうるため**引用文で grep してから**編集する:
 
 1. 「show 時に毎回検索バー高さ(52px)にリセット」→「show 時に毎回検索バー高さ(`font_size + bar_padding`・既定 43px)にリセットしてから結果に応じて拡張する(#646)」
-2. 「検索結果はフルパスの1行表示」→「検索結果は 2 行表示: 上段 = 表示名(`font_size`・末尾省略)、下段 = フルパス(`font_size × 0.78`・左寄せ・幅超過時のみ中間省略)(#646)」
+2. 「検索結果はフルパスの1行表示」→「検索結果は 2 行表示: 上段 = 表示名(`font_size`・末尾省略)、下段 = フルパス(`font_size × 0.78`・左寄せ・幅超過時のみ中間省略)(#646)」。**直下の子 bullet(SPEC.md:514「長いパスは中間セグメント省略…」)は置換文と内容重複するため統合し、515(フォルダ末尾 `\` 区別)は残す**(scout-docs 指摘)
 3. 「**検索バー高さは 52px 固定**(font_size 非連動の as-built。行高との連動は #646)」→「検索バー高さは `font_size + bar_padding`(既定 15+28=43px)、結果行高は `font_size + path行 + row_padding + 4`(下限 24px)。`row_padding` / `bar_padding` は `[visual]` の config キー(既定 6 / 28・#646)」
 4. §20.3 の「高さ 52px(2行 × 26px)」および「`--update-toast-height` (52px) を加算」「検索バー直下の 52px 行」→ toast 高は `bar_height` と同値(既定 43px)に連動する旨へ(3 文とも。行内の y 配置は高さ比 0.25 / 0.75)
+5. `docs/architecture.md`: 「show 時に 52px へリセット」(89 行付近)→「show 時に bar_height(`font_size + bar_padding`・既定 43px)へリセット」、「トースト UI は…52px で表示」(147 行付近)→「bar_height と同高で表示」
+6. `src-tauri/CLAUDE.md`「show の操作順序制約」: 「高さリセット(52px)」→「高さリセット(bar_height・既定 43px)」(順序制約自体は不変)
+7. SPEC §11 の管理項目列挙(509-511 行)への `row_padding` / `bar_padding` 追記は**しない** — あの列挙は GUI 設定タブの項目一覧であり、新キーは GUI 非露出(scout-docs の裏取りで確定)
 
 - [ ] **Step 2: governance:check を実行する**
 
@@ -468,8 +491,8 @@ Expected: PASS(SPEC § 参照の整合。`*.md` は hook 検査対象外——�
 - [ ] **Step 3: コミット**
 
 ```powershell
-git add SPEC.md && git commit -m @'
-docs: SPEC を Metrics 連動 + 2 行表示の as-built へ同期(#646 PR1)
+git add SPEC.md docs/architecture.md src-tauri/CLAUDE.md && git commit -m @'
+docs: SPEC/architecture/CLAUDE.md を Metrics 連動 + 2 行表示の as-built へ同期(#646 PR1)
 
 Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
 '@

--- a/docs/superpowers/specs/2026-07-24-646-two-window-ui-design.md
+++ b/docs/superpowers/specs/2026-07-24-646-two-window-ui-design.md
@@ -11,7 +11,7 @@ brainstorm で issue 本文の「3 ウィンドウ構成」を **2 窓構成に�
 
 ## スコープ
 
-**含む**: メトリクス(行高・バー高・toast 高)の font_size 連動化 + 結果行の 2 行表示化(名前 + パス・決定 9)(PR1)/ 結果リストの独立窓化・透明ギャップ・DWM 角丸と影・実件数フィット(PR2)/ 新 config キー 3 つ(`window_gap` / `row_padding` / `bar_padding`)。
+**含む**: メトリクス(行高・バー高・toast 高)の font_size 連動化 + 結果行の 2 行表示化(名前 + パス・決定 9)(PR1)/ 結果リストの独立窓化・透明ギャップ・DWM 角丸と影・実件数フィット・メイン窓のドラッグ移動(決定 10)(PR2)/ 新 config キー 3 つ(`window_gap` / `row_padding` / `bar_padding`)。
 
 **含まない**: トーストの別窓化(メイン同一窓を維持)/ 新キーの設定 UI(`snotra-settings`)露出(config.toml 直編集で調整・露出は後続 issue)/ 角丸半径の config 化(DWM 管理ゆえ指定不可)/ テーマ・配色の変更。
 
@@ -86,12 +86,22 @@ pub struct Metrics {
 - 1 行モードは設けない(config キー化しない・YAGNI。要望が出たら後続 issue)
 - 行高は決定 2 の式(`font_size + path_size + row_padding + 4`)。実装は PR1(`draw_result_row` と `Metrics` は同じ変更単位)
 
+### 決定 10: メイン窓は入力欄以外の全域でドラッグ移動できる
+
+`decorations: false` ゆえ OS の掴める枠が無い。tauri `Window::start_dragging()`(tao `drag_window` → ネイティブ移動ループ)で移動を実装する。
+
+- **掴み領域 = メイン窓の「ウィジェットでない」全域**: バーの余白(左右パディング・上下の隙間)と toast の背景部。入力欄(クリック = キャレット・ドラッグ = テキスト選択)・toast ボタン・結果行は従来の操作を保つ。egui 側は「pointer press がどのウィジェットにも hit していない + ドラッグ開始」を検出して `start_dragging()` を呼ぶ
+- **結果窓の追従**: ドラッグ中はネイティブ移動ループが回り egui フレームが止まるため、results の毎フレーム突き合わせ(決定 6)は効かない。tao の `Moved` イベントで results の位置更新を wake する(イベント駆動 wake 規範の適用)。それでも追従が視覚的に許容できない場合のフォールバックは「ドラッグ中 results を hide し、drop で再表示」
+- **位置永続との整合**: 手動移動後の位置が既存の位置永続(`window.bin`)・`position_on_target_monitor`(show 時の配置)とどう合流するかを計画時に確認する——移動先を記憶するか、次回 show で従来配置に戻るかを既存機構の実装に合わせて決める
+- 実装は PR2(結果窓の追従と同じ変更単位で検証するため)
+
 ## リスク・実装時に実測で確定する点
 
 1. tauri `Window::builder` に `WS_EX_NOACTIVATE` を直接指定する API が無い場合、生成後に `SetWindowLongPtrW(GWL_EXSTYLE)` で付与する(windows クレート v0.62 での API 形状・feature フラグ `Win32_Graphics_Dwm` / `Win32_UI_WindowsAndMessaging` を実装前に確認——`src-tauri/CLAUDE.md` の規律)
 2. tauri `show()` が活性化を伴う場合の非活性表示(決定 4 の SW_SHOWNOACTIVATE フォールバック)
 3. DWM 角丸は Windows 11 専用(`DWMWA_WINDOW_CORNER_PREFERENCE` は build 22000+)。Windows 10 では角のまま=装飾なしで受容(機能影響なし)
 4. 2 窓とも同一イベントループスレッドで `update()` が走る(runtime は窓ごと状態を `HashMap` 管理・`runtime.rs`)。スナップショットの `Mutex` は同一スレッド内の順次アクセスが基本で競合は薄いが、`/race-check` で worker スレッド(icon/folder load)からの wake 経路を検証する
+5. `start_dragging()` のネイティブ移動ループがイベントループを占有する間の挙動(ドラッグ中の再描画停止・`Moved` イベントの配送粒度・blur 誤発火の有無)。「メッセージポンプが 1 イテレーション内で停止」系のデッドロック不変条件(`src-tauri/CLAUDE.md`)に抵触しないかを実測で確定する
 
 ## SPEC 同期対象
 
@@ -99,3 +109,4 @@ pub struct Metrics {
 - §11(視覚): 固定 30px/52px の記載箇所を計画時に grep で数え上げ、連動式(`font_size + padding`)へ同期・`window_gap` / `row_padding` / `bar_padding` キーの追加
 - §20.3(updater toast): toast 高が `bar_height` 連動になる旨(位置・挙動は不変)
 - 結果行レイアウトの記載箇所(name/path の 1 行併記・右寄せを記す §): 2 行表示へ(該当 § は計画時に grep で確定)
+- ウィンドウ操作の節(表示・非表示・位置を記す §): ドラッグ移動(決定 10)を追記(仕様追加。該当 § は計画時に grep で確定)

--- a/docs/superpowers/specs/2026-07-24-646-two-window-ui-design.md
+++ b/docs/superpowers/specs/2026-07-24-646-two-window-ui-design.md
@@ -11,7 +11,7 @@ brainstorm で issue 本文の「3 ウィンドウ構成」を **2 窓構成に�
 
 ## スコープ
 
-**含む**: メトリクス(行高・バー高・toast 高)の font_size 連動化(PR1)/ 結果リストの独立窓化・透明ギャップ・DWM 角丸と影・実件数フィット(PR2)/ 新 config キー 3 つ(`window_gap` / `row_padding` / `bar_padding`)。
+**含む**: メトリクス(行高・バー高・toast 高)の font_size 連動化 + 結果行の 2 行表示化(名前 + パス・決定 9)(PR1)/ 結果リストの独立窓化・透明ギャップ・DWM 角丸と影・実件数フィット(PR2)/ 新 config キー 3 つ(`window_gap` / `row_padding` / `bar_padding`)。
 
 **含まない**: トーストの別窓化(メイン同一窓を維持)/ 新キーの設定 UI(`snotra-settings`)露出(config.toml 直編集で調整・露出は後続 issue)/ 角丸半径の config 化(DWM 管理ゆえ指定不可)/ テーマ・配色の変更。
 
@@ -28,12 +28,12 @@ PR1 は 1 窓のまま固定値を連動式へ置き換える。目に見える�
 ```rust
 pub struct Metrics {
     pub bar_height: f64,    // font_size + bar_padding
-    pub row_height: f64,    // max(font_size + row_padding, 24.0)  下限はアイコン 16px + 余白
+    pub row_height: f64,    // max(font_size + path_size + row_padding + 4.0, 24.0)  2 行表示(決定 9)
     pub toast_height: f64,  // bar_height と同値
 }
 ```
 
-- **加算式の意味**: 現行固定値を「font_size=24 でチューニングされた結果」と読み直したもの。既定 `bar_padding=28` / `row_padding=6` のとき font 24 で 52 / 30 となり**現行とピクセル一致**(font 24 利用者には無変化)。既定 font 15 では 43 / 24 に締まる
+- **加算式の意味**: `bar_padding` は現行バー高を「font_size=24 でチューニングされた結果」と読み直したもの——既定 28 のとき font 24 で 52 となり**現行とピクセル一致**。`row_height` は 2 行表示(決定 9)の積算: name 行(`font_size`)+ path 行(`path_size = max(font_size × 0.78, 9)`・`RowTheme` と同係数)+ 行間 4 + `row_padding`。既定(font 15・row_padding 6)で約 37px。下限 24 はアイコン 16px + 余白の安全床
 - **config キー**(`[visual]`・すべて `#[serde(default = ...)]` で旧 config は既定値のまま読める=移行不要):
   - `window_gap: u32 = 4` — メイン窓と結果窓の隙間 px(PR2 で使用。モックアップ確認で 8 → 4 に決定)
   - `row_padding: u32 = 6`
@@ -75,7 +75,16 @@ pub struct Metrics {
 - **ユニット**: `Metrics` の式・下限・config 反映(layout.rs)/ 実件数フィットの高さ算出 / スナップショット述語
 - **skill**: `/plan-review`(計画後)・`/state-check`(results 可視性という新ガード条件・reset-on-show との相互作用)・`/race-check`(スナップショット共有・クリック逆流の await/フレーム間競合)・`/persistence-check`(config 3 キーの後方互換)
 - **smoke**: `scripts/smoke-egui.ps1` の前提(trace イベント名・hotkey)が壊れないか確認。実機 GUI smoke で 2 窓の従属(位置・ギャップ・フォーカス非奪取・toast 出没時の追従)と DWM 角丸を目視
-- **PR1 の後方互換の要**: font_size=24 でスクリーンショット比較(ピクセル一致が受け入れ条件)
+- **PR1 の後方互換の要**: バーと toast は font_size=24 のスクリーンショット比較でピクセル一致(`bar_height` の式が現行を再現する証拠)。結果行は 2 行化(決定 9)で**意図的に変わる**ため一致比較の対象外——目視で新レイアウト(上段名前・下段パス・全幅)を確認する
+
+### 決定 9: 結果行は 2 行表示(名前 + パス)を既定にする
+
+モックアップの 2 行トグルを目視して決定(2026-07-24)。
+
+- 上段 = 名前(`font_size`・`text_color`)、下段 = パス(`path_size`・`hint_text_color`・**左寄せ**)。アイコン 16px は 2 行ぶんの左に縦中央
+- パスが行の全幅を使えるため、中間省略(`truncate_middle`)は幅超過時のフォールバックに退く。#632 で入れた「name 60% 制限 + path 右寄せ + 実測幅による重なり回避」の座標計算は**廃止**——2 行化で name と path が幅を取り合わなくなり、描画コードは単純になる
+- 1 行モードは設けない(config キー化しない・YAGNI。要望が出たら後続 issue)
+- 行高は決定 2 の式(`font_size + path_size + row_padding + 4`)。実装は PR1(`draw_result_row` と `Metrics` は同じ変更単位)
 
 ## リスク・実装時に実測で確定する点
 
@@ -89,3 +98,4 @@ pub struct Metrics {
 - §4.5(動的ウィンドウ高さ): 実件数フィット + 2 窓構成へ
 - §11(視覚): 固定 30px/52px の記載箇所を計画時に grep で数え上げ、連動式(`font_size + padding`)へ同期・`window_gap` / `row_padding` / `bar_padding` キーの追加
 - §20.3(updater toast): toast 高が `bar_height` 連動になる旨(位置・挙動は不変)
+- 結果行レイアウトの記載箇所(name/path の 1 行併記・右寄せを記す §): 2 行表示へ(該当 § は計画時に grep で確定)

--- a/docs/superpowers/specs/2026-07-24-646-two-window-ui-design.md
+++ b/docs/superpowers/specs/2026-07-24-646-two-window-ui-design.md
@@ -35,7 +35,7 @@ pub struct Metrics {
 
 - **加算式の意味**: 現行固定値を「font_size=24 でチューニングされた結果」と読み直したもの。既定 `bar_padding=28` / `row_padding=6` のとき font 24 で 52 / 30 となり**現行とピクセル一致**(font 24 利用者には無変化)。既定 font 15 では 43 / 24 に締まる
 - **config キー**(`[visual]`・すべて `#[serde(default = ...)]` で旧 config は既定値のまま読める=移行不要):
-  - `window_gap: u32 = 8` — メイン窓と結果窓の隙間 px(PR2 で使用)
+  - `window_gap: u32 = 4` — メイン窓と結果窓の隙間 px(PR2 で使用。モックアップ確認で 8 → 4 に決定)
   - `row_padding: u32 = 6`
   - `bar_padding: u32 = 28`
 - 3 キーとも `font_size` と同じ**毎フレーム live-read**(`row_theme()` と同じ読み取りで `Metrics` を導出。新しい保持状態は作らない)。config 保存 → `config-applied` wake → 即反映

--- a/docs/superpowers/specs/2026-07-24-646-two-window-ui-design.md
+++ b/docs/superpowers/specs/2026-07-24-646-two-window-ui-design.md
@@ -1,0 +1,91 @@
+# #646: egui UI の 2 ウィンドウ化 + メトリクス font 連動 設計
+
+日付: 2026-07-24 / 対象: #646「egui 版のUIを整える」 / 先行: #532 SU7(flip 3 部作完了・WebView2 完全撤去済み・PR #662)
+brainstorm で issue 本文の「3 ウィンドウ構成」を **2 窓構成に確定**した(決定 3)。
+
+## 背景と言語化
+
+- SU6.5 の外観目視(G2)で「固定行高 30px / バー高 52px は font_size=24 前提のチューニングであり、既定の 15 では間延びする」が設計課題として挙がった(#646 コメント)。SU6.5 #643 は parity 制約(WebView2 も固定値)ゆえバー高を据え置いたが、**SU7 で WebView2 が消滅し parity 制約は存在しない**。固定高を font 連動へ改める自由がある
+- issue 本文の 3 窓案(トースト / メイン / 検索結果)のうち、トーストは issue 自身が「実態は 1 ウィンドウでもいいのか」と未決だった。brainstorm でトーストはメイン同一窓と決定し、2 窓構成になった
+- ユーザーが窓分離で得たいものは 3 点: **バーと結果の間の透明ギャップ**(Raycast/PowerToys Run 風)・**角丸と影の輪郭表現**・**伸縮挙動の分離**(バーは常に同じ形・同じ位置)
+
+## スコープ
+
+**含む**: メトリクス(行高・バー高・toast 高)の font_size 連動化(PR1)/ 結果リストの独立窓化・透明ギャップ・DWM 角丸と影・実件数フィット(PR2)/ 新 config キー 3 つ(`window_gap` / `row_padding` / `bar_padding`)。
+
+**含まない**: トーストの別窓化(メイン同一窓を維持)/ 新キーの設定 UI(`snotra-settings`)露出(config.toml 直編集で調整・露出は後続 issue)/ 角丸半径の config 化(DWM 管理ゆえ指定不可)/ テーマ・配色の変更。
+
+## 決定事項
+
+### 決定 1: PR は 2 段(PR1 = メトリクス連動、PR2 = 窓分離)
+
+PR1 は 1 窓のまま固定値を連動式へ置き換える。目に見える改善(既定 font 15 の間延び解消)を先に届け、窓分離のリスクを PR2 に隔離する。PR2 は PR1 の `Metrics` を前提に窓を分ける。
+
+### 決定 2: `Metrics` 純粋核 + config 3 キー(live-read)
+
+`layout.rs`(純粋核・ユニットテスト対象)に新設:
+
+```rust
+pub struct Metrics {
+    pub bar_height: f64,    // font_size + bar_padding
+    pub row_height: f64,    // max(font_size + row_padding, 24.0)  下限はアイコン 16px + 余白
+    pub toast_height: f64,  // bar_height と同値
+}
+```
+
+- **加算式の意味**: 現行固定値を「font_size=24 でチューニングされた結果」と読み直したもの。既定 `bar_padding=28` / `row_padding=6` のとき font 24 で 52 / 30 となり**現行とピクセル一致**(font 24 利用者には無変化)。既定 font 15 では 43 / 24 に締まる
+- **config キー**(`[visual]`・すべて `#[serde(default = ...)]` で旧 config は既定値のまま読める=移行不要):
+  - `window_gap: u32 = 8` — メイン窓と結果窓の隙間 px(PR2 で使用)
+  - `row_padding: u32 = 6`
+  - `bar_padding: u32 = 28`
+- 3 キーとも `font_size` と同じ**毎フレーム live-read**(`row_theme()` と同じ読み取りで `Metrics` を導出。新しい保持状態は作らない)。config 保存 → `config-applied` wake → 即反映
+- `view.rs` の固定値 3 箇所(`draw_result_row` の `row_h = 30.0`・toast 行の `52.0`・`compute_window_height` 引数)を `Metrics` 経由へ置換し、直書きを消滅させる
+
+### 決定 3: トーストはメイン同一窓(2 窓構成)
+
+窓は "main"(バー + toast)と "results"(結果リスト)の 2 つ。toast の見た目の境界は描画(背景色差・区切り)で作る。窓数を増やさないことでフォーカス判定・位置同期の複雑さを持ち込まない。
+
+### 決定 4: 結果窓は「フォーカスを取らない従属窓」+ DWM 角丸
+
+- "results" は setup で生成(**窓生成は setup 限定**の不変条件を維持・`src-tauri/CLAUDE.md`)し、`WS_EX_NOACTIVATE` 拡張スタイルでクリックしてもアクティベーションを辞退する。キーボードフォーカスは常にメイン窓の入力欄にあり、**`blur_should_hide` の純粋核は無改修**(フォーカスを持ちうる窓が従来どおり "main" だけ)
+- 表示も非活性(show がフォーカスを奪わないこと。tauri `show()` が内部で活性化する場合は Win32 `ShowWindow(SW_SHOWNOACTIVATE)` へ落とす——実装時に実測で確定)
+- 角丸と影は DWM `DwmSetWindowAttribute(DWMWA_WINDOW_CORNER_PREFERENCE, Round)` に委ねる(Windows 11)。softbuffer は AA を持たず自前角丸は品質が出ない——ネイティブ機構優先。メイン窓にも同じ角丸を適用して 2 窓の輪郭言語を揃える
+- 却下案: (B) 結果窓もフォーカス可能 + 合成フォーカス hide 判定——窓間フォーカス移動の過渡(両方 false)をデバウンスで吸う必要があり誤 hide の温床。現在の結果窓操作はクリックとホイールのみでフォーカス不要。(C) 1 窓 + レイヤードウィンドウ透過——softbuffer はアルファ合成前提でなく、ギャップのクリック透過も得られない
+
+### 決定 5: 状態は「main が所有・results は写しを描く」一方向フロー
+
+- `SearchWindowView`(main)が検索状態の所有者のまま。毎フレーム、描画用スナップショット(結果行・選択位置・view_kind・indexing 表示状態)を `Arc<Mutex<RowsSnapshot>>` へ発行する
+- 新設 `ResultsView`("results" の `EguiView`)はスナップショットを読んで描くだけ。行クリックは index を共有スロットへ積み、main の `egui::Context` を `request_repaint()` で起こして **main 側が起動処理**する(起動ロジックを一箇所に保つ)。既存 `ToastAction` の遅延 dispatch と同型
+- 選択移動(↑↓)は main が受け、スナップショット更新後に results の ctx を wake。**「paint 後に状態を変えたら repaint」規範(`src-tauri/CLAUDE.md` egui_shell 節)を窓間に拡張**した形——どちらかの窓の状態に触れたら、その窓の ctx を起こす
+- `icon_textures` はテクスチャが egui Context(= 窓の renderer)従属のため `ResultsView` へ移管。main はアイコンを描かない
+- indexing 中の案内 overlay・instant/folder 行・`scroll_to_me` は描画ごと results 窓へ移動(挙動不変)
+
+### 決定 6: 位置とライフサイクルは main 起点の従属
+
+- results の位置 = `main.outer_position + main 高さ + window_gap`。results view が毎フレーム突き合わせ、ずれたときだけ `set_position`(`last_set_height` と同型のデルタガード)。toast の出没でメインが伸びれば自然に追従する
+- 可視性: `show_results`(結果があり、かつ plain 非表示条件に当たらない)が true なら表示・false なら hide。メイン窓の高さは `bar_height (+ toast_height)` のみで、**結果による伸縮はしなくなる**
+- hide は現行 `hide_egui_main` 合流点で**両窓を隠す**(working set trim も同じ合流点のまま)。show は main のみ能動表示し、results は次フレームの `show_results` 判定に従う(reset-on-show でクエリ空 = 結果なし = 非表示)
+
+### 決定 7: 結果窓の高さは実件数フィット(仕様変更・SPEC 同期)
+
+現行 `compute_window_height` は `max_results` 固定で、結果が少ないと窓内に空白が残る。分離後は `min(実件数, max_results) × row_height + padding` で**カードが中身にフィット**する。窓を分けた以上「空白 = 窓の余り」は許されないための押し出し。`HeightParams` に実件数が入り、layout.rs のテストを更新する。SPEC の動的高さ節(§4.5 系)を同期する(AGENTS.md ステップ 0: 文書化された挙動の変更 = 仕様変更)。
+
+### 決定 8: 検証戦略
+
+- **ユニット**: `Metrics` の式・下限・config 反映(layout.rs)/ 実件数フィットの高さ算出 / スナップショット述語
+- **skill**: `/plan-review`(計画後)・`/state-check`(results 可視性という新ガード条件・reset-on-show との相互作用)・`/race-check`(スナップショット共有・クリック逆流の await/フレーム間競合)・`/persistence-check`(config 3 キーの後方互換)
+- **smoke**: `scripts/smoke-egui.ps1` の前提(trace イベント名・hotkey)が壊れないか確認。実機 GUI smoke で 2 窓の従属(位置・ギャップ・フォーカス非奪取・toast 出没時の追従)と DWM 角丸を目視
+- **PR1 の後方互換の要**: font_size=24 でスクリーンショット比較(ピクセル一致が受け入れ条件)
+
+## リスク・実装時に実測で確定する点
+
+1. tauri `Window::builder` に `WS_EX_NOACTIVATE` を直接指定する API が無い場合、生成後に `SetWindowLongPtrW(GWL_EXSTYLE)` で付与する(windows クレート v0.62 での API 形状・feature フラグ `Win32_Graphics_Dwm` / `Win32_UI_WindowsAndMessaging` を実装前に確認——`src-tauri/CLAUDE.md` の規律)
+2. tauri `show()` が活性化を伴う場合の非活性表示(決定 4 の SW_SHOWNOACTIVATE フォールバック)
+3. DWM 角丸は Windows 11 専用(`DWMWA_WINDOW_CORNER_PREFERENCE` は build 22000+)。Windows 10 では角のまま=装飾なしで受容(機能影響なし)
+4. 2 窓とも同一イベントループスレッドで `update()` が走る(runtime は窓ごと状態を `HashMap` 管理・`runtime.rs`)。スナップショットの `Mutex` は同一スレッド内の順次アクセスが基本で競合は薄いが、`/race-check` で worker スレッド(icon/folder load)からの wake 経路を検証する
+
+## SPEC 同期対象
+
+- §4.5(動的ウィンドウ高さ): 実件数フィット + 2 窓構成へ
+- §11(視覚): 固定 30px/52px の記載箇所を計画時に grep で数え上げ、連動式(`font_size + padding`)へ同期・`window_gap` / `row_padding` / `bar_padding` キーの追加
+- §20.3(updater toast): toast 高が `bar_height` 連動になる旨(位置・挙動は不変)


### PR DESCRIPTION
## 概要

#646「egui 版のUIを整える」の設計 spec と PR1 実装計画を追加する(docs のみ・コード変更なし)。

Refs #646

## 内容

- `docs/superpowers/specs/2026-07-24-646-two-window-ui-design.md` — brainstorm で確定した決定 1〜10:
  - 2 窓構成(main = バー + toast / results = 独立カード)・`window_gap` 既定 4px
  - PR1 = Metrics font 連動 + 結果行 2 行表示、PR2 = 窓分離(WS_EX_NOACTIVATE 従属窓 + DWM 角丸)・実件数フィット・ドラッグ移動
  - 新 config キー `window_gap` / `row_padding` / `bar_padding`(serde default・live-read)
- `docs/superpowers/plans/2026-07-24-646-pr1-metrics-two-line-rows.md` — PR1 の TDD 実装計画(Task 6 個)。/plan-review 済み:
  - 偵察 3 体 + 独立導出 1 体で検証し、指摘 5 点(fixture 必須フィールド・folder エラー行の鏡像分岐・虚偽化コメント 2 箇所・文書同期漏れ 3 件・SPEC 514 統合)を反映済み

## 検証

- `npm run governance:check` — G1..G10 passed(ローカル実測)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
