### PR TITLE
fix: capabilities/ を復活させ src-tauri の永久リビルドを止める

### DIFF
--- a/src-tauri/capabilities/README.md
+++ b/src-tauri/capabilities/README.md
@@ -1,0 +1,24 @@
+# capabilities/（意図的に空）
+
+**このディレクトリは capability を 1 つも持たないが、存在し続ける必要がある。** 消すと `snotra`（`src-tauri`）が**ローカルで毎回フルリビルドされる**（release で 1 回 3 分 20 秒・#701 の follow-up として計測）。
+
+## 機構
+
+`build.rs` の `tauri_build::build()` は、`capabilities_path_pattern` 属性を渡さない既定経路で次を**無条件に**出す（`tauri-build-2.6.3/src/acl.rs:427`）:
+
+```
+cargo:rerun-if-changed=capabilities
+```
+
+**cargo は `rerun-if-changed` の対象が存在しないとき、その crate を毎回 dirty と判定する。** ゆえにディレクトリ不在は「ビルドが壊れる」ではなく「**毎回 3 分余計にかかる**」という形で現れ、CI（毎回クリーン checkout ゆえ常に 1 回だけビルド）では**永久に顕在化しない**。実際、`capabilities/main.json` を削除した #662（#532 SU7 PR3・IPC とフロントの撤去で ACL が不要になった）から数サイクル、ローカルだけがこのコストを払っていた。
+
+## この README がここに在っても無害な理由
+
+capability の走査は `parse_capabilities("./capabilities/**/*")` だが、glob の結果は
+`CAPABILITY_FILE_EXTENSIONS`（`json` / `toml`、feature 次第で `json5`）で絞られる
+（`tauri-utils-2.8.3/src/acl/build.rs`）。**`.md` は読まれない**ので、ACL の意味は
+「capability ゼロ」のまま変わらない。
+
+## capability が再び必要になったら
+
+このディレクトリへ `*.json` を置けばよい（tauri の標準レイアウトを保っているのはそのため）。その時点で `cargo:rerun-if-changed` が本来の役割——capability 変更時の再ビルド——を果たすようになる。


### PR DESCRIPTION
## 症状

`src-tauri`（`snotra`）が**ローカルで毎回フルリビルドされていました**。実測: `cargo build --release -p snotra` を 3 回連続で走らせても毎回 `Compiling snotra` + **3 分 19〜21 秒**。#701 の作業中に「cargo に鮮度を問う」（＝再コンパイルが走らないことを現行性の証拠にする）手法を使おうとして、収束しないことに気づきました。

## 原因

`tauri_build::build()` は、`capabilities_path_pattern` 属性を渡さない既定経路で次を**無条件に**出します。

```rust
// tauri-build-2.6.3/src/acl.rs:427
println!("cargo:rerun-if-changed=capabilities");
```

**cargo は `rerun-if-changed` の対象が存在しないとき、その crate を毎回 dirty と判定します。** `src-tauri/capabilities/` は #532 SU7 PR3（`15933af`）が IPC とフロントを撤去した際に `capabilities/main.json` ごと消えており（ACL が不要になったので判断自体は正しい）、それ以降このディレクティブは**宛先のないパス**を指していました。

★ 症状が「壊れる」ではなく「**毎回 3 分余計にかかる**」という形だったこと、そして **CI は毎回クリーン checkout で 1 回だけビルドするため永久に顕在化しない**ことが重なり、数サイクル誰も気づきませんでした——ローカルだけがコストを払っていた形です。

## 対処

標準レイアウトのディレクトリを戻します。**capability は 1 つも置きません。** `README.md` に機構と「なぜ空で在るのか」を書き、次に誰かが「空だから消そう」と判断するのを防ぎます（git は空ディレクトリを追跡できないため、実体としても README が必要です）。

### 安全性（上流の一次資料で確認）

capability の走査は `parse_capabilities("./capabilities/**/*")` で全ファイルを glob しますが、結果は `CAPABILITY_FILE_EXTENSIONS = ["json", "toml"]`（feature 次第で `json5`）で絞られます（`tauri-utils-2.8.3/src/acl/build.rs`）。**`.md` は読まれない**ため:

- ACL の意味は「capability ゼロ」のまま**不変**
- `gen/schemas/*.json`（ACL 生成物）も書き換わらない（`git status` で確認）

capability が再び必要になれば、このディレクトリへ `*.json` を置くだけで `rerun-if-changed` が本来の役割を果たすようになります。

## 実測（before / after）

| 条件 | 1 回目 | 2 回目 | 3 回目 |
|---|---|---|---|
| 修正前 `--release` | `Compiling` 3m19s | `Compiling` 3m20s | `Compiling` 3m20s |
| 修正前 `cargo check` | `Compiling` 1m07s | `Compiling` 2.02s | — |
| **修正後 `--release`** | `Compiling` 3m21s | **no-op 1.1s** | **no-op 1.1s** |
| **修正後 `cargo check`** | `Compiling` 2.01s | **no-op 0.86s** | **no-op 0.84s** |

修正後の 1 回目が再ビルドになるのは `build.rs` の入力が変わったためで、正常です。**2 回目以降で `Compiling snotra` が消える**ことが収束の証拠です。

## 検証

- `cargo check --workspace` exit 0
- `npm run governance:check` G1..G10 passed（対象文書 36 件 / rules 7 件 / skills 12 件）
- **Rust ソースは 1 行も変えていない**ため clippy・test は PR CI に委ねます（`.md` 1 ファイルの追加のみ）

## 副産物（記録）

測定中に release ビルドが一度 `os error 5`（アクセス拒否）で落ちました——目視スモークで起動したままの `snotra.exe` が `target/release/snotra.exe` をロックしていたためで、本変更とは無関係です。このとき `Compiling` / `Finished` だけを拾う grep が error 行を落とし、「release では収束しない」というプロファイル依存の誤った仮説を立てかけました。**検出は exit code、出力は証拠**（#471）がそのまま当てはまる事例です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
