### PR TITLE
fix(icon): 冷えたシェルキャッシュの初回失敗で検索結果のアイコンが出ない件を直す

### DIFF
--- a/src-tauri/src/commands/icon.rs
+++ b/src-tauri/src/commands/icon.rs
@@ -1,7 +1,7 @@
 use rayon::prelude::*;
 use tauri::State;
 
-use crate::icon::{extract_png, IconCache, IconCacheState};
+use crate::icon::{extract_png, IconCache, IconCacheState, IconFailure};
 use crate::state::AppState;
 
 pub(crate) fn ensure_icon_cache_loaded_if_enabled(
@@ -27,20 +27,38 @@ pub(crate) fn ensure_icon_cache_loaded_if_enabled(
     }
 }
 
+/// 1 パス分のアイコン取得結果。**「取れなかった」を 1 つに潰さない**（#692）——
+/// 呼び出し側が再試行の可否を決めるには理由が要る。
+pub(crate) enum IconOutcome {
+    /// PNG バイト列（キャッシュヒットまたは抽出成功）。
+    Png(Vec<u8>),
+    /// 抽出が失敗した。`IconFailure::is_transient` が再試行の可否を示す。
+    Failed(IconFailure),
+    /// キャッシュ自体が使えなかった（`show_icons=false`、または無効化と競合）。
+    /// パス固有の失敗ではないので、**恒久的な欠落として扱ってはならない**。
+    Unavailable,
+}
+
 /// egui worker 用: paths のアイコン PNG を（キャッシュ get-or-extract-insert して）owned で返す。
-/// ensure-loaded + 3 段ロック規律（miss 収集 → ロック外抽出 → 挿入）。show_icons=false 時は全 None。
+/// ensure-loaded + 3 段ロック規律（miss 収集 → ロック外抽出 → 挿入）。
+/// show_icons=false 時は全 `Unavailable`。
 pub(crate) fn load_icon_pngs(
     state: &State<AppState>,
     icons: &State<IconCacheState>,
     paths: Vec<String>,
-) -> Vec<(String, Option<Vec<u8>>)> {
+) -> Vec<(String, IconOutcome)> {
     ensure_icon_cache_loaded_if_enabled(state, icons);
     // Step 1: miss 収集（1 ロック）
     let mut misses: Vec<String> = Vec::new();
     {
         let cache = icons.lock().unwrap();
         match cache.as_ref() {
-            None => return paths.into_iter().map(|p| (p, None)).collect(),
+            None => {
+                return paths
+                    .into_iter()
+                    .map(|p| (p, IconOutcome::Unavailable))
+                    .collect();
+            }
             Some(c) => {
                 for p in &paths {
                     if c.get(p).is_none() {
@@ -50,25 +68,61 @@ pub(crate) fn load_icon_pngs(
             }
         }
     }
-    // Step 2: ロック外抽出（rayon）
-    let extracted: Vec<(String, Vec<u8>)> = misses
+    // Step 2: ロック外抽出（rayon）。**失敗した path と理由も保持する**——落とすと
+    // Step 3 で「キャッシュに無い」としか分からず、恒久/一過性の区別が消える（#692）。
+    let extracted: Vec<(String, Result<Vec<u8>, IconFailure>)> = misses
         .into_par_iter()
-        .filter_map(|p| extract_png(&p).map(|png| (p, png)))
+        .map(|p| {
+            let outcome = extract_png(&p);
+            if let Err(reason) = &outcome {
+                // #692: 失敗を握りつぶさず理由を残す。呼び出し側は「アイコンが無い」と
+                // 「一時的に取れなかった」を区別できないため、ここが唯一の観測点である。
+                crate::commands::trace_command(
+                    "icon:extract_failed",
+                    serde_json::json!({
+                        "path": p,
+                        "reason": format!("{reason:?}"),
+                        "transient": reason.is_transient(),
+                        "exists": std::path::Path::new(&p).exists(),
+                    }),
+                );
+            }
+            (p, outcome)
+        })
         .collect();
     // Step 3: 挿入して owned で返す（clone・16x16 PNG ≤8 件ゆえ許容）
     let mut cache = icons.lock().unwrap();
-    if let Some(c) = cache.as_mut() {
-        for (p, png) in extracted {
-            c.insert(p, png);
-        }
-        paths
+    let Some(c) = cache.as_mut() else {
+        return paths
             .into_iter()
-            .map(|p| {
-                let png = c.get(&p).map(|s| s.to_vec());
-                (p, png)
-            })
-            .collect()
-    } else {
-        paths.into_iter().map(|p| (p, None)).collect()
+            .map(|p| (p, IconOutcome::Unavailable))
+            .collect();
+    };
+    // 失敗の理由は path 単位で引けるようにしてから挿入する。
+    let mut failures: std::collections::HashMap<String, IconFailure> =
+        std::collections::HashMap::new();
+    for (p, outcome) in extracted {
+        match outcome {
+            Ok(png) => c.insert(p, png),
+            Err(reason) => {
+                failures.insert(p, reason);
+            }
+        }
     }
+    paths
+        .into_iter()
+        .map(|p| {
+            // キャッシュにあれば PNG。無ければ、この呼び出しで失敗した理由を返す。
+            // どちらでもない（= miss でも失敗でもない）は起こらないが、起きたときに
+            // 恒久扱いしないよう `Unavailable` へ倒す。
+            let outcome = match c.get(&p) {
+                Some(png) => IconOutcome::Png(png.to_vec()),
+                None => match failures.remove(&p) {
+                    Some(reason) => IconOutcome::Failed(reason),
+                    None => IconOutcome::Unavailable,
+                },
+            };
+            (p, outcome)
+        })
+        .collect()
 }

--- a/src-tauri/src/egui_shell/icon_textures.rs
+++ b/src-tauri/src/egui_shell/icon_textures.rs
@@ -9,7 +9,10 @@ use std::collections::{HashMap, HashSet};
 /// driver（view.rs の worker spawn / load_texture）が消費する（#532 SU4 Task 5）。
 pub(crate) enum IconMsg {
     Loaded(String, egui::ColorImage),
-    Missing(String),
+    /// 取得できなかった。**第 2 引数は「再試行してよいか」**（#692）——一過性の失敗
+    /// （冷えたシェルのアイコンキャッシュ等）を恒久的な欠落と同じ扱いにすると、その行は
+    /// 可視である限りグレーのプレースホルダのまま戻らない。
+    Missing(String, bool),
 }
 
 /// 自前エンコードの RGBA8 PNG（icon.rs bgra_to_png）を ColorImage へ decode する。
@@ -35,17 +38,26 @@ pub(crate) fn png_to_color_image(png: &[u8]) -> Option<egui::ColorImage> {
     Some(egui::ColorImage::new([w, h], pixels))
 }
 
-/// path が未取得かつ未 missing なら true（抽出 worker に積むべきか）。値型 `V` でジェネリック化
-/// してあるのは呼び出し側の型（`egui::TextureHandle`）に依存させないため——ctx 無しに生成できない
-/// TextureHandle を使わずとも、判定は `have`/`missing` のキー集合演算のみで完結する（ユニットテスト
-/// でダミー値型を使い present/missing/new の全経路を検証できる）。driver（view.rs）が消費する
-/// （#532 SU4 Task 5）。
+/// 抽出を諦めるまでの試行回数（#692）。`extract_icon` 内のリトライ（シェルの冷えた
+/// キャッシュ対策）とは別の層で、**worker 往復を含む再試行**の上限である。
+pub(crate) const ICON_MAX_ATTEMPTS: u8 = 3;
+
+/// path が未取得かつ試行上限に達していないなら true（抽出 worker に積むべきか）。
+///
+/// **失敗を「有無」ではなく「回数」で持つ**（#692）。一過性の失敗（シェルのアイコン
+/// キャッシュが冷えている等）を 1 度で恒久的な欠落として latch すると、その行は可視で
+/// ある限りグレーのプレースホルダのまま戻らない。恒久的な失敗（パス不在等）は
+/// 呼び出し側が `ICON_MAX_ATTEMPTS` を直接入れて即座に打ち切る。
+///
+/// 値型 `V` でジェネリック化してあるのは呼び出し側の型（`egui::TextureHandle`）に依存
+/// させないため——ctx 無しに生成できない TextureHandle を使わずとも、判定はキー集合と
+/// 回数の演算のみで完結する（#532 SU4 Task 5）。
 pub(crate) fn needs_extraction<V>(
     path: &str,
     have: &HashMap<String, V>,
-    missing: &HashSet<String>,
+    attempts: &HashMap<String, u8>,
 ) -> bool {
-    !have.contains_key(path) && !missing.contains(path)
+    !have.contains_key(path) && attempts.get(path).copied().unwrap_or(0) < ICON_MAX_ATTEMPTS
 }
 
 /// 可視集合に無い path の値を drop（メモリを可視集合に頭打ち・SU4 決定 A メモリ境界）。
@@ -85,16 +97,24 @@ mod tests {
     // HashMap<String, u32> で present→skip / missing→skip / new→needs、retain の drop/keep を実際に検証する。
 
     #[test]
-    fn needs_extraction_skips_present_and_missing() {
+    fn needs_extraction_retries_until_attempt_cap() {
         let mut have: HashMap<String, u32> = HashMap::new();
         have.insert("present.exe".into(), 1);
-        let mut missing: HashSet<String> = HashSet::new();
-        missing.insert("m.exe".into());
+        let mut attempts: HashMap<String, u8> = HashMap::new();
+        attempts.insert("once.exe".into(), 1);
+        attempts.insert("capped.exe".into(), ICON_MAX_ATTEMPTS);
 
-        assert!(super::needs_extraction("new.exe", &have, &missing), "未知は要抽出");
-        assert!(!super::needs_extraction("m.exe", &have, &missing), "missing は再抽出しない");
+        assert!(super::needs_extraction("new.exe", &have, &attempts), "未知は要抽出");
         assert!(
-            !super::needs_extraction("present.exe", &have, &missing),
+            super::needs_extraction("once.exe", &have, &attempts),
+            "1 度失敗しただけでは諦めない（#692: 一過性の失敗を恒久扱いしない）"
+        );
+        assert!(
+            !super::needs_extraction("capped.exe", &have, &attempts),
+            "上限に達したら再抽出しない（無限リトライを作らない）"
+        );
+        assert!(
+            !super::needs_extraction("present.exe", &have, &attempts),
             "既取得は再抽出しない"
         );
     }

--- a/src-tauri/src/egui_shell/results_view.rs
+++ b/src-tauri/src/egui_shell/results_view.rs
@@ -12,6 +12,8 @@ use std::sync::mpsc::{Receiver, Sender, channel};
 use snotra_core::ui_types::SearchResult;
 use tauri::Manager;
 
+use crate::commands::IconOutcome;
+use crate::egui_shell::icon_textures::ICON_MAX_ATTEMPTS;
 use crate::egui_shell::{IconMsg, RowTheme, needs_extraction, retain_visible};
 
 /// main が毎フレーム発行する描画用スナップショット（spec 決定 5）。
@@ -84,8 +86,11 @@ pub(crate) struct ResultsView {
     /// path→TextureHandle（セッション内保持。可視集合に頭打ち・#532 SU4。Task 5 で view.rs から
     /// 本 view へ移設——TextureHandle は窓の Context 従属のため、行描画と同じ窓に置く）。
     icon_textures: HashMap<String, egui::TextureHandle>,
-    /// 抽出済みだが PNG 化できなかった/存在しない path（再抽出しない・SU4）。
-    icon_missing: HashSet<String>,
+    /// path→抽出の失敗回数（#692）。**「失敗したか」ではなく「何回失敗したか」を持つ**
+    /// ——一過性の失敗（冷えたシェルのアイコンキャッシュ等）を 1 度で恒久的な欠落として
+    /// latch すると、その行は可視である限りグレーのプレースホルダのまま戻らない。
+    /// 恒久的な失敗（パス不在・decode 不能）は `ICON_MAX_ATTEMPTS` を直接入れて即打ち切る。
+    icon_attempts: HashMap<String, u8>,
     /// worker へ渡し済みだが IconMsg 未 drain の path（in-flight）。request_icons_for_results の
     /// wanted 収集から除外し、同一 settle に対する repaint 毎の重複 spawn を防ぐ（thread pileup
     /// 対策）。drain 時（Loaded/Missing）に remove する。show=false 時の明示 clear は行わない
@@ -105,7 +110,7 @@ impl ResultsView {
             last_scrolled_selected: None,
             last_generation: 0,
             icon_textures: HashMap::new(),
-            icon_missing: HashSet::new(),
+            icon_attempts: HashMap::new(),
             icon_pending: HashSet::new(),
             icon_tx,
             icon_rx,
@@ -134,7 +139,7 @@ impl ResultsView {
         let mut wanted: Vec<String> = Vec::new();
         for r in rows {
             if !r.is_error
-                && needs_extraction(&r.path, &self.icon_textures, &self.icon_missing)
+                && needs_extraction(&r.path, &self.icon_textures, &self.icon_attempts)
                 && !self.icon_pending.contains(&r.path)
                 && !wanted.contains(&r.path)
             {
@@ -168,10 +173,27 @@ impl ResultsView {
                 return;
             };
             let loaded = crate::commands::load_icon_pngs(&state, &icons, paths);
-            for (path, png) in loaded {
-                let msg = match png.and_then(|b| crate::egui_shell::png_to_color_image(&b)) {
-                    Some(img) => IconMsg::Loaded(path, img),
-                    None => IconMsg::Missing(path),
+            for (path, outcome) in loaded {
+                // **「取れなかった」を 1 つに潰さない**（#692）。`retryable=false` は
+                // 「このパスにアイコンは無い」に近い恒久的失敗で、driver は即座に打ち切る。
+                let msg = match outcome {
+                    IconOutcome::Png(bytes) => {
+                        match crate::egui_shell::png_to_color_image(&bytes) {
+                            Some(img) => IconMsg::Loaded(path, img),
+                            // decode 失敗は保存済みバイト列の問題であり、再試行しても同じ。
+                            None => {
+                                crate::trace_main(
+                                    "egui_icon:decode_failed",
+                                    serde_json::json!({ "path": path, "bytes": bytes.len() }),
+                                );
+                                IconMsg::Missing(path, false)
+                            }
+                        }
+                    }
+                    IconOutcome::Failed(reason) => IconMsg::Missing(path, reason.is_transient()),
+                    // キャッシュ自体が使えなかった（show_icons=false / 無効化と競合）。
+                    // パス固有の失敗ではないので再試行してよい。
+                    IconOutcome::Unavailable => IconMsg::Missing(path, true),
                 };
                 let _ = tx.send(msg);
             }
@@ -392,9 +414,16 @@ impl snotra_egui_runtime::EguiView for ResultsView {
                     self.icon_textures.insert(path, handle);
                     icon_arrived = true;
                 }
-                IconMsg::Missing(path) => {
+                IconMsg::Missing(path, retryable) => {
                     self.icon_pending.remove(&path); // in-flight 解除（thread pileup 対策）
-                    self.icon_missing.insert(path);
+                    // 一過性なら 1 回ぶん加算して次の要求で再試行、恒久なら上限を直接入れて
+                    // 打ち切る（#692）。`retain_visible` で可視集合外は自然に忘れる。
+                    let entry = self.icon_attempts.entry(path).or_insert(0);
+                    *entry = if retryable {
+                        entry.saturating_add(1)
+                    } else {
+                        ICON_MAX_ATTEMPTS
+                    };
                 }
             }
         }
@@ -442,7 +471,11 @@ impl snotra_egui_runtime::EguiView for ResultsView {
         // 指摘・受容）。
         let visible: HashSet<String> = snapshot.rows.iter().map(|r| r.path.clone()).collect();
         retain_visible(&mut self.icon_textures, &visible);
-        self.icon_missing.retain(|p| visible.contains(p));
+        self.icon_attempts.retain(|p, _| visible.contains(p));
+        // **pending も可視集合で刈る**（#692）。worker が 1 通も送らずに終わる経路
+        // （managed state 不在で早期 return）があり、刈らないと path が永久に in-flight
+        // 扱いのまま `needs_extraction` を素通りできず、その行のアイコンは戻らない。
+        self.icon_pending.retain(|p| visible.contains(p));
         // snapshot.settled は旧 view.rs の `!self.search_debounce.is_armed()` ゲート（連打中は
         // icon worker を積まない・perf 最適化）の後継（#532 SU4 の系譜）。main の search_debounce は
         // ResultsView から参照できないため、live 値を snapshot 経由で運ぶ（Task 5 concern 2 の fix）。

--- a/src-tauri/src/icon.rs
+++ b/src-tauri/src/icon.rs
@@ -14,6 +14,7 @@ use windows::Win32::Graphics::Gdi::{
     BI_RGB, BITMAPINFO, BITMAPINFOHEADER, CreateCompatibleDC, DIB_RGB_COLORS, DeleteDC,
     DeleteObject, GetDIBits, SelectObject,
 };
+use windows::Win32::Foundation::GetLastError;
 use windows::Win32::Storage::FileSystem::{FILE_FLAGS_AND_ATTRIBUTES, SearchPathW};
 use windows::Win32::UI::Shell::{SHFILEINFOW, SHGFI_ICON, SHGFI_SMALLICON, SHGetFileInfoW};
 use windows::Win32::UI::WindowsAndMessaging::{DestroyIcon, GetIconInfo, HICON, ICONINFO};
@@ -105,10 +106,47 @@ impl IconCache {
     }
 }
 
+/// アイコン抽出が失敗した段階（#692）。**`None` に潰すと「アイコンが無い」と
+/// 「一時的に取れなかった」が区別できず、呼び出し側が恒久的な欠落として latch する。**
+/// 失敗の 3 分類は `is_transient` が担う（呼び出し側が再試行の可否を決める材料）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IconFailure {
+    /// `SHGetFileInfoW` が 0 を返した（パス不在・アクセス不可を含む）。
+    ShellQueryFailed(u32),
+    /// 戻り値は非 0 だが HICON が無効。
+    NoIconHandle,
+    /// `GetIconInfo` 失敗。
+    IconInfoFailed(u32),
+    /// `CreateCompatibleDC` 失敗（GDI リソース枯渇の疑い）。
+    CreateDcFailed(u32),
+    /// カラービットマップが無い（モノクロアイコン）。
+    NoColorBitmap,
+    /// `GetDIBits` が 0 行を返した（**従来は戻り値を捨てていた**）。
+    GetDiBitsFailed(u32),
+    /// 取得できたが全画素ゼロ。
+    AllPixelsZero,
+    /// PNG エンコード失敗。
+    PngEncodeFailed,
+}
+
+impl IconFailure {
+    /// 再試行で解消しうるか。`false` は「このパスにアイコンは無い」に近い恒久的失敗。
+    pub fn is_transient(self) -> bool {
+        match self {
+            // GDI/DC 系は資源枯渇で一時的に落ちうる。shell 問い合わせも同様（不在は
+            // 呼び出し側が Path::exists() で切り分ける）。
+            Self::CreateDcFailed(_) | Self::GetDiBitsFailed(_) | Self::IconInfoFailed(_) => true,
+            Self::ShellQueryFailed(_) | Self::NoIconHandle => true,
+            // モノクロ・全ゼロ・エンコード失敗はそのアイコン固有で、再試行しても同じ。
+            Self::NoColorBitmap | Self::AllPixelsZero | Self::PngEncodeFailed => false,
+        }
+    }
+}
+
 /// Extract PNG bytes for a path without holding any lock.
-pub fn extract_png(path: &str) -> Option<Vec<u8>> {
+pub fn extract_png(path: &str) -> Result<Vec<u8>, IconFailure> {
     let icon_data = extract_icon(path)?;
-    bgra_to_png(&icon_data)
+    bgra_to_png(&icon_data).ok_or(IconFailure::PngEncodeFailed)
 }
 
 /// Managed state for icon cache
@@ -176,7 +214,36 @@ fn resolve_to_full_path(path: &str) -> String {
     }
 }
 
-fn extract_icon(path: &str) -> Option<IconData> {
+/// アイコンを抽出する。**`NoIconHandle` は 1 回だけ即時リトライする**（#692）。
+///
+/// `SHGetFileInfoW` は**成功（非 0）を返しながら HICON を返さない**ことがある——プロセス
+/// ごとに冷えたシェルのアイコンキャッシュに対する初回要求で起きる。実測（#692）:
+///
+/// - 実機 1 セッションで 17 件が `NoIconHandle`（いずれも `exists=true`）
+/// - 396 パス × 6 周のうち**失敗するのは周 1 だけ**（16 件 → 以降 0 件）。新しいプロセスで
+///   再び周 1 が失敗する＝**キャッシュはプロセスごと**
+/// - **0ms の即時リトライで 15/15 回復**（待ち時間は不要。回復しない残り 2 件はパスが実在
+///   しないもので、これは恒久的失敗として正しい）
+///
+/// リトライしないと呼び出し側が「アイコンが無い」と解釈して恒久的に latch し、その行は
+/// グレーのプレースホルダのままになる（本 issue の症状）。
+fn extract_icon(path: &str) -> Result<IconData, IconFailure> {
+    // 3 回まで（= リトライ 2 回）。実測では 2 回目でほぼ全て成功するが、並列負荷下の
+    // run によっては 1 リトライ後も数件残ったため 1 回ぶん余裕を持たせる。**待ち時間は
+    // 置かない**（0ms リトライで回復することを実測済み・待っても回復率は変わらない）。
+    // リトライするのは `NoIconHandle` だけ——`ShellQueryFailed`（パス不在）は何度呼んでも
+    // 同じで、無駄なシェル問い合わせを増やすだけである（実測: 6 回試しても回復しない）。
+    let mut last = extract_icon_once(path);
+    for _ in 0..2 {
+        if !matches!(last, Err(IconFailure::NoIconHandle)) {
+            break;
+        }
+        last = extract_icon_once(path);
+    }
+    last
+}
+
+fn extract_icon_once(path: &str) -> Result<IconData, IconFailure> {
     let resolved = resolve_to_full_path(path);
     unsafe {
         let wide_path: Vec<u16> = resolved.encode_utf16().chain(std::iter::once(0)).collect();
@@ -190,8 +257,11 @@ fn extract_icon(path: &str) -> Option<IconData> {
             SHGFI_ICON | SHGFI_SMALLICON,
         );
 
-        if result == 0 || shfi.hIcon.is_invalid() {
-            return None;
+        if result == 0 {
+            return Err(IconFailure::ShellQueryFailed(GetLastError().0));
+        }
+        if shfi.hIcon.is_invalid() {
+            return Err(IconFailure::NoIconHandle);
         }
 
         let icon_data = hicon_to_bgra(shfi.hIcon);
@@ -200,18 +270,18 @@ fn extract_icon(path: &str) -> Option<IconData> {
     }
 }
 
-fn hicon_to_bgra(hicon: HICON) -> Option<IconData> {
+fn hicon_to_bgra(hicon: HICON) -> Result<IconData, IconFailure> {
     unsafe {
         let mut icon_info = ICONINFO::default();
         if GetIconInfo(hicon, &mut icon_info).is_err() {
-            return None;
+            return Err(IconFailure::IconInfoFailed(GetLastError().0));
         }
 
         let _cleanup = BitmapCleanup(&icon_info);
 
         let hdc_screen = CreateCompatibleDC(None);
         if hdc_screen.is_invalid() {
-            return None;
+            return Err(IconFailure::CreateDcFailed(GetLastError().0));
         }
 
         let width = ICON_SIZE as u32;
@@ -232,28 +302,41 @@ fn hicon_to_bgra(hicon: HICON) -> Option<IconData> {
 
         let mut pixels = vec![0u8; (width * height * 4) as usize];
 
-        if !icon_info.hbmColor.is_invalid() {
-            let old = SelectObject(hdc_screen, icon_info.hbmColor.into());
-            GetDIBits(
-                hdc_screen,
-                icon_info.hbmColor,
-                0,
-                height,
-                Some(pixels.as_mut_ptr() as *mut _),
-                &mut bmi,
-                DIB_RGB_COLORS,
-            );
-            SelectObject(hdc_screen, old);
+        if icon_info.hbmColor.is_invalid() {
+            let _ = DeleteDC(hdc_screen);
+            return Err(IconFailure::NoColorBitmap);
         }
+        let old = SelectObject(hdc_screen, icon_info.hbmColor.into());
+        // **戻り値（コピーできた走査行数）を捨てない**（#692）。0 は失敗であり、
+        // 捨てると pixels が初期値ゼロのまま「全画素ゼロ」に化けて理由が消える。
+        let scanlines = GetDIBits(
+            hdc_screen,
+            icon_info.hbmColor,
+            0,
+            height,
+            Some(pixels.as_mut_ptr() as *mut _),
+            &mut bmi,
+            DIB_RGB_COLORS,
+        );
+        let dib_error = if scanlines == 0 {
+            Some(GetLastError().0)
+        } else {
+            None
+        };
+        SelectObject(hdc_screen, old);
 
         let _ = DeleteDC(hdc_screen);
 
-        let has_data = pixels.iter().any(|&b| b != 0);
-        if !has_data {
-            return None;
+        if let Some(code) = dib_error {
+            return Err(IconFailure::GetDiBitsFailed(code));
         }
 
-        Some(IconData {
+        let has_data = pixels.iter().any(|&b| b != 0);
+        if !has_data {
+            return Err(IconFailure::AllPixelsZero);
+        }
+
+        Ok(IconData {
             width,
             height,
             bgra: pixels,
@@ -307,6 +390,62 @@ fn bgra_to_png(data: &IconData) -> Option<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #692 の再現ハーネス（`#[ignore]`・環境依存ゆえ CI では走らせない）。
+    ///
+    /// シェルのアイコンキャッシュは**プロセスごとに冷えており**、初回要求で
+    /// `SHGetFileInfoW` が成功を返しながら HICON を返さないことがある（`NoIconHandle`）。
+    /// 修正（`extract_icon` の即時リトライ）が効いていることは、**冷えたプロセスで
+    /// 1 周目に `NoIconHandle` が出ないこと**で確かめる——温まった後では区別が付かない。
+    ///
+    /// ```text
+    /// $env:SNOTRA_ICON_DIAG_PATHS = "C:\path\a;C:\path\b"   # 省略時は既定の 5 件
+    /// cargo test -p snotra diagnose_icon_cold_start -- --ignored --nocapture
+    /// ```
+    ///
+    /// 実測（2026-07-26・396 パス）: 修正前は 1 周目に 16〜18 件の `NoIconHandle`、
+    /// 修正後は 0 件（残る `ShellQueryFailed` はパス不在で、恒久的失敗として正しい）。
+    #[test]
+    #[ignore]
+    fn diagnose_icon_cold_start() {
+        use rayon::prelude::*;
+        use std::collections::BTreeMap;
+
+        let default = [
+            r"C:\Windows\explorer.exe",
+            r"C:\Windows\notepad.exe",
+            r"C:\Windows\System32\cmd.exe",
+            r"C:\Windows",
+            r"C:\Program Files",
+        ]
+        .join(";");
+        let paths: Vec<String> = std::env::var("SNOTRA_ICON_DIAG_PATHS")
+            .unwrap_or(default)
+            .split(';')
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_owned())
+            .collect();
+        println!("対象 {} 件", paths.len());
+
+        // **最初に測る**——先に別の pass を走らせるとシェルのキャッシュが温まり、
+        // 「冷えた初回」の観測ができなくなる（計測順序そのものが観測対象を変える）。
+        for round in 1..=2 {
+            let mut kinds: BTreeMap<String, usize> = BTreeMap::new();
+            let failures: Vec<(String, IconFailure)> = paths
+                .par_iter()
+                .filter_map(|p| extract_png(p).err().map(|e| (p.clone(), e)))
+                .collect();
+            for (_, e) in &failures {
+                let label = format!("{e:?}");
+                let kind = label.split('(').next().unwrap_or(&label).to_owned();
+                *kinds.entry(kind).or_default() += 1;
+            }
+            println!("  周 {round}: 失敗 {} 件 {kinds:?}", failures.len());
+            for (p, e) in failures.iter().take(5) {
+                println!("    {e:?} exists={} {p}", std::path::Path::new(p).exists());
+            }
+        }
+    }
 
     /// issue #522 の回帰テスト: invalidate（ファイル削除 + メモリ None 化）と
     /// 並行ロード（None 検知 → icons.bin ロード）を並走させ、「icons.bin 不在なのに
@@ -545,7 +684,7 @@ mod tests {
                     let t = Instant::now();
                     let out = extract_png(p);
                     us.push(t.elapsed().as_micros());
-                    assert!(out.is_some(), "{p} の抽出が None（テスト前提の実在パス）");
+                    assert!(out.is_ok(), "{p} の抽出が失敗（テスト前提の実在パス）: {out:?}");
                 }
             }
             println!(


### PR DESCRIPTION
## 概要

検索結果のアイコンが表示されない（グレーのプレースホルダのまま）件を、**計器を入れて原因に名乗らせてから**直す。#628 で確立した「原因を決める前に測る」刻みに従い、推測で当てた仮説を 3 つ実測で潰したうえで真因に到達した。

## 根本原因

`SHGetFileInfoW(SHGFI_ICON)` は **成功（非 0）を返しながら HICON を返さない**ことがある。**プロセスごとに冷えたシェルのアイコンキャッシュ**への初回要求で起きる。

| 実測 | 値 |
|---|---|
| 実機 1 セッションでの失敗 | **17 件すべて `NoIconHandle`**・全て `exists=true` |
| 396 パス × 6 周 | 失敗するのは**周 1 だけ**（16 件 → 以降 0 件） |
| 新しいプロセスで再実行 | **また周 1 で 18 件失敗** → キャッシュはプロセスごと |
| 冷えた並列負荷下の試行回数 | 1 回目 379 / **2 回目 15** / 6 回でも失敗 2（＝実在しないパス） |
| 待ち時間の効果 | 0ms でも 50ms でも回復率は同じ → **待つ必要はない** |

呼び出し側はこれを「アイコンが無い」と解釈して**恒久的に latch** するため、その行は可視である限りグレーのままだった。

## 変更

### 1. `NoIconHandle` を最大 2 回リトライする（`60ca312`）

待ち時間は置かない（0ms で回復すると実測）。`ShellQueryFailed`（パス不在）はリトライしない——6 回試しても回復しないと実測済みで、無駄なシェル問い合わせを増やすだけ。

### 2. 失敗理由を型で運ぶ（`60ca312`）

`extract_png` の戻り値を `Option<Vec<u8>>` → `Result<_, IconFailure>` へ。**失敗を `None` に潰していたため原因の段階が消えていた**——これが無ければ今回の特定はできなかった。

あわせて **`GetDIBits` の戻り値を捨てていた**のを直した。失敗しても `pixels` が初期値ゼロのまま残り、後段の「全画素ゼロ」判定に化けて理由が消えていた。

### 3. 一過性の失敗を恒久扱いしない（`7464c82`）

- `load_icon_pngs` の戻り値を `IconOutcome`（`Png` / `Failed(IconFailure)` / `Unavailable`）へ。`Unavailable` はキャッシュ自体が使えなかった場合で、パス固有の失敗ではないため恒久扱いしない
- `IconMsg::Missing` に「再試行してよいか」を持たせる
- `icon_missing: HashSet` → **`icon_attempts: HashMap<String, u8>`**。「失敗したか」ではなく「何回失敗したか」を持ち、`ICON_MAX_ATTEMPTS` で打ち切る。恒久的な失敗（パス不在・decode 不能）は上限を直接入れて即諦める
- **`icon_pending` も可視集合で刈る**。worker が 1 通も送らずに終わる経路（managed state 不在で早期 return）があり、刈らないと path が永久に in-flight のまま `needs_extraction` を通れない（`icon_missing` だけが刈られていた非対称の解消）

## 検証

**冷えたプロセスで `NoIconHandle` = 0 件**（修正前は毎回 16〜18 件）。3 プロセスとも再現。

実機（release・`SNOTRA_TRACE=1`・200 件の結果を 2 回描画）:

| | 修正前 | 修正後 |
|---|---|---|
| `icon:extract_failed` | **17 件** | **0 件** |
| `egui_icon:decode_failed` | — | **0 件** |
| 目視（スクリーンショット 2 枚） | `cassini_of_summer_sky` / `C:\Toolbox\Snotra` / `ghost-launcher.exe` がグレー | **グレーなし・全行にアイコン** |

- `cargo test -p snotra` — **150 passed / 0 failed**
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `needs_extraction` のテストを更新（「1 度失敗しただけでは諦めない」「上限に達したら諦める」を検証）

## 計器の去就

`SNOTRA_TRACE` ゲート下で 2 本を恒久計器として残す（未設定なら 1 行も出ない）:

- **`icon:extract_failed`** — path / 段階 / `GetLastError` / `exists` / `transient`
- **`egui_icon:decode_failed`** — キャッシュ済みバイト列が decode できない稀なケース

**毎フレーム出る `egui_icon:request` は外した**——他のイベントが読めなくなり、診断としての役目も終えたため。

再現ハーネス `diagnose_icon_cold_start`（`#[ignore]`）を残す。**修正の検証条件が「冷えた 1 周目で `NoIconHandle` が出ないこと」であり、温まった後では区別が付かない**ため、計測順序ごとハーネスに固定した（実際、最初の計測で順序を誤って自分の観測を汚染した）。

## 副次的に起票した issue

計測中に見つかった別事象（この PR のスコープ外）:

- **#714** — 再検索時に結果窓が前のスクロール位置から先頭までアニメーションする
- **#715** — 実機で Windows の通知音が 1 回鳴った（再現性乏しい。アプリ内の唯一の候補は特定済みで、`config.toml.bak` のタイムスタンプから当日については棄却）

Closes #692
