### PR TITLE
feat(governance): ADR ファイル名と見出しの形を検査する G-adr-file-names (#816)

### DIFF
--- a/scripts/governance-check.mjs
+++ b/scripts/governance-check.mjs
@@ -1234,6 +1234,57 @@ export function checkCheckSkillEnumeration(snapshot) {
 }
 
 // ---------------------------------------------------------------------------
+// G-adr-file-names — `docs/adr/` のファイル名が `ADR-<slug>.md` 形で、本文の見出しと一致するか（#816）。
+//
+// `G-adr-citations` は**引用側**しか見ない——「`ADR-<slug>` と書かれた引用に対応するファイルが
+// 在るか」を照合する。**ファイルの側が規約に従っているか**は見ておらず、`docs/adr/foo.md` を
+// 作っても誰も引用しなければ静かに通る（#789 の見直しで残余として特定した）。
+//
+// 見出しと stem の一致まで見るのは、#812 の裁定が「**stem = 引用文字列**」にすることで機械照合を
+// 可能にしたからである。2 つがずれると、文書の自己申告と実体が食い違う——引用は解決するのに
+// 開いた先が別の名前を名乗る形になり、どちらが正しいかを機械で決められなくなる。
+//
+// **連番へ戻る変更もここで落ちる**（`0019-foo.md` は形に合わない）。#812 が廃した連番は、
+// 規範だけでは戻りうる——「番号の方が並び順が分かる」という理由は毎回もっともらしく見える。
+// ---------------------------------------------------------------------------
+
+/** ADR のファイル名の形。stem がそのまま短縮引用になる（#812） */
+const ADR_FILE_NAME = /^ADR-([a-z][a-z0-9]*(?:-[a-z0-9]+)*)\.md$/;
+
+export function adrFiles(snapshot) {
+  return snapshot.files.filter((f) => /^docs\/adr\/[^/]+\.md$/.test(f));
+}
+
+export function checkAdrFileNames(snapshot) {
+  const findings = [];
+  const files = adrFiles(snapshot);
+  // 空母集団は明示 fail——走査が空でも「逸脱なし」に見える沈黙経路を塞ぐ（#497）
+  if (files.length === 0) return [finding("docs/adr", 1, "ADR が 0 件（G-adr-file-names 母集団の欠落）")];
+  for (const f of files) {
+    const base = f.slice("docs/adr/".length);
+    const m = base.match(ADR_FILE_NAME);
+    if (!m) {
+      findings.push(finding(f, 1, `ADR のファイル名が \`ADR-<slug>.md\` 形でない: ${base}（連番を振らない・#812）`));
+      continue;
+    }
+    const text = snapshot.read(f);
+    if (text == null) {
+      findings.push(finding(f, 1, "ADR が読めない（G-adr-file-names 母集団の欠落）"));
+      continue;
+    }
+    const heading = text.split("\n")[0].match(/^#\s+(ADR-[a-z0-9-]+)\s*[:：]/);
+    if (heading == null) {
+      findings.push(finding(f, 1, `冒頭が \`# ADR-<slug>: <題>\` の形でない（stem = 引用文字列の対応が取れない）`));
+    } else if (heading[1] !== `ADR-${m[1]}`) {
+      findings.push(
+        finding(f, 1, `見出しがファイル名と食い違う: 見出し \`${heading[1]}\` / ファイル名 \`ADR-${m[1]}\``),
+      );
+    }
+  }
+  return findings;
+}
+
+// ---------------------------------------------------------------------------
 // G-adr-citations — `ADR-<slug>` の短縮引用が実在の ADR を指すか（#812 の A）。
 //
 // **連番だった頃、この検査は書けなかった。** `ADR-0007` はファイル名の一部でしかなく、
@@ -1317,6 +1368,7 @@ export function buildChecks(snapshot, sink = {}) {
     { id: "G-area-budget", run: () => checkNormativeAreaBudget(snapshot) },
     { id: "G-config-reachability", run: () => checkConfigFieldReachability(snapshot) },
     { id: "G-check-skill-enumeration", run: () => checkCheckSkillEnumeration(snapshot) },
+    { id: "G-adr-file-names", run: () => checkAdrFileNames(snapshot) },
     { id: "G-adr-citations", run: () => record("adrCitations", scanAdrCitations(snapshot, adrCitationDocs(snapshot, docs))) },
     { id: "G-heading-refs", run: () => record("headingRefs", scanHeadingRefs(snapshot, refDocs)) },
     { id: "G-stale-identifiers", run: () => record("stale", scanStaleIdentifiers(snapshot, staleDocs)) },
@@ -1336,7 +1388,7 @@ export function runAll(snapshot) {
   const rules = snapshot.files.filter((f) => /^\.claude\/rules\/[^/]+\.md$/.test(f)).length;
   const skills = snapshot.files.filter((f) => /^\.claude\/skills\/[^/]+\/SKILL\.md$/.test(f)).length;
   const configFieldCount = CONFIG_SOURCE_PATHS.flatMap((p) => configFields(snapshot.read(p) ?? "")).length;
-  const evidence = `検査 ${checks.length} 件 / 対象文書 ${ctx.docs.length} 件 / rules ${rules} 件 / skills ${skills} 件 / 恒久規範 常時ロード ${area.always}/${AREA_BUDGET.alwaysLoaded} 字・rules ${area.rules}/${AREA_BUDGET.rules} 字 / 見出し参照 ${ctx.headingRefs} 件を ${ctx.refDocs.length} 文書から照合 / config フィールド ${configFieldCount} 件の到達性 / 規範の識別子 ${ctx.stale} 件を ${ctx.staleDocs.length} 文書から照合 / 近傍の見出し参照 ${ctx.nearRefs} 件 / ADR の短縮引用 ${ctx.adrCitations} 件`;
+  const evidence = `検査 ${checks.length} 件 / 対象文書 ${ctx.docs.length} 件 / rules ${rules} 件 / skills ${skills} 件 / 恒久規範 常時ロード ${area.always}/${AREA_BUDGET.alwaysLoaded} 字・rules ${area.rules}/${AREA_BUDGET.rules} 字 / 見出し参照 ${ctx.headingRefs} 件を ${ctx.refDocs.length} 文書から照合 / config フィールド ${configFieldCount} 件の到達性 / 規範の識別子 ${ctx.stale} 件を ${ctx.staleDocs.length} 文書から照合 / 近傍の見出し参照 ${ctx.nearRefs} 件 / ADR ${adrFiles(snapshot).length} 本の名前 / ADR の短縮引用 ${ctx.adrCitations} 件`;
   return { findings, evidence };
 }
 

--- a/scripts/governance-check.test.mjs
+++ b/scripts/governance-check.test.mjs
@@ -38,6 +38,8 @@ import {
   currentVocabulary,
   runAll,
   buildChecks,
+  checkAdrFileNames,
+  adrFiles,
   checkAdrCitations,
   scanAdrCitations,
   adrCitationDocs,
@@ -841,6 +843,48 @@ describe("G-config-reachability カナリア — 守りたい対象が実リポ�
     delete without["VisualConfig.preset"];
     const f = checkConfigFieldReachability(s, without);
     expect(f.some((x) => x.message.includes("VisualConfig.preset"))).toBe(true);
+  });
+});
+
+describe("G-adr-file-names（ADR のファイル名と見出しの形・#816）", () => {
+  // 守りたい対象 = `docs/adr/foo.md` や連番への逆戻り。G-adr-citations は引用側しか見ないので、
+  // 誰も引用しなければ逸脱が静かに通る（#789 の見直しで残余として特定）。
+  const ok = { "docs/adr/ADR-plan-ownership-boundary.md": "# ADR-plan-ownership-boundary: 計画の所有境界\n" };
+
+  it("形が揃っていれば findings 無し（緑）", () => {
+    expect(checkAdrFileNames(snap(ok))).toEqual([]);
+  });
+
+  it("赤: 連番へ戻る（#812 が廃した形）", () => {
+    const f = checkAdrFileNames(snap({ ...ok, "docs/adr/0019-foo.md": "# ADR-0019: x\n" }));
+    expect(f.some((x) => x.message.includes("0019-foo.md"))).toBe(true);
+  });
+
+  it("赤: ADR- 前置が無い", () => {
+    const f = checkAdrFileNames(snap({ ...ok, "docs/adr/foo.md": "# ADR-foo: x\n" }));
+    expect(f.some((x) => x.message.includes("foo.md"))).toBe(true);
+  });
+
+  it("赤: 見出しがファイル名と食い違う（stem = 引用文字列の対応が崩れる）", () => {
+    const f = checkAdrFileNames(snap({ "docs/adr/ADR-alpha.md": "# ADR-beta: x\n" }));
+    expect(f).toHaveLength(1);
+    expect(f[0].message).toContain("食い違う");
+  });
+
+  it("赤: 冒頭が `# ADR-<slug>:` の形でない", () => {
+    const f = checkAdrFileNames(snap({ "docs/adr/ADR-alpha.md": "# 計画の所有境界\n" }));
+    expect(f[0].message).toContain("形でない");
+  });
+
+  it("カナリア: 空母集団は明示 fail（走査が空でも「逸脱なし」に見える沈黙経路を塞ぐ）", () => {
+    const f = checkAdrFileNames(snap({ "CLAUDE.md": "" }));
+    expect(f).toHaveLength(1);
+    expect(f[0].message).toContain("母集団の欠落");
+  });
+
+  it("判定対象外の不混入: docs/adr/ 直下の md だけを見る", () => {
+    const s = snap({ ...ok, "docs/adr/sub/0001-x.md": "", "docs/architecture.md": "", "docs/adr/notes.txt": "" });
+    expect(adrFiles(s)).toEqual(["docs/adr/ADR-plan-ownership-boundary.md"]);
   });
 });
 


### PR DESCRIPTION
#789 の見直しで残余として特定した穴を塞ぐ。

## 穴

`G-adr-citations`（#812 の A・PR #815）は**引用側**しか見ない——「`ADR-<slug>` と書かれた引用に対応するファイルが在るか」を照合する検査であり、**ファイルの側が規約に従っているか**は見ていなかった。`docs/adr/foo.md` を作っても、**誰も引用しなければ静かに通る**。

## 見るもの

| 判定 | 落ちる例 |
|---|---|
| ファイル名が `ADR-<slug>.md` 形か | `0019-foo.md`（連番へ戻る）/ `foo.md`（前置なし） |
| 冒頭の `# ADR-<slug>:` が stem と一致するか | ファイル名 `ADR-alpha` / 見出し `ADR-beta` |

**見出しまで見るのは、#812 の裁定が「stem = 引用文字列」にすることで機械照合を可能にしたからである。** 2 つがずれると、引用は解決するのに開いた先が別の名前を名乗る形になり、**どちらが正しいかを機械で決められなくなる**。

**連番へ戻る変更もここで落ちる。** #812 が廃した連番は規範だけでは戻りうる——「番号の方が並び順が分かる」という理由は毎回もっともらしく見える。

## カナリア

**母集団が空なら明示 fail** にした。走査が空でも「逸脱なし」に見える沈黙経路を塞ぐ（#497・`.claude/rules/safety-nets.md`「これまで無意味だった状態に意味を与える変更は、その状態に到達する全経路を列挙する」）。

## 検証

- **実リポジトリで 3 種の逸脱を注入**し、それぞれ赤が出て復元できることを確認:

| 種 | 出た finding |
|---|---|
| `0019-foo.md` を置く | `ADR のファイル名が ADR-<slug>.md 形でない: 0019-foo.md（連番を振らない・#812）` |
| `foo.md` を置く | 同上 |
| 見出しを `ADR-something-else` へ | `見出しがファイル名と食い違う: 見出し ADR-something-else / ファイル名 ADR-norm-review-seeding` |

- `npm run governance:check` — **全検査 passed**（**17 検査** / ADR 19 本の名前）
- `npm test` — **467 件 passed**（新規 7 件・空母集団のカナリアを含む）
- 現状 **19/19** がファイル名の形を満たし、**見出しも全件 stem と一致**している（実測）
- `cargo` 系は該当なし（Rust の変更なし）

## 検査を足すのに番号の割り当ては要らなかった

PR #814 で入れた登録表に**1 行**足すだけで「検査 16 件」→「17 件」へ自動更新された。#812 の狙いが 2 回目も効いている。

Closes #816
