### PR TITLE
config.toml のカラー変更を main/results 両ウィンドウへ即時反映

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -368,7 +368,7 @@ bool フラグでは検知できず、実際の kana 文字列の `starts_with` 
 - 設定の読み込み失敗時の扱い（`config_watcher`）:
   - 内容破損（TOML parse 失敗・非 UTF-8）: 既定値を適用し `config.toml.bak` へ退避、トレイバルーンで通知
   - 一時的・環境的な失敗（権限/ロック/共有違反, `LoadOutcome::ReadFailed`）: まず短いバウンドリトライ（既定 3 回 × 150ms backoff）でロック解除を待ち、解けたら正規の変更を適用する（取りこぼし防止）。予算を使い切っても失敗する場合は **実行中の設定を維持し、何も適用しない**（既定値で上書きせず、再インデックスや履歴剪定も走らせない）。`config.toml` は無傷なので次の保存イベントでも回収される。live-read 化した履歴剪定が既定値で走るとデータ損失になるため（#348）
-- 反映機構（#532 SU6）: config_watcher は適用完了後に `config-applied` を発火し、egui ウィンドウはこれを再描画の合図としてのみ消費する（値は運ばず、毎フレーム実行中 config を live-read）。`indexing-started` / `indexing-complete` も同様に合図として消費し、index build 完了世代（`index_generation`）の差分で現クエリを再検索する（§4.7・#633）。font_family・ウィンドウ幅・ネイティブ背景ブラシはフレーム内のエッジ検出で追従する。hotkey 登録失敗——設定変更時（`hotkey-registration-failed`）は payload を保持し次の表示時に整形・通知し、起動時（`initial-hotkey-failed`）は §10 のとおり検索 UI を能動表示してから通知する（#652）
+- 反映機構（#532 SU6）: config_watcher は適用完了後に `config-applied` を発火し、main/results 両 egui ウィンドウは同じイベントを再描画の合図としてのみ消費する（値は運ばず、毎フレーム実行中 config を live-read）。main の `Visuals` 変更は root UI の style snapshot より後に適用されるため、差分がある場合だけ次の pass も要求する。`background_color` のエッジ検出では main/results 両方のネイティブ背景ブラシを更新する。`indexing-started` / `indexing-complete` も同様に main の合図として消費し、index build 完了世代（`index_generation`）の差分で現クエリを再検索する（§4.7・#633）。font_family・ウィンドウ幅もフレーム内のエッジ検出で追従する。hotkey 登録失敗——設定変更時（`hotkey-registration-failed`）は payload を保持し次の表示時に整形・通知し、起動時（`initial-hotkey-failed`）は §10 のとおり検索 UI を能動表示してから通知する（#652）
 
 ### 7.6 起動時の設定初期化
 

