### PR TITLE
chore: snotra-egui-runtime を 3 機構の対象集合へ入れ、漏れをカナリアで塞ぐ

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,6 +12,10 @@ on:
     # （egui 経路の自動回帰の最低線）+ 手動 GUI smoke 体制（docs/build-commands.md）。
     paths:
       - 'src-tauri/**'
+      # 描画ループ・入力・IME・repaint を所有する接着層（#701）。src-tauri だけを列挙していた頃は、
+      # runtime の *.rs だけを触る PR で smoke が回らなかった（#660 の PR は manifest 経由で
+      # 偶然発火していた＝「緑」が「検査が走った」を意味しない形の一種・#686 と同族）
+      - 'snotra-egui-runtime/**'
       - '.github/workflows/e2e.yml'
       # workflow の各ステップが直接呼ぶスクリプト（変更で自己検証する）
       - 'scripts/smoke-startup.ps1'      # "Run startup smoke" ステップ

--- a/docs/build-commands.md
+++ b/docs/build-commands.md
@@ -41,7 +41,7 @@ npm run smoke:egui       # 必須: egui show/hide スモーク（hotkey 注入 +
 ```
 
 - WebView2 E2E（Playwright + tauri-driver）は #532 SU7 flip で撤去済み。後継は `smoke:egui`（自動回帰の最低線）+ 手動 GUI smoke（カテゴリ D）
-- **PR 上の実行責任**: `npm test` は通常 PR CI（`ci.yml`）で自動実行されるが、`smoke:startup` / `smoke:egui` は**通常 PR CI では走らない**。`src-tauri`・依存 manifest/lockfile 等を含む変更は `Smoke` workflow（`e2e.yml`）が **paths により自動起動**し両 smoke を実行する。paths 外の変更で回したいときは `workflow_dispatch`（手動実行）。「通常 CI が緑」だけでは smoke 済みを意味しない
+- **PR 上の実行責任**: `npm test` は通常 PR CI（`ci.yml`）で自動実行されるが、`smoke:startup` / `smoke:egui` は**通常 PR CI では走らない**。`src-tauri`・`snotra-egui-runtime`（描画ループ所有・#701 で追加）・依存 manifest/lockfile 等を含む変更は `Smoke` workflow（`e2e.yml`）が **paths により自動起動**し両 smoke を実行する。paths 外の変更で回したいときは `workflow_dispatch`（手動実行）。「通常 CI が緑」だけでは smoke 済みを意味しない
   - **CI に検証を委ねるなら、その job が実際に何を実行したかを確かめる**（#671 サイクルで実測: `Smoke` が 5 run 連続で緑のまま results の検証を skip していた）。この 1 事例は `-RequireResults` が機構化した（#686・下記）が、**「緑」が「検査が走った」を意味しない形は他にも作れる**——委ねる前に、その job のステップと渡す引数を読む
 
 ### D. UI のスタイル・レイアウト・テキスト表示に影響する変更（A／B／C に追加）

--- a/scripts/governance-check.mjs
+++ b/scripts/governance-check.mjs
@@ -76,8 +76,11 @@ const finding = (file, line, message) => ({ file, line, message });
 // 1 行複数バッククォートをパースせずに済ませる意図的な弱化（wrong-directory 検出は放棄）。
 // ---------------------------------------------------------------------------
 // ui は #532 SU7 のフロント撤去で消滅（ui/CLAUDE.md ごと削除）
-const G1_CRATES = {
+// snotra-egui-runtime は #701 で追加。「#532 の検証層」として作られたまま母集団から漏れており、
+// SU7 で製品の描画層になった後も更新されていなかった（G3 の governanceDocs も同時に是正）
+export const G1_CRATES = {
   "snotra-core": { src: "snotra-core/src/", exts: /\.rs$/ },
+  "snotra-egui-runtime": { src: "snotra-egui-runtime/src/", exts: /\.rs$/ },
   "src-tauri": { src: "src-tauri/src/", exts: /\.rs$/ },
   "snotra-settings": { src: "snotra-settings/src/", exts: /\.rs$/ },
 };
@@ -557,7 +560,7 @@ export function governanceDocs(snapshot) {
     (f) =>
       ["CLAUDE.md", "AGENTS.md", "CONTRIBUTING.md", "SPEC.md"].includes(f) ||
       (f.startsWith("docs/") && f.endsWith(".md") && !f.startsWith("docs/superpowers/")) ||
-      /^(snotra-core|src-tauri|snotra-settings)\/CLAUDE\.md$/.test(f) ||
+      /^(snotra-core|snotra-egui-runtime|src-tauri|snotra-settings)\/CLAUDE\.md$/.test(f) ||
       /^\.claude\/rules\/[^/]+\.md$/.test(f) ||
       /^\.claude\/skills\/[^/]+\/SKILL\.md$/.test(f),
   );

--- a/scripts/governance-check.test.mjs
+++ b/scripts/governance-check.test.mjs
@@ -1,8 +1,13 @@
 // governance-check.mjs の検査関数を、フォールトインジェクションフィクスチャ（赤）と正常フィクスチャ（緑）の
 // 両方向で検証する。各フィクスチャは「守りたい対象 1 件が入力に現れること」と
 // 「判定対象外が入力に混じらないこと」の入力集合検算を兼ねる（.claude/rules/safety-nets.md）。
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
 import {
+  G1_CRATES,
+  governanceDocs,
+  makeSnapshot,
   checkHookCommands,
   checkModuleIndex,
   checkArchitectureTable,
@@ -46,6 +51,43 @@ describe("globToRegex（G7 の意味論固定・代表入力）", () => {
     const re = globToRegex("foo{bar.rs");
     expect(re.test("foo{bar.rs")).toBe(true);
     expect(re.test("foobar.rs")).toBe(false);
+  });
+});
+
+// G1/G3 の母集団は手で列挙する定数であり、**crate を足しても何も鳴らない**（沈黙する経路）。
+// `snotra-egui-runtime` は「#532 の検証層」として作られたまま両方から漏れ、SU7 で製品の
+// 描画層になった後も索引ドリフト・参照切れが検知されない状態が続いていた（#701）。
+// 実 `Cargo.toml` を読み、CLAUDE.md を持つ member が両母集団に載っていることを固定する。
+describe("G1/G3 母集団カナリア — #701", () => {
+  it("CLAUDE.md を持つ workspace member は G1_CRATES と governanceDocs の両方に載る", () => {
+    const root = fileURLToPath(new URL("..", import.meta.url));
+    const src = readFileSync(fileURLToPath(new URL("../Cargo.toml", import.meta.url)), "utf8");
+
+    // 書式が変わったら「読めなかった」と落ちる（fail-closed・post-edit.test.mjs の members カナリアと同型）
+    const section = src.match(/\[workspace\]\r?\n([\s\S]*?)(?=\r?\n\[|$)/);
+    expect(section, "Cargo.toml の [workspace] セクションを読めなかった").not.toBeNull();
+    const m = section[1].match(/^members\s*=\s*\[([^\]]*)\]/m);
+    expect(m, "[workspace] の members 行を読めなかった（書式が変わった）").not.toBeNull();
+    const members = m[1]
+      .split(",")
+      .map((s) => s.trim().replace(/^"|"$/g, ""))
+      .filter((s) => s.length > 0);
+
+    const docs = governanceDocs(makeSnapshot(root));
+    const withClaudeMd = members.filter((c) => existsSync(fileURLToPath(new URL(`../${c}/CLAUDE.md`, import.meta.url))));
+    // 母集団が空になる形（members 読み違い・全 crate が CLAUDE.md 無し）を合格に見せない
+    expect(withClaudeMd.length, "CLAUDE.md を持つ member が 0 件（母集団の欠落）").toBeGreaterThan(0);
+
+    for (const crate of withClaudeMd) {
+      expect(
+        Object.keys(G1_CRATES),
+        `${crate} が G1_CRATES に無い。src/exts を添えて追加すること（索引ドリフトが沈黙で通る）`,
+      ).toContain(crate);
+      expect(
+        docs,
+        `${crate}/CLAUDE.md が G3 母集団に無い。governanceDocs の正規表現を更新すること（参照切れが沈黙で通る）`,
+      ).toContain(`${crate}/CLAUDE.md`);
+    }
   });
 });
 

--- a/snotra-egui-runtime/Cargo.toml
+++ b/snotra-egui-runtime/Cargo.toml
@@ -4,6 +4,11 @@ version.workspace = true
 edition = "2024"
 publish = false
 
+# docgen 検出器（#562）の opt-in。他 3 crate は当初から持っており、当 crate だけが
+# 漏れていた（#701）——ルート [workspace.lints.rustdoc] の deny がここで初めて効く。
+[lints]
+workspace = true
+
 [dependencies]
 arboard = "3"
 egui.workspace = true

--- a/snotra-egui-runtime/src/raster.rs
+++ b/snotra-egui-runtime/src/raster.rs
@@ -10,7 +10,7 @@ pub(crate) fn edge(ax: f32, ay: f32, bx: f32, by: f32, px: f32, py: f32) -> f32 
     (bx - ax) * (py - ay) - (by - ay) * (px - ax)
 }
 
-/// premultiplied sRGB 同士の over 合成。dst は 0x00RRGGBB、src は [r,g,b,a]。
+/// premultiplied sRGB 同士の over 合成。dst は 0x00RRGGBB、src は `[r, g, b, a]`。
 pub(crate) fn blend_premultiplied(dst: u32, src: [u8; 4]) -> u32 {
     let inverse = 255 - src[3] as u32;
     let dst_r = (dst >> 16) & 0xFF;


### PR DESCRIPTION
## 概要

`snotra-egui-runtime` は「#532 の検証層」として作られたまま **3 つの機構の対象集合から揃って漏れており**、SU7 で製品の描画層になった後も更新されていなかった。3 件はいずれも #660 以前からの既存事象で、#660 で `docs/architecture.md` の「検証層」枠組みを撤去したことで輪郭がはっきりした。

Closes #701

## 3 件の是正

### 1. #562 の docgen 検出器 opt-in（`snotra-egui-runtime/Cargo.toml`）

他 3 crate は当初から `[lints] workspace = true` を持っており、当 crate だけが無かった。そのためルートの `broken_intra_doc_links = "deny"` が適用されず、`raster.rs:13` の `[r,g,b,a]` が **`on by default` の warning で素通り**していた。

opt-in を入れた時点で同じ行が **error（exit 101）に変わることを実測**してから、コードスパン `` `[r, g, b, a]` `` へ直した。この error 転化そのものが「deny が当 crate で初めて効いた」ことの実測である（ガードの行使＝弱化していない）。

### 2. `governance:check` の G1 / G3 母集団（`scripts/governance-check.mjs`）

- **G1**（モジュール索引 ↔ 実ファイルの双方向照合）: `G1_CRATES` へ追加
- **G3**（参照実在）: `governanceDocs()` の正規表現へ追加

索引は 9 実ファイル（`lib.rs` / `input.rs` / `ime.rs` / `windows_ime.rs` / `raster.rs` / `renderer.rs` / `repaint.rs` / `runtime.rs` / `surface.rs`）と**既に双方向一致していた**ため findings はゼロ（対象文書 35→36）。当 crate の `CLAUDE.md` には拡張子付きパス参照が無いことも確認済みで、G3 追加による新規の照合対象は発生しない。

### 3. Smoke（`e2e.yml`）の自動発火 paths

描画ループ・入力・IME・repaint を所有する crate が paths に無く、**runtime の `*.rs` だけを触る PR では smoke が回らなかった**（#660 の PR は root `Cargo.toml` / `Cargo.lock` 経由で偶然発火していた＝「緑」が「検査が走った」を意味しない形の一種・#686 と同族）。`docs/build-commands.md` の「PR 上の実行責任」も同期した。

**この PR 自身が item 3 の自己検証になる**——`snotra-egui-runtime/**` と `.github/workflows/e2e.yml` の両方に該当し、Smoke が起動する。

## 同じ漏れを 5 つ目の crate で再発させない機構

3 件を個別に直すだけでは、**次に crate を足したときに同じことが起きる**。母集団は手で列挙する定数であり、crate を足しても何も鳴らない——`.claude/rules/safety-nets.md` の言う**沈黙する経路**そのものである。

そこで `scripts/governance-check.test.mjs` に **「G1/G3 母集団カナリア」** を置いた: 実 `Cargo.toml` の `members` を読み（書式が変わったら「読めなかった」で落ちる fail-closed）、**`CLAUDE.md` を持つ member が G1_CRATES と `governanceDocs()` の両方に載っていること**を固定する。失敗メッセージは更新先（`src`/`exts` を添えた `G1_CRATES` への追加 / `governanceDocs` の正規表現）を名指しする。`post-edit.test.mjs` の members カナリアと同型で、判定に必要な `G1_CRATES` を export した。母集団が空になる形（members 読み違い・全 crate が CLAUDE.md 無し）を合格に見せないガードも入れてある。

## フォールトインジェクション（稼働ガードは無変更・複製に変異を当てる方式）

`governance-check.mjs` の検査関数は snapshot 注入の純関数なので、**実 snapshot から派生させた変異 snapshot** を渡して測った（ディスクもライブの定数も触っていない）。

| 変異 | 結果 |
|---|---|
| G1 順方向: 索引に実在しないファイル（`gone_repaint.rs`）を載せる | 検出 ✓ |
| G1 逆方向: 索引に無い `src/orphan.rs` を足す | 検出 ✓ |
| G1 不混入: `src` 配下でない `.rs`（`tests/` 直下・crate 直下）を足す | **要求しない** ✓（両方向の入力集合検算） |
| G3 母集団: `runtime/CLAUDE.md` が対象文書に含まれる | 含まれる ✓ |
| G3 検出: 宛先のない `.md` 参照を足す | 検出 ✓ |
| カナリア: `G1_CRATES` から runtime を抜く（#701 以前の状態を再現） | 赤 ✓ |
| カナリア: G3 母集団から `runtime/CLAUDE.md` を抜く | 赤 ✓ |
| カナリア: `CLAUDE.md` 付きの将来 crate を未登録で足す | 赤 ✓ |
| ベースライン: 変異なし | いずれも findings ゼロ ✓ |

## 検証

| 検証 | 結果 |
|---|---|
| `cargo check --workspace` / `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo test -p snotra-egui-runtime` | 18 passed |
| `cargo doc --workspace --no-deps --document-private-items` | **警告ゼロ**・exit 0（4 crate すべてが deny 下） |
| `npm test` | 218 passed（カナリア +1） |
| `npm run governance:check` | G1..G10 passed（対象文書 36 件・`runtime/CLAUDE.md` を含む / rules 7 件 / skills 12 件） |

`scripts/**/*.mjs` は PostToolUse hook の検査割り当てが無い（沈黙は「何も走らなかった」）ため、`npm test` と `governance:check` は手で実行している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
