### PR TITLE
chore(rules): safety-nets と governance-docs の paths を scripts/*.mjs へ広げる

### DIFF
--- a/.claude/rules/governance-docs.md
+++ b/.claude/rules/governance-docs.md
@@ -3,7 +3,7 @@ paths:
   - "AGENTS.md"
   - "CLAUDE.md"
   - "docs/adr/**"
-  - "scripts/governance-check.mjs"
+  - "scripts/*.mjs"
 ---
 
 # ガバナンス文書の参照と命名のルール

--- a/.claude/rules/safety-nets.md
+++ b/.claude/rules/safety-nets.md
@@ -6,7 +6,7 @@ paths:
   - ".github/workflows/**"
   - ".claude/rules/**"
   - ".claude/skills/**"
-  - "scripts/governance-check.mjs"
+  - "scripts/*.mjs"
 ---
 
 # セーフティネット（hook / CI / githooks / 規範）を新設・変更するときのルール


### PR DESCRIPTION
`.claude/rules/` の 2 本が `paths` で `scripts/governance-check.mjs` を**名指ししていた**ため、他のセーフティネットスクリプトを直す人にルールが配送されなかった。両方を `scripts/*.mjs` へ広げる。

#834（`plan:ledger` の母集団永続化）の実装中に発見し、エージェント設定の変更ゆえ同 PR の射程外としてユーザー判断へ回したもの。裁定は「glob で足す」（2026-07-29）。

## 1 件ずつではなく glob にした理由

同一パターンをコードベース全体で探すと（`AGENTS.md`「バグ発見時は同一パターン全コードパス検索を行う」）、**穴は当初報告した 1 件ではなく 2 rules × 2 スクリプト**だった。判別線は「check スキルの判定がそれに依存するか」で、規範からの参照数がそのまま出る:

| スクリプト | 規範からの参照 | セーフティネットか |
|---|---|---|
| `governance-check.mjs` | 23 文書 | ✓（既に `paths` にあった） |
| `plan-review-ledger.mjs` | 2 文書 | ✓（#834 で見つけた穴） |
| `race-boundaries.mjs` | 1 文書 | ✓（**同型の穴**） |
| `clean-worktrees.mjs` | 0 文書 | ✗（純粋なユーティリティ） |

1 件ずつ足す形では、次にスクリプトが増えたとき同じ漏れが再発する——**そしてその漏れを検出する機構は無い**。glob なら自動で覆え、`.test.mjs` も入る（セーフティネットのテストを直すのもセーフティネットの変更である）。

## 射程は推測せず、ツール自身に問うた

glob の意味論はツールごとに違うため（`docs/development-principles.md`「列挙の完全性」）、検査側の matcher を直接呼んだ:

```
globToRegex("scripts/*.mjs") → /^scripts\/[^/]*\.mjs$/
マッチする実ファイル 8 件（4 スクリプト + 各テスト）・`*` は `/` を跨がない
```

`governance-docs.md` 側は**具体対象で両方向の検算**も行った（`.claude/rules/safety-nets.md`「検査の入力集合を、具体対象で検算する」）——8 件中 6 件が正準形の参照か ADR 参照を実際に持ち、0 件なのは `clean-worktrees` 系の 2 件だけだった。

**2 つの rules の配送対象が一致したことで、片方だけが古びる形も消えた。** `grep -rn 'scripts/governance-check.mjs"' .claude/rules/` は 0 件。

## 引き換えに受け入れたこと

**`clean-worktrees.mjs` とそのテストへ誤配送する。** `safety-nets.md` 自身が「誤配送を避けるため規範文書は `paths` 外」と述べており、これは意図的なトレードオフである。当該スクリプトは git worktree とブランチを消す破壊的ユーティリティで、フォールトインジェクションの規律も正準形の規律も、有害になる相手ではない。

## 検証

`npm run governance:check` 全 18 検査 passed（`G-rules-globs` を含む）。

## 受容する残余

**配送そのものは本サイクルで実測できていない。** 両 rules とも同一セッションで既に配送済みで、harness はセッション内で重複配送しない（`scripts/race-boundaries.mjs` を実際に読んでも再配送されなかった——これは緑にも赤にも読めない観測である）。**次の新しいセッションで `scripts/*.mjs` を触った回が、最初の観測機会になる。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