--- a/src-tauri/src/egui_shell/mod.rs
+++ b/src-tauri/src/egui_shell/mod.rs
@@ -383,11 +383,15 @@ pub(crate) fn register_hide_listener(app: &tauri::AppHandle) {
 /// 最新を描く）。**「値を運ばない」はこの benign 性の load-bearing 前提**——将来イベントに値を
 /// 載せる変更はこの前提を壊す（spec 決定 1）。
 pub(crate) fn register_config_wake_listeners(app: &tauri::AppHandle) {
-    for event in [
-        crate::events::CONFIG_APPLIED,
-        crate::events::INDEXING_STARTED,
-        crate::events::INDEXING_COMPLETE,
-    ] {
+    {
+        let handle = app.clone();
+        app.listen(crate::events::CONFIG_APPLIED, move |_| {
+            // update_config 後、両 Context を同じイベントで直接起こす。
+            wake_main(&handle);
+            wake_results(&handle);
+        });
+    }
+    for event in [crate::events::INDEXING_STARTED, crate::events::INDEXING_COMPLETE] {
         let handle = app.clone();
         app.listen(event, move |_| {
             wake_main(&handle);

--- a/src-tauri/src/egui_shell/view.rs
+++ b/src-tauri/src/egui_shell/view.rs
@@ -273,18 +273,18 @@ impl EguiView for SearchWindowView {
         // 値はフレーム冒頭の `visual` から取る（#673）。**適用はこの位置のまま**（呼び出し
         // 位置は本段では動かさない）——egui 0.35.0 では root `Ui` が pass 冒頭で
         // `ctx.global_style()` を `Arc` snapshot するため、ここで呼ぶ `ctx.set_visuals` は
-        // 現在の pass の `Ui` に届かない。この潜在バグは #751 であり、**本段では直さない**。
+        // 現在の pass の `Ui` に届かないため、下の差分判定で次 pass を 1 回だけ要求する。
         let mut visuals = ctx.style_of(ctx.theme()).visuals.clone();
-        visuals.panel_fill = visual.background;
-        visuals.window_fill = visuals.panel_fill;
-        visuals.extreme_bg_color = visual.input_bg; // TextEdit 背景
-        visuals.selection.bg_fill = visual.selection;
         // TextEdit の hint 色はここだけが効く（#654・詳細は TextEdit 構築部のコメント）。
         // **他の描画を巻き込まない**: この view が使う egui ウィジェットは TextEdit 1 つだけで
         //（`ui.label` / `ui.button` の類は 0 件・残りは raw painter に色を明示渡し）、
         // weak text を読むのはその hint のみ。results 窓は別 Context ゆえ影響外。
-        visuals.weak_text_color = Some(visual.hint);
+        let visual_refresh_needed = super::visual::apply_main_visuals(&mut visuals, &visual);
         ctx.set_visuals(visuals);
+        if visual_refresh_needed {
+            // root Ui は pass 冒頭の style snapshot を持つため、変更色を次 pass で描く。
+            ctx.request_repaint();
+        }
 
         // SU6 spec 決定 2: font_family hot-reload（WebView2 の --font-family CSS 変数即時反映 parity）。
         // applied は解決成否に依らず無条件更新（フィールド doc 参照）。
@@ -299,10 +299,13 @@ impl EguiView for SearchWindowView {
         // `#FFF` 等でこの経路の挙動が黙って変わる・#673 spec / visual.rs の `//!`）。
         if let Some(hex) = &visual.background_hex_changed {
             self.applied_background_hex = hex.clone();
-            if let Some(window) = app.get_window("main") {
-                let color = crate::config_watcher::parse_hex_color(hex)
-                    .unwrap_or(tauri::window::Color(0x28, 0x28, 0x28, 0xff));
-                let _ = window.set_background_color(Some(color));
+            let color = crate::config_watcher::parse_hex_color(hex)
+                .unwrap_or(tauri::window::Color(0x28, 0x28, 0x28, 0xff));
+            // softbuffer present 前に露出する下地は各窓のネイティブブラシである。
+            for label in ["main", "results"] {
+                if let Some(window) = app.get_window(label) {
+                    let _ = window.set_background_color(Some(color));
+                }
             }
         }
 

--- a/src-tauri/src/egui_shell/visual.rs
+++ b/src-tauri/src/egui_shell/visual.rs
@@ -129,6 +129,21 @@ pub(crate) fn visual_snapshot(
     }
 }
 
+/// main の `Visuals` へ snapshot を適用し、style の次 pass が必要なら `true` を返す。
+pub(crate) fn apply_main_visuals(visuals: &mut egui::Visuals, snapshot: &VisualSnapshot) -> bool {
+    let changed = visuals.panel_fill != snapshot.background
+        || visuals.window_fill != snapshot.background
+        || visuals.extreme_bg_color != snapshot.input_bg
+        || visuals.selection.bg_fill != snapshot.selection
+        || visuals.weak_text_color != Some(snapshot.hint);
+    visuals.panel_fill = snapshot.background;
+    visuals.window_fill = snapshot.background;
+    visuals.extreme_bg_color = snapshot.input_bg;
+    visuals.selection.bg_fill = snapshot.selection;
+    visuals.weak_text_color = Some(snapshot.hint);
+    changed
+}
+
 /// `#RRGGBB` 等を `Color32` へ。parse 失敗時は既定値（の parse 結果）へ落ちる。
 /// 既定値まで parse に失敗することは無い（`config.rs` の `default_*` は妥当な 6 桁 hex）が、
 /// release は `panic="abort"` ゆえ unwrap しない——最後は黒へ落とす。
@@ -213,5 +228,23 @@ mod tests {
             changed.background_hex_changed.as_deref(),
             Some(v.background_color.as_str())
         );
+    }
+
+    #[test]
+    fn main_visuals_report_every_config_color_change_once() {
+        let mut v = cfg();
+        v.background_color = "#123456".into();
+        v.input_background_color = "#234567".into();
+        v.selected_row_color = "#345678".into();
+        v.hint_text_color = "#456789".into();
+        let snapshot = visual_snapshot(&v, true, applied_none(&v.font_family));
+        let mut visuals = egui::Visuals::dark();
+        assert!(apply_main_visuals(&mut visuals, &snapshot));
+        assert!(!apply_main_visuals(&mut visuals, &snapshot));
+        assert_eq!(visuals.panel_fill, snapshot.background);
+        assert_eq!(visuals.window_fill, snapshot.background);
+        assert_eq!(visuals.extreme_bg_color, snapshot.input_bg);
+        assert_eq!(visuals.selection.bg_fill, snapshot.selection);
+        assert_eq!(visuals.weak_text_color, Some(snapshot.hint));
     }
 }

--- a/src-tauri/src/egui_shell/window_coordinator.rs
+++ b/src-tauri/src/egui_shell/window_coordinator.rs
@@ -470,10 +470,7 @@ pub(crate) fn drive_results_window(app: &tauri::AppHandle, i: DriveResultsInputs
     if results.show() {
         crate::trace_main("egui_results:show", serde_json::json!({ "rows": count }));
     }
-    // 決定 5（#673 spec・#697）: この無条件 wake を edge 化してはならない。results は
-    // config 系イベントを一切 listen せず（register_config_wake_listeners は wake_main のみ）、
-    // visual-only の config 変更では RowsSnapshot が不変ゆえ snapshot 差分 wake も発火しない。
-    // results が新しい色・フォント・行高を描くことを**保証する**唯一の経路がこの
-    // level-triggered wake である（入力起因の偶発 wake でも描かれるが、それに依れない）。
+    // 決定 5（#673 spec・#697）: config-applied は results も直接起こすが、入力・検索・
+    // サイズ変更にも results を追従させるため、この level-triggered wake は維持する。
     wake_results(app);
 }


### PR DESCRIPTION
### Motivation

- `config.toml` の `[visual]` 色変更が実ウィンドウ（ネイティブ背景ブラシ）や results 窓へ確実に反映されず視覚的なずれや白フラッシュが起きるケースを修正するため。
- root UI の `Visuals` は pass の style snapshot の制約で当該フレームに即時反映されないため、差分がある場合のみ追加パスで確実に適用する必要があるため。 

### Description

- `config-applied` 受信時に main と results 両方を直接起こすようにし、results の更新が main の次フレームに間接依存しないようにした（`register_config_wake_listeners` を変更して `wake_main` と `wake_results` を発火）。
- main の `Visuals` 適用ロジックをヘルパー化して `VisualSnapshot` と比較し、差分があるときだけ追加の repaint を要求する `apply_main_visuals` を追加して、余分なスピンを防止した（`src-tauri/src/egui_shell/visual.rs` / `view.rs`）。
- `background_color` 変更時に main だけでなく results も含む両ウィンドウのネイティブ背景ブラシを更新するようにした（`view.rs` のネイティブ背景更新を両窓へ拡張）。
- 色適用の収束性を検証するユニットテスト `main_visuals_report_every_config_color_change_once` を `visual.rs` のテスト群に追加した。 
- 反映経路とタイミングに関して `SPEC.md` を同期し、main/results 両窓の扱いと次パス要求の説明を明記した。 
- 作業ブランチは `fix/config-color-refresh`、コミット済み（コミット: `2ea6db3`）。

### Testing

- `npm run governance:check` を実行してガバナンス検査は合格（G1..G11 passed）。
- `npm test` を実行し Vitest の JS テスト群は全件成功（5 files / 373 tests passed）。
- Rust のユニットテスト `cargo test -p snotra main_visuals_report_every_config_color_change_once` を試行したが、コンテナ環境にシステム依存の `glib-2.0.pc` が存在しないため `glib-sys` ビルドで失敗し完遂できなかった（環境依存のビルド失敗）。
- フォーマットと静的チェックは `rustfmt` / `git diff --check` を実行し問題なしを確認した。 
- `git push` はこの環境に `origin` remote が設定されていないため実行できなかった（ローカルでブランチ作成・コミットは完了）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67862a6f488322aefeb5c342456ffb)