### PR TITLE
chore: メモリ実測の基盤整備とボトルネック洗い出し（計測フェーズ）

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -49,6 +49,10 @@ opt-level = "s"
 
 ## アイドルメモリ（working set）の削減（2026-06-01〜02 計測）
 
+> **この節は WebView2 期の記録である（#532 SU7 でフロント撤去済み）。** 現行構成のプロセスツリーは
+> **1 件**（webview2 子孫はゼロ）で、数値・内訳とも現行には当てはまらない。現行の実測は
+> 「egui 期のメモリ実測」節を参照。`EmptyWorkingSet` の採用判断（下記）だけは現行でも生きている。
+
 ランチャーは 99% 非表示常駐のため、アイドル時の物理メモリ（working set / private RSS）の最小化が重要。installed release ビルド（32GB/SSD 機）で WebView2 プロセスツリー（main + webview2 子孫 計 7 プロセス）を実機計測した。
 
 ### 実態（Private Working Set = プロセス固有の物理 RAM）
@@ -107,6 +111,55 @@ trace 計装（`suspend:call_returned` / `suspend:completed`）で、`TrySuspend
 - **tokio / rayon の worker スレッド削減**: Rust 本体は Tauri 既定の multi-thread tokio（worker = CPU コア数）+ rayon プールで ~50 スレッドを抱えるが、スレッドスタックは計 2.17MB（committed 42.8MB の 5%）に過ぎず、worker を絞っても RSS 削減は <1MB で**無意味**。30MB の大半はヒープ/フレームワーク baseline
 - **`--disable-gpu --disable-gpu-compositing`**: GPU プロセスは消えない（in-process ソフト合成に切替）が Private 18→6MB・合計 110→99MB。ただしブラウザフラグは Microsoft 非サポート（ランタイム更新で挙動変化）＋ CPU 合成化で描画レイテンシ未検証。限界効用は `EmptyWorkingSet`（~107MB）に対し桁違いに小さく見送り
 - **アイコン PNG 圧縮強化（issue #335）**: 16×16 アイコンで実測 ~0.06MB と桁違いに小さく却下（詳細は #335）
+
+## egui 期のメモリ実測（2026-07-25 計測）
+
+`#532 SU7` 後の構成（単一プロセス・WebView2 なし）を release ビルドで実機計測した。
+計測ハーネスは `snotra-core/tests/memory_footprint.rs`（アロケータ計数・実行コマンドは
+`docs/build-commands.md`）と `scripts/measure-memory.ps1`。
+
+### 軸の取り違えに注意 — PrivWS は trim 後の値である
+
+hide 経路の `EmptyWorkingSet`（`src-tauri/src/working_set.rs`）は物理ページをほぼ完全に返す。
+**非表示アイドルの PrivWS は 2.3 MiB** で、ここに削る余地は無い。一方 PrivComm は trim で
+**動かない**（97.1 → 97.1）。ゆえに**ヒープ調律の軸は PrivComm のみ**であり、PrivWS の
+小ささを「メモリを使っていない」と読んではならない。
+
+### font_family A/B（前景計測・`auto_hide_on_focus_lost = false`）
+
+実運用 config（38,847 エントリ・migemo 有効）での PrivComm。B は `font_family` を
+解決不能名にして user_font 経路だけを落とした変種。
+
+| 段階 | A: `font_family = "HackGen Console"` | B: 解決不能（jp_font 単一） | 差 |
+|---|---:|---:|---:|
+| アイドル（一度も表示せず） | 61.9 MiB | 41.3 MiB | **20.6** |
+| 表示（空クエリ） | 75.1 MiB | 43.8 MiB | **31.3** |
+| 検索実行後 | 97.1 MiB | 56.2 MiB | **40.9** |
+
+- **user_font 経路が最大の単一項目**。窓を一度も出していないアイドル時点で既に 20.6 MiB 効いており、
+  フォント解決が表示より前に走ることを示す
+- 差はファイルサイズ（`HackGenConsole-Regular.ttf` = 10.21 MiB）の約 2 倍。`resolve_font_family` の
+  `data.to_vec()` による複製に加え、egui 側の解析・グリフ実体化が上乗せされる。**内訳は未分離**
+- `JP_FONT_BYTES: OnceLock<Box<[u8]>>` は `YuGothM.ttc`（**13.26 MiB**）を丸ごと保持し**解放経路が無い**。
+  user_font が CJK を被覆する場合（HackGen 等）でも fallback として常駐し続ける
+- 実行間のばらつきは ~4 MiB（別実行のアイドルは 65.9 MiB）。背景再スキャンの進行差による。
+  **1 MiB 単位の差を有意と読まない**
+
+### 索引の常駐（アロケータ実測・38,847 エントリ）
+
+| 指標 | 値 |
+|---|---:|
+| 定常 live | **14.96 MiB**（404 B/entry） |
+| ロード時ピーク | 19.97 MiB（定常の 1.33 倍） |
+| live ブロック数 | 233,430（6.0 blocks/entry） |
+
+- `index.bin` は **6.80 MiB / 38,847 件**。「index は極小（数百 bytes）」という旧記述は
+  WebView2 期の別環境の値で、実運用点とは 4 桁ずれる
+- **`normalized_keys` が 3.05 MiB**（索引の 22%）。`normalize_entry_key` = 小文字化 + `/`→`\` の
+  長さ保存変換ゆえ、on-disk バイト数は `target_path` と完全一致する——原文パスと二重に持っている
+- migemo の限界費用は 10k/38.8k/100k で一貫して **+28.6%**（133 → 171 B/entry）
+- アロケータ実測は `layout.size()` の集計であり、Windows ヒープのブロックヘッダ・
+  サイズクラス丸めを**含まない**。233,430 ブロックゆえ実 RSS はこれより大きい
 
 ## 試みたが機能しない手法
 

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -140,6 +140,11 @@ hide 経路の `EmptyWorkingSet`（`src-tauri/src/working_set.rs`）は物理ペ
   フォント解決が表示より前に走ることを示す
 - 差はファイルサイズ（`HackGenConsole-Regular.ttf` = 10.21 MiB）の約 2 倍。`resolve_font_family` の
   `data.to_vec()` による複製に加え、egui 側の解析・グリフ実体化が上乗せされる。**内訳は未分離**
+- **差が段階とともに広がる（20.6 → 31.3 → 40.9）のが要点**。一度きりのバイト複製なら差は一定のはずで、
+  広がるということはグリフ実体化の分が乗っているということ。同じクエリ 1 回の検索で A は +22.0 MiB、
+  B は +12.4 MiB しか増えない——検索時の増分もアイコンではなく**主にフォント由来**である。
+  ゆえに「user_font が CJK を被覆するなら冗長な jp_font を積まない」が具体的な削減候補になる
+  （被覆判定の述語が要る）
 - `JP_FONT_BYTES: OnceLock<Box<[u8]>>` は `YuGothM.ttc`（**13.26 MiB**）を丸ごと保持し**解放経路が無い**。
   user_font が CJK を被覆する場合（HackGen 等）でも fallback として常駐し続ける
 - 実行間のばらつきは ~4 MiB（別実行のアイドルは 65.9 MiB）。背景再スキャンの進行差による。

--- a/docs/build-commands.md
+++ b/docs/build-commands.md
@@ -97,6 +97,7 @@ npm run verify                   # Rust + node 一括検証（cargo check --work
 npm run smoke:startup             # 起動時スモーク（trace の *:error 不在検証）
 npm run smoke:egui                # egui 経路の show/hide スモーク（keybd_event 注入 + trace検証・#532 SU7。既定 ExePath = target/release）
 npm run measure:memory            # メモリ実測（PrivWS 軸・ツリー合算・#532 flip 基準 3）
+npm run measure:memory:stages     # メモリ実測（起動→表示→検索→hide の段階別・前景計測。実行中の snotra を kill する）
 npm run tauri build              # リリースビルド（NSIS バンドル。`prepare:sidecar` で binaries/ を用意してから）
 ```
 

--- a/docs/build-commands.md
+++ b/docs/build-commands.md
@@ -87,6 +87,7 @@ cargo test -p snotra-egui-mvp    # MVPのEngine・Updaterモード・jp_fontベ�
 cargo test -p snotra             # ユニットテスト（Tauri 統合層: state/indexing/config_watcher 等）
 cargo test -p snotra-settings    # ユニットテスト（設定 GUI の純ロジック: font face 検証・TOML エラーローカライズ）
 cargo test --release -p snotra-core bench_ -- --ignored --nocapture  # 検索パフォーマンス計測（詳細: PERFORMANCE.md）
+cargo test --release -p snotra-core --test memory_footprint -- --ignored --nocapture  # 索引の常駐メモリ実測（アロケータ計数・詳細: PERFORMANCE.md）
 cargo check --workspace          # Rust 全 crate 型チェック
 cargo clippy --workspace --all-targets -- -D warnings  # lint チェック（カテゴリ A と同じ）
 cargo run -p snotra-settings     # snotra-settings（egui ネイティブ設定 GUI）の単独起動

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "smoke:startup": "pwsh -NoProfile -File scripts/smoke-startup.ps1",
     "smoke:egui": "pwsh -NoProfile -File scripts/smoke-egui.ps1",
     "measure:memory": "pwsh -NoProfile -File scripts/measure-memory.ps1",
+    "measure:memory:stages": "pwsh -NoProfile -File scripts/measure-memory-stages.ps1",
     "prepare:sidecar": "pwsh -NoProfile -File scripts/prepare-sidecar.ps1 -Release",
     "verify": "cargo check --workspace && npm test",
     "tauri": "tauri"

--- a/scripts/measure-memory-stages.ps1
+++ b/scripts/measure-memory-stages.ps1
@@ -1,0 +1,94 @@
+<#
+.SYNOPSIS
+  起動 → 表示 → 検索 → hide の各段階で Snotra のメモリを実測する（段階別・前景計測）。
+
+.DESCRIPTION
+  `measure-memory.ps1` が「今この瞬間」の 1 点を測るのに対し、本スクリプトは
+  ホットキーとクエリを注入しながら**段階列**を測る。フォント設定など「表示・描画で
+  初めて実体化する」コストは 1 点計測では見えないため（2026-07-25 実測: user_font は
+  アイドル 20.6 MiB → 検索後 40.9 MiB と段階とともに差が広がる）。
+
+  **サンプリングは `measure-memory.ps1` を `&` で呼んで再利用する（重複実装しない）。**
+  `&` は同一プロセスで .ps1 を実行するのでコンソールが増えない。ここが本質で、
+  `pwsh -File measure-memory.ps1` と書くと**新しいコンソールがフォーカスを奪い**、
+  以後の SendKeys が Snotra ではなく別窓へ流れて標本が無言で無効になる（実際に踏んだ）。
+
+  前提:
+  - release ビルド済み（既定 `target/release/snotra.exe`）
+  - `[hotkey]` が既定の `Ctrl+K` 系であること（段階 B の注入キーは下でハードコード）
+  - `[general] auto_hide_on_focus_lost = false` は**推奨であって必須ではない**。上記の
+    同一プロセス実行でフォーカスを保つため、`true` のままでも段階列は取れる（実測で
+    B/C/D とも成立）。ただし外的要因でフォーカスが逸れると窓が hide して PrivWS が
+    trim 後の値へ落ち、段階列が無言で壊れる。長時間の計測や無人実行では false にする
+  - **実行中の snotra を kill する**（`smoke-egui.ps1` と同じくローカル実行時は注意）
+
+  読み方: PrivWS は hide 経路の `EmptyWorkingSet` で trim された後の値になりうるため、
+  確保需要の軸は **PrivComm** を見る（詳細は PERFORMANCE.md「egui 期のメモリ実測」）。
+
+.PARAMETER Label
+  出力に付ける見出し（A/B 比較時の変種名。例 "font=HackGen" / "font=解決不能"）。
+
+.PARAMETER Query
+  段階 C で注入する検索クエリ。開発機の索引に一致する文字列を指定する。
+
+.PARAMETER ExePath
+  計測対象の実行ファイル。
+
+.EXAMPLE
+  npm run measure:memory:stages
+  pwsh -NoProfile -File scripts/measure-memory-stages.ps1 -Label "font=解決不能" -Query notepad
+#>
+param(
+    [string]$Label = '',
+    [string]$Query = 'code',
+    [string]$ExePath = "$PSScriptRoot/../target/release/snotra.exe"
+)
+
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.Windows.Forms
+
+$measure = Join-Path $PSScriptRoot 'measure-memory.ps1'
+if (-not (Test-Path $measure)) { throw "測定器が見つかりません: $measure" }
+if (-not (Test-Path $ExePath)) { throw "実行ファイルが見つかりません: $ExePath（release ビルド済みか確認）" }
+
+# `&` = 同一プロセス実行（新コンソールを作らない）。フォーカスを保つための必須条件。
+function Invoke-Stage {
+    param([string]$Stage)
+    # measure-memory.ps1 は**失敗時のみ** `exit`（1: プロセス不在 / 2: perf 0 件）する。
+    # 成功時は最後まで流れて終わるため $LASTEXITCODE は更新されない。直前の値が残ると
+    # 成功を失敗と誤判定するので、呼ぶ前に 0 で潰してから判定する（誤爆を実測で確認済み）。
+    $global:LASTEXITCODE = 0
+    & $measure -Label "$Label / $Stage"
+    if ($LASTEXITCODE -ne 0) {
+        throw "[$Stage] サンプリング失敗 (exit $LASTEXITCODE)。0 MiB と読んではならない。"
+    }
+}
+
+function Send-Keys {
+    param([string]$Keys, [int]$WaitSeconds)
+    [System.Windows.Forms.SendKeys]::SendWait($Keys)
+    Start-Sleep -Seconds $WaitSeconds
+}
+
+Write-Host ''
+Write-Host "########## 段階別メモリ実測: $Label ##########" -ForegroundColor Cyan
+
+Stop-Process -Name snotra -Force -ErrorAction SilentlyContinue
+Start-Sleep -Seconds 2
+
+Start-Process -FilePath $ExePath
+Start-Sleep -Seconds 14      # 索引ロード + 背景再スキャンの収束待ち
+Invoke-Stage 'A. アイドル（一度も表示せず）'
+
+Send-Keys '^k' 4             # ホットキーで表示（config の [hotkey] に合わせて要調整）
+Invoke-Stage 'B. 表示（空クエリ）'
+
+Send-Keys $Query 6           # 検索 + アイコン抽出・テクスチャ化の収束待ち
+Invoke-Stage "C. 検索実行後（query=$Query）"
+
+Send-Keys '{ESC}' 5          # hide → EmptyWorkingSet trim
+Invoke-Stage 'D. hide 後（trim 済み）'
+
+Stop-Process -Name snotra -Force -ErrorAction SilentlyContinue
+Write-Host "########## 終了: $Label ##########" -ForegroundColor Cyan
+Write-Host '注: PrivWS は trim 後の値になりうる。確保需要は PrivComm を見ること。' -ForegroundColor DarkGray

--- a/snotra-core/tests/memory_footprint.rs
+++ b/snotra-core/tests/memory_footprint.rs
@@ -1,0 +1,273 @@
+//! メモリ常駐量の実測ハーネス（計測専用・`#[ignore]`）。
+//!
+//! `SearchEngine` の常駐ヒープを**アロケータ実測**で取る。構造体の算術見積もりは
+//! アロケータのブロックヘッダ・サイズクラス丸めを取りこぼすため、live バイト数と
+//! **確保回数**の両方を測る（1 エントリあたり複数の小 `Box<str>` を持つ設計では、
+//! 回数由来のオーバーヘッドが無視できない）。
+//!
+//! 計測は環境依存ゆえ CI では回さない。手元で release 実行する:
+//! `cargo test -p snotra-core --release --test memory_footprint -- --ignored --nocapture`
+//!
+//! 実運用点（`%APPDATA%\Snotra\index.bin` の実インデックス）と合成ラダーの両方を測る。
+//! 実インデックスが無い環境では Phase A は自動スキップし、合成のみ報告する。
+//!
+//! `tests/*.rs` は独立したクレートルートゆえ、ここで宣言する `#[global_allocator]` は
+//! 製品バイナリに一切入らない（`tests/search_frame_cost.rs` と同じ隔離）。
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use snotra_core::config::Config;
+use snotra_core::indexer::{self, AppEntry, LoadOrScanResult};
+use snotra_core::search::SearchEngine;
+
+// ---------------------------------------------------------------------------
+// 計数アロケータ
+// ---------------------------------------------------------------------------
+
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+static LIVE_BLOCKS: AtomicUsize = AtomicUsize::new(0);
+
+/// `System` を包み、live / peak バイト数と確保回数を数えるだけのアロケータ。
+/// 並行スレッド（rayon の Wave 1/2 構築）からの確保も合算される。
+struct Counting;
+
+impl Counting {
+    fn on_alloc(size: usize) {
+        let live = LIVE.fetch_add(size, Ordering::Relaxed) + size;
+        PEAK.fetch_max(live, Ordering::Relaxed);
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        LIVE_BLOCKS.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn on_dealloc(size: usize) {
+        LIVE.fetch_sub(size, Ordering::Relaxed);
+        LIVE_BLOCKS.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let p = unsafe { System.alloc(layout) };
+        if !p.is_null() {
+            Self::on_alloc(layout.size());
+        }
+        p
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) };
+        Self::on_dealloc(layout.size());
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let p = unsafe { System.realloc(ptr, layout, new_size) };
+        if !p.is_null() {
+            // realloc はブロック数を変えない（1 ブロックのサイズ差し替え）。
+            LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
+            let live = LIVE.fetch_add(new_size, Ordering::Relaxed) + new_size;
+            PEAK.fetch_max(live, Ordering::Relaxed);
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+        }
+        p
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+/// 計測区間のスナップショット。
+#[derive(Clone, Copy)]
+struct Snap {
+    live: usize,
+    peak: usize,
+    allocs: usize,
+    blocks: usize,
+}
+
+fn snap() -> Snap {
+    Snap {
+        live: LIVE.load(Ordering::Relaxed),
+        peak: PEAK.load(Ordering::Relaxed),
+        allocs: ALLOCS.load(Ordering::Relaxed),
+        blocks: LIVE_BLOCKS.load(Ordering::Relaxed),
+    }
+}
+
+/// peak を現在の live まで引き下げ、次の区間の peak を独立に測れるようにする。
+fn reset_peak() {
+    PEAK.store(LIVE.load(Ordering::Relaxed), Ordering::Relaxed);
+}
+
+fn mib(bytes: usize) -> f64 {
+    bytes as f64 / 1024.0 / 1024.0
+}
+
+/// 区間の差分を 1 行で報告する。`n` はエントリ数（0 なら per-entry を出さない）。
+fn report(label: &str, before: Snap, after: Snap, n: usize) {
+    let live = after.live.saturating_sub(before.live);
+    let blocks = after.blocks.saturating_sub(before.blocks);
+    let allocs = after.allocs.saturating_sub(before.allocs);
+    println!(
+        "  {label:<34} live {:>8.2} MiB  peak {:>8.2} MiB  blocks {blocks:>9}  allocs {allocs:>9}",
+        mib(live),
+        mib(after.peak.saturating_sub(before.live)),
+    );
+    if n > 0 {
+        println!(
+            "  {:<34} = {:>6.1} B/entry, {:>5.2} blocks/entry",
+            "",
+            live as f64 / n as f64,
+            blocks as f64 / n as f64,
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 合成インデックス（実運用点の文字列長分布に合わせる）
+// ---------------------------------------------------------------------------
+
+/// 実測分布（`index.bin` デコード: name 平均 10.4B / path 平均 66.4B / folder 率 98.9%）に
+/// 寄せた合成エントリを作る。文字列長がメモリ量を支配するため、長さの再現を優先する。
+fn synthetic_entries(n: usize) -> Vec<AppEntry> {
+    (0..n)
+        .map(|i| {
+            let name = format!("entry{i:05}");
+            let target_path =
+                format!("C:\\workspace\\project{:03}\\src\\module{:04}\\{name}", i % 512, i % 997);
+            AppEntry {
+                name,
+                target_path,
+                is_folder: i % 100 != 0,
+            }
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Phase A: 実運用点（実 index.bin）
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "計測専用。release + --nocapture で手動実行する"]
+fn measure_real_index_footprint() {
+    let config = Config::load();
+    let scan = &config.paths.scan;
+    if scan.is_empty() {
+        println!("実 config に scan パスが無いため Phase A をスキップします。");
+        return;
+    }
+
+    println!("\n=== Phase A: 実運用点（実 index.bin / 実 config）===");
+    println!(
+        "  migemo_enabled = {}, show_hidden_system = {}",
+        config.search.migemo_enabled, config.search.show_hidden_system
+    );
+
+    // 実起動と同じ経路を辿る（main.rs:203 → 246）: load_or_scan_with_stats が返す
+    // cached_masks を new_from_cache へ渡し、Wave 1 をスキップする。ここを
+    // load_or_scan（masks 破棄）で代用すると再計算が走り、ピークも構築コストも別物になる。
+    reset_peak();
+    let t0 = snap();
+    let result = indexer::load_or_scan_with_stats(scan, config.search.show_hidden_system);
+    let t1 = snap();
+    let n = result.entries.len();
+
+    if result.cache_changed {
+        println!(
+            "  警告: index.bin がヒットせず全走査が走りました（entries={n}）。\
+             以下の load 区間は走査コスト込みで、常駐量の解釈には使えません。"
+        );
+    }
+    println!(
+        "  entries = {n}, cache_hit = {}, cached_masks = {}",
+        result.stats.cache_hit,
+        result.cached_masks.is_some()
+    );
+    report("index.bin ロード（entries + masks）", t0, t1, n);
+
+    let LoadOrScanResult { entries, cached_masks, rescan_task, .. } = result;
+    // 背景再スキャンタスクは src-tauri 側で別スレッドが消費する。常駐計測の対象外。
+    drop(rescan_task);
+
+    // 実 config どおりの migemo 設定で構築（= 実運用の常駐形）。
+    reset_peak();
+    let t2 = snap();
+    let engine = match cached_masks {
+        Some(masks) => SearchEngine::new_with_cached_masks(
+            entries,
+            masks.char_masks,
+            masks.file_name_char_masks,
+            masks.lower_names,
+            masks.lower_file_names,
+            masks.normalized_keys,
+            config.search.migemo_enabled,
+        ),
+        None => SearchEngine::new_with_migemo(entries, config.search.migemo_enabled),
+    };
+    let t3 = snap();
+    report("SearchEngine 構築（実 config）", t2, t3, n);
+
+    println!(
+        "  --- 合計常駐（entries + 派生）: {:.2} MiB / peak {:.2} MiB ---",
+        mib(t3.live.saturating_sub(t0.live)),
+        mib(t3.peak.saturating_sub(t0.live)),
+    );
+
+    drop(engine);
+    let t4 = snap();
+    println!(
+        "  drop 後の残留: {:.2} MiB（0 に近ければリークなし）",
+        mib(t4.live.saturating_sub(t0.live))
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Phase B: migemo の限界費用と規模スケーリング
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "計測専用。release + --nocapture で手動実行する"]
+fn measure_synthetic_scaling() {
+    println!("\n=== Phase B: 合成インデックスのスケーリング ===");
+
+    for n in [10_000usize, 38_847, 100_000] {
+        println!("\n  [N = {n}]");
+
+        reset_peak();
+        let t0 = snap();
+        let entries = synthetic_entries(n);
+        let t1 = snap();
+        report("Vec<AppEntry> のみ", t0, t1, n);
+
+        // migemo 無効（kana 2 本が空 Vec）。
+        let cloned = entries.clone();
+        reset_peak();
+        let t2 = snap();
+        let engine_off = SearchEngine::new_with_migemo(cloned, false);
+        let t3 = snap();
+        report("SearchEngine（migemo=off）", t2, t3, n);
+        drop(engine_off);
+
+        // migemo 有効（kana_lower_names + kana_char_masks を追加構築）。
+        let cloned = entries.clone();
+        reset_peak();
+        let t4 = snap();
+        let engine_on = SearchEngine::new_with_migemo(cloned, true);
+        let t5 = snap();
+        report("SearchEngine（migemo=on）", t4, t5, n);
+        drop(engine_on);
+
+        let off = t3.live.saturating_sub(t2.live);
+        let on = t5.live.saturating_sub(t4.live);
+        println!(
+            "  {:<34} +{:.2} MiB（migemo の限界費用）",
+            "kana 2 本の追加分",
+            mib(on.saturating_sub(off))
+        );
+
+        drop(entries);
+    }
+}


### PR DESCRIPTION
## 概要

メモリチューニングの**計測フェーズのみ**。ボトルネックの洗い出しまでを行い、計測手段を再利用可能な形で残す。
**製品コード（`snotra-core` / `src-tauri`）は 1 行も変更していない。**

## なぜ

PERFORMANCE.md のメモリ節が WebView2 期（プロセスツリー 7 件）の記録のままで、現行構成（単一プロセス・#532 SU7 でフロント撤去済み）と乖離していた。とくに「index は極小（`index.bin` 数百 bytes）」は実運用点（**6.80 MiB / 38,847 件**）と 4 桁ずれる。この状態では、どこを削るべきかの判断が誤った前提の上に乗る。

## 実測結果

### 軸の取り違えが最大の落とし穴だった

hide 経路の `EmptyWorkingSet` が物理ページをほぼ完全に返すため、**非表示アイドルの PrivWS は 2.3 MiB** で削る余地が無い。一方 PrivComm は trim で**動かない**（97.1 → 97.1）。ヒープ調律の軸は PrivComm のみで、PrivWS の小ささを「メモリを使っていない」と読んではならない。

### font_family A/B が順位を逆転させた（PrivComm）

| 段階 | A: `font_family = "HackGen Console"` | B: 解決不能（jp_font 単一） | 差 |
|---|---:|---:|---:|
| アイドル（一度も表示せず） | 61.9 MiB | 41.3 MiB | **20.6** |
| 表示（空クエリ） | 75.1 MiB | 43.8 MiB | **31.3** |
| 検索実行後 | 97.1 MiB | 56.2 MiB | **40.9** |

**フォント（20.6〜40.9 MiB）> 索引（14.96 MiB）**。差が段階とともに**広がる**のが要点で、一度きりのバイト複製ならば差は一定のはず。広がる以上グリフ実体化が乗っており、同一クエリ 1 回の検索増分が A +22.0 MiB / B +12.4 MiB であることと合わせ、検索時の膨張もアイコンではなく主にフォント由来だと分かる。

`JP_FONT_BYTES: OnceLock<Box<[u8]>>` は `YuGothM.ttc`（13.26 MiB）を丸ごと保持し**解放経路が無い**。user_font が CJK を被覆する場合でも fallback として常駐し続ける。

### 索引（アロケータ実測・38,847 エントリ）

定常 **14.96 MiB**（404 B/entry）/ ロード時ピーク 19.97 MiB（1.33 倍）/ live ブロック 233,430。
うち `normalized_keys` **3.05 MiB** は `target_path` の長さ保存変換（小文字化 + `/`→`\`）で、原文パスと二重に持っている。on-disk バイト数が完全一致することが根拠。

## 変更内容

| ファイル | 内容 |
|---|---|
| `snotra-core/tests/memory_footprint.rs` | 新規。アロケータ計数ハーネス（`#[ignore]`）。`tests/*.rs` は独立クレートルートゆえ `#[global_allocator]` は製品バイナリに入らない（`search_frame_cost.rs` と同じ隔離） |
| `scripts/measure-memory-stages.ps1` | 新規。起動→表示→検索→hide の段階別実測。サンプリングは `measure-memory.ps1` を `&` で呼んで再利用（重複実装なし） |
| `package.json` / `docs/build-commands.md` | 上記 2 つの実行コマンドを SSOT へ登録 |
| `PERFORMANCE.md` | egui 期の実測を追加。WebView2 期の節は削らず冒頭で「歴史」と画定 |

## 検証

- `npm run governance:check` — G1..G10 passed
- `npm test` — 217 passed
- clippy / `cargo test -p snotra-core` — PostToolUse hook で沈黙（= 合格）
- 段階別スクリプトは A/B の variant A を再現（61.9 / 75.2 / 97.3 / 2.4 MiB・先の実測と ±0.2 MiB 以内）
- A/B に用いたユーザ `config.toml` は **SHA256 一致で原本復元済み**、計測用に起動したプロセスも停止済み

## 残余・注意

- **チューニングは未着手**。候補は ①user_font が CJK を被覆するなら冗長な jp_font を積まない（被覆判定の述語が要る）②`normalized_keys` の二重保持 ③ロード時ピーク
- ②は**スコアリングのホットパスで読まれる**（`v.normalized_key.find(pq)`）。#110 が 35〜120% 劣化で却下されたのと同じ形であり、着手するならレイテンシ実測（`bench_fuzzy_search_scaling` / `search_frame_cost`）とセットで行うこと
- フォント差 20.6 MiB がファイルサイズ 10.21 MiB の約 2 倍である点の内訳（複製 vs 解析・グリフ）は**未分離**
- 実行間ばらつきは ~4 MiB（背景再スキャンの進行差）。1 MiB 単位の差を有意と読まない
- ハーネスは `%APPDATA%\Snotra` の実 index/config を読む環境依存ゆえ CI では回さない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
