### PR TITLE
test: GUI入力のフレーム合流を許容し失敗時traceを出力

### DIFF
--- a/scripts/lib/SnotraSmoke.Tests.ps1
+++ b/scripts/lib/SnotraSmoke.Tests.ps1
@@ -255,6 +255,20 @@ include_folders = true
             & $pressKey 0x1B # Escape: alpha を復元し、次の z が末尾へ入るべき経路。
             & $pressKey 0x5A
             & $waitForInputChange 'search' 5 6 $true | Should -Not -BeNullOrEmpty
+        } catch {
+            Write-Host '--- caret integration stderr trace ---'
+            if (Test-Path -LiteralPath $stderr) {
+                $stderrLines = @(Get-Content -LiteralPath $stderr)
+                if ($stderrLines.Count -eq 0) {
+                    Write-Host '(stderr is empty)'
+                } else {
+                    $stderrLines | ForEach-Object { Write-Host $_ }
+                }
+            } else {
+                Write-Host "(stderr file not found: $stderr)"
+            }
+            Write-Host '--- end caret integration stderr trace ---'
+            throw
         } finally {
             if ($null -ne $proc -and -not $proc.HasExited) {
                 Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue

--- a/scripts/lib/SnotraSmoke.Tests.ps1
+++ b/scripts/lib/SnotraSmoke.Tests.ps1
@@ -205,9 +205,9 @@ include_folders = true
         $waitForInputChange = {
             param(
                 [string]$Scope,
-                [int]$BeforeChars,
                 [int]$AfterChars,
                 [bool]$AppendedAtEnd,
+                [Nullable[int]]$BeforeChars = $null,
                 [int]$TimeoutMs = 5000
             )
             $deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMs)
@@ -215,9 +215,9 @@ include_folders = true
                 $matched = @(Read-SnotraTraceEvents -Path $stderr | Where-Object {
                     $_.event -eq 'egui_input:changed' -and
                     $_.data.scope -eq $Scope -and
-                    $_.data.before_chars -eq $BeforeChars -and
                     $_.data.after_chars -eq $AfterChars -and
-                    $_.data.appended_at_end -eq $AppendedAtEnd
+                    $_.data.appended_at_end -eq $AppendedAtEnd -and
+                    ($null -eq $BeforeChars -or $_.data.before_chars -eq $BeforeChars)
                 } | Select-Object -Last 1)
                 if ($matched.Count -gt 0) { return $matched[0] }
                 if ($null -ne $proc -and $proc.HasExited) { break }
@@ -244,17 +244,21 @@ include_folders = true
             Set-SnotraForegroundWindow -Handle $hwnd | Should -BeTrue
             Start-Sleep -Milliseconds 300
             foreach ($vk in [byte[]](0x41, 0x4C, 0x50, 0x48, 0x41)) { & $pressKey $vk }
-            & $waitForInputChange 'search' 4 5 $true | Should -Not -BeNullOrEmpty
+            # runner が遅いと複数文字が同一フレームへまとまるため、準備入力は最終状態だけを見る。
+            & $waitForInputChange -Scope 'search' -AfterChars 5 -AppendedAtEnd $true |
+                Should -Not -BeNullOrEmpty
 
             & $pressKey 0x27 # Right: 唯一の検索結果である alpha フォルダへ入る。
             Start-Sleep -Milliseconds 300
             & $pressKey 0x41
             & $pressKey 0x41
-            & $waitForInputChange 'folder' 1 2 $true | Should -Not -BeNullOrEmpty
+            & $waitForInputChange -Scope 'folder' -AfterChars 2 -AppendedAtEnd $true |
+                Should -Not -BeNullOrEmpty
 
             & $pressKey 0x1B # Escape: alpha を復元し、次の z が末尾へ入るべき経路。
             & $pressKey 0x5A
-            & $waitForInputChange 'search' 5 6 $true | Should -Not -BeNullOrEmpty
+            & $waitForInputChange -Scope 'search' -BeforeChars 5 -AfterChars 6 `
+                -AppendedAtEnd $true | Should -Not -BeNullOrEmpty
         } catch {
             Write-Host '--- caret integration stderr trace ---'
             if (Test-Path -LiteralPath $stderr) {


### PR DESCRIPTION
## 概要

キャレット統合テストの準備入力について、複数文字が同一 egui フレームへ合流する実行を許容します。失敗時には製品プロセスの stderr 全体を区切り付きで CI ログへ出します。

## 原因

`main` CI と本 PR の再実行で、`"alpha"` が `0→1`、`1→5` の2フレームとして処理されることを実測しました。製品は5文字へ正しく到達していましたが、テストが中間の厳密な `4→5` を要求していたため失敗していました。

## 変更内容

- 準備入力は `after_chars=5` / `after_chars=2` と末尾追記だけを検査し、フレーム境界を固定しない
- 回帰の本体である Escape 復帰後の `search 5→6` は厳密なまま維持する
- 失敗時だけ stderr trace を出し、元の例外を再送出する

## 影響

製品挙動は変わりません。テスト成功時の追加出力もありません。

## 検証

- [x] `git diff --check`
- [x] 旧判定の Red: hosted runner で `0→1`, `1→5` を観測し `4→5` 不在で失敗
- [x] 診断ブロックのフォールトインジェクションで stderr 出力と例外再送出を確認
- [x] `npm run test:powershell`（10 passed）
- [x] `npm test`（531 passed）
- [x] PR CI `rust-check`（Pester を含む）
- [x] PR Smoke `smoke-egui`