### PR TITLE
fix: スラッシュ区切りでも親フォルダへ移動できるようにする

### DIFF
--- a/src-tauri/src/egui_shell/search_state.rs
+++ b/src-tauri/src/egui_shell/search_state.rs
@@ -401,12 +401,15 @@ pub fn should_flush_on_enter(view_kind: ViewKind, is_plain: bool, armed: bool) -
 }
 
 /// 親ディレクトリを返す。ルート（`C:\` / `\\server\share\`）で None。folderNav.computeParentDir 相当。
+/// 入力ではスラッシュとバックスラッシュの混在を許容し、返り値はバックスラッシュへ統一する。
 pub(crate) fn compute_parent_dir(current_dir: &str) -> Option<String> {
+    // config の scan path は原表記を保持するため、OS が返す区切りとの混在をここで正規化する。
+    let canonical = current_dir.replace('/', "\\");
     // 末尾 `\` を剥がす（ただしドライブルート "X:\" は保持しない — 後段で判定）。
-    let normalized = if current_dir.len() > 3 && current_dir.ends_with('\\') {
-        &current_dir[..current_dir.len() - 1]
+    let normalized = if canonical.len() > 3 && canonical.ends_with('\\') {
+        &canonical[..canonical.len() - 1]
     } else {
-        current_dir
+        &canonical
     };
     // UNC ルート判定: \\server\share（2 セグメント以下）は終端。
     if let Some(rest) = normalized.strip_prefix("\\\\") {
@@ -662,6 +665,17 @@ mod tests {
         assert_eq!(compute_parent_dir("\\\\srv\\share\\x"), Some("\\\\srv\\share".to_string()));
         assert_eq!(compute_parent_dir("\\\\srv\\share"), None); // UNC 共有ルート終端
         assert_eq!(compute_parent_dir("\\\\srv"), None); // UNC 不完全
+    }
+
+    #[test]
+    fn parent_dir_normalizes_forward_and_mixed_separators() {
+        assert_eq!(compute_parent_dir("C:/a/b"), Some("C:\\a".to_string()));
+        assert_eq!(compute_parent_dir("C:/a\\b"), Some("C:\\a".to_string()));
+        assert_eq!(compute_parent_dir("C:/a"), Some("C:\\".to_string()));
+        assert_eq!(compute_parent_dir("C:/"), None); // `/` 表記のドライブルートも終端
+        assert_eq!(compute_parent_dir("//srv/share/x"), Some("\\\\srv\\share".to_string()));
+        assert_eq!(compute_parent_dir("\\\\srv/share\\x"), Some("\\\\srv\\share".to_string()));
+        assert_eq!(compute_parent_dir("//srv/share"), None); // `/` 表記の UNC 共有ルートも終端
     }
 
     #[test]


### PR DESCRIPTION
## 概要

スラッシュ区切りまたは区切りが混在した scan path でも、フォルダ展開中に ← でドライブ／UNC 共有ルートまで親フォルダへ移動できるようにします。

Closes #841

## 原因

`compute_parent_dir` がバックスラッシュだけを区切りとして扱っていました。config の scan path は原表記を保持するため、`C:/tmp` のような prefix と OS が返すバックスラッシュ区切りの子パスが混在すると、prefix まで戻った時点で親の計算が `None` になっていました。

呼び出し側は `None` をルート終端と同様に扱うため、エラーや trace を出さず ← が無反応になっていました。

## 変更内容

- `compute_parent_dir` の入力区切りを関数内でバックスラッシュへ正規化
- ドライブパス、UNC パス、混在区切り、各ルート終端の回帰テストを追加
- 既存のドライブ／UNC ルート判定と返り値契約は維持

## 影響

永続化された config の表記は変更しません。親ディレクトリの返り値だけを通常の Windows パス表記へ統一します。SPEC §6.2 に既に記載されたルート終端へ挙動を合わせるバグ修正のため、SPEC の変更はありません。

## 検証

- [x] Red: 新テストが `C:/a/b` で `None` となることを確認
- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p snotra`（182 passed / 2 ignored）
- [x] `cargo doc --workspace --no-deps --document-private-items`
- [x] `git diff --check`
