### PR TITLE
style: cargo fmt --all を全体へ適用 (#858 の 1/2)

### DIFF
--- a/snotra-core/src/binfmt.rs
+++ b/snotra-core/src/binfmt.rs
@@ -59,10 +59,7 @@ impl BinFile {
     ///
     /// Returns `Some((data, version))` where `version` is the version that
     /// succeeded, so the caller can apply version-specific migrations.
-    pub fn load_with_fallback<T: DeserializeOwned>(
-        &self,
-        fallbacks: &[u32],
-    ) -> Option<(T, u32)> {
+    pub fn load_with_fallback<T: DeserializeOwned>(&self, fallbacks: &[u32]) -> Option<(T, u32)> {
         let bytes = fs::read(&self.path).ok()?;
 
         // Try current version (always postcard)
@@ -282,8 +279,7 @@ mod tests {
         let input = Dummy { value: 100 };
         assert!(bf.save(&input));
 
-        let (output, ver): (Dummy, u32) =
-            bf.load_with_fallback(&[2]).expect("load");
+        let (output, ver): (Dummy, u32) = bf.load_with_fallback(&[2]).expect("load");
         assert_eq!(output, input);
         assert_eq!(ver, 3);
 
@@ -300,8 +296,7 @@ mod tests {
 
         // Create a BinFile expecting v3 as current
         let bf = bin_file_in(&dir, *b"TEST", 3, "data.bin");
-        let (output, ver): (Dummy, u32) =
-            bf.load_with_fallback(&[2]).expect("load v2 fallback");
+        let (output, ver): (Dummy, u32) = bf.load_with_fallback(&[2]).expect("load v2 fallback");
         assert_eq!(output, Dummy { value: 55 });
         assert_eq!(ver, 2);
 
@@ -358,8 +353,7 @@ mod tests {
     fn try_roundtrip_with_header() {
         let input = Dummy { value: 42 };
         let bytes = try_serialize_with_header(*b"TEST", 1, &input).expect("serialize");
-        let output: Dummy =
-            try_deserialize_with_header(&bytes, *b"TEST", 1).expect("deserialize");
+        let output: Dummy = try_deserialize_with_header(&bytes, *b"TEST", 1).expect("deserialize");
         assert_eq!(input, output);
     }
 
@@ -426,8 +420,7 @@ mod tests {
             name: "hello".to_string(),
         };
         let bytes = try_serialize_with_header(*b"LRGE", 2, &input).expect("serialize");
-        let output: Large =
-            try_deserialize_with_header(&bytes, *b"LRGE", 2).expect("deserialize");
+        let output: Large = try_deserialize_with_header(&bytes, *b"LRGE", 2).expect("deserialize");
         assert_eq!(input, output);
     }
 }

--- a/snotra-core/src/config.rs
+++ b/snotra-core/src/config.rs
@@ -22,9 +22,9 @@ use crate::hotkey::HotkeyParseError;
 // `OpenerRule`/`OpenerTool` は `Config.openers` として config.toml に紐づく serde 型のため、
 // re-export で既存の呼び出し元（`snotra_core::config::...` パス、src-tauri/snotra-settings 含む）を壊さない。
 pub use crate::opener::{
-    detect_opener_presets, extract_ext_part, extract_path_condition, find_matching_tools,
-    is_preset_already_added, normalize_openers, opener_specificity_order, OpenerPreset,
-    OpenerRule, OpenerTool,
+    OpenerPreset, OpenerRule, OpenerTool, detect_opener_presets, extract_ext_part,
+    extract_path_condition, find_matching_tools, is_preset_already_added, normalize_openers,
+    opener_specificity_order,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -38,9 +38,9 @@ pub enum Language {
 #[serde(rename_all = "snake_case")]
 pub enum AutoUpdateMode {
     #[default]
-    Full,       // チェック + インストール（インストーラー版向け）
-    CheckOnly,  // チェックのみ・通知する（ポータブル版向け）
-    Disabled,   // チェックしない
+    Full, // チェック + インストール（インストーラー版向け）
+    CheckOnly, // チェックのみ・通知する（ポータブル版向け）
+    Disabled,  // チェックしない
 }
 
 /// `Config::load_reporting()` の結果区分。UI 文字列を持たない（表示・通知は呼び出し側の責務）。
@@ -83,13 +83,17 @@ pub struct InstantCommand {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum InstantAction {
-    Url { url: String },
+    Url {
+        url: String,
+    },
     Exec {
         exe: String,
         #[serde(default)]
         args: String,
     },
-    Legacy { command: String },
+    Legacy {
+        command: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -625,7 +629,9 @@ impl Config {
             .effective_visible_rows()
             .max(self.search.effective_result_limit())
             .max(self.search.effective_recent_limit());
-        working_set.max(1).saturating_mul(ICON_CACHE_RETENTION_FACTOR)
+        working_set
+            .max(1)
+            .saturating_mul(ICON_CACHE_RETENTION_FACTOR)
     }
 
     /// Returns the default scan paths (common Start Menu + Desktop).
@@ -768,7 +774,7 @@ impl Config {
         self.instant_commands.retain(|c| {
             if c.name.is_empty() {
                 return true; // 空名は dedup 対象外（検出=validate / 補正=migration の責務分離。
-                             // validate の !name.is_empty() エラーを migration が隠さない）
+                // validate の !name.is_empty() エラーを migration が隠さない）
             }
             let keep = seen.insert(c.name.clone());
             if !keep {
@@ -830,9 +836,18 @@ impl Config {
     /// skip_serializing が無効化されるため）。既定値補完は `changed` に寄与しない（常に実行される
     /// no-op 相当の後始末のため、挙動不変のまま元の実装に合わせて戻り値を持たない）。
     fn resolve_count_param_defaults(&mut self) {
-        let _ = self.appearance.visible_rows.get_or_insert_with(default_visible_rows);
-        let _ = self.search.result_limit.get_or_insert_with(default_result_limit);
-        let _ = self.search.recent_limit.get_or_insert_with(default_recent_limit);
+        let _ = self
+            .appearance
+            .visible_rows
+            .get_or_insert_with(default_visible_rows);
+        let _ = self
+            .search
+            .result_limit
+            .get_or_insert_with(default_result_limit);
+        let _ = self
+            .search
+            .recent_limit
+            .get_or_insert_with(default_recent_limit);
     }
 
     /// (4) fuzzy_history_cap_ratio が不正（非有限 or [0.0, 1.0] 範囲外）なら既定値へ補正する。
@@ -871,8 +886,7 @@ impl Config {
         let default_hotkey = HotkeyConfig::default();
         eprintln!(
             "[config] invalid hotkey detected ({reason}: {}+{}), falling back to default ({}+{})",
-            self.hotkey.modifier, self.hotkey.key,
-            default_hotkey.modifier, default_hotkey.key,
+            self.hotkey.modifier, self.hotkey.key, default_hotkey.modifier, default_hotkey.key,
         );
         self.hotkey = default_hotkey;
         true
@@ -991,8 +1005,7 @@ impl Config {
         fs::create_dir_all(dir).map_err(|e| format!("ディレクトリ作成失敗: {e}"))?;
 
         let path = dir.join("config.toml");
-        let content =
-            toml::to_string_pretty(self).map_err(|e| format!("シリアライズ失敗: {e}"))?;
+        let content = toml::to_string_pretty(self).map_err(|e| format!("シリアライズ失敗: {e}"))?;
 
         // Atomic write: .tmp → rename
         let tmp = path.with_extension("toml.tmp");
@@ -1012,7 +1025,9 @@ impl Config {
             errors.push(ConfigError::VisibleRowsZero);
         }
         if self.appearance.window_width < 200 {
-            errors.push(ConfigError::WindowWidthTooSmall(self.appearance.window_width));
+            errors.push(ConfigError::WindowWidthTooSmall(
+                self.appearance.window_width,
+            ));
         }
 
         // Search validation
@@ -1451,7 +1466,10 @@ background_color = '#123456'
         let mut config = Config::normalized_default();
         let before = config.clone();
         let changed = config.apply_migrations();
-        assert!(!changed, "normalized_default() should already be migration-stable");
+        assert!(
+            !changed,
+            "normalized_default() should already be migration-stable"
+        );
         assert_eq!(config, before);
     }
 
@@ -1564,9 +1582,18 @@ background_color = '#123456'
 
         let serialized = toml::to_string(&config).expect("serialize");
         // 旧キーは skip_serializing で出力されない
-        assert!(!serialized.contains("max_results"), "old key leaked: {serialized}");
-        assert!(!serialized.contains("top_n_history"), "old key leaked: {serialized}");
-        assert!(!serialized.contains("max_history_display"), "old key leaked: {serialized}");
+        assert!(
+            !serialized.contains("max_results"),
+            "old key leaked: {serialized}"
+        );
+        assert!(
+            !serialized.contains("top_n_history"),
+            "old key leaked: {serialized}"
+        );
+        assert!(
+            !serialized.contains("max_history_display"),
+            "old key leaked: {serialized}"
+        );
         // 新キーは出力される
         assert!(serialized.contains("visible_rows"));
         assert!(serialized.contains("result_limit"));
@@ -1710,12 +1737,16 @@ background_color = '#123456'
         assert_eq!(config.instant_commands[0].name, "g");
         assert_eq!(
             config.instant_commands[0].action,
-            InstantAction::Url { url: "https://www.google.com/search?q={query}".to_string() }
+            InstantAction::Url {
+                url: "https://www.google.com/search?q={query}".to_string()
+            }
         );
         assert_eq!(config.instant_commands[1].name, "gh");
         assert_eq!(
             config.instant_commands[1].action,
-            InstantAction::Url { url: "https://github.com/search?q={query}".to_string() }
+            InstantAction::Url {
+                url: "https://github.com/search?q={query}".to_string()
+            }
         );
     }
 
@@ -2006,7 +2037,10 @@ background_color = '#123456'
     fn validate_default_config_returns_no_errors() {
         let config = Config::default();
         let errors = config.validate();
-        assert!(errors.is_empty(), "default config should have no validation errors");
+        assert!(
+            errors.is_empty(),
+            "default config should have no validation errors"
+        );
     }
 
     #[test]
@@ -2071,7 +2105,9 @@ background_color = '#123456'
         config.appearance.window_width = 200;
         let errors = config.validate();
         assert!(
-            !errors.iter().any(|e| matches!(e, ConfigError::WindowWidthTooSmall(_))),
+            !errors
+                .iter()
+                .any(|e| matches!(e, ConfigError::WindowWidthTooSmall(_))),
             "window_width=200 should not produce an error"
         );
     }
@@ -2098,7 +2134,9 @@ background_color = '#123456'
         config.search.fuzzy_history_cap_ratio = 0.0;
         let errors = config.validate();
         assert!(
-            !errors.iter().any(|e| matches!(e, ConfigError::FuzzyCapRatioOutOfRange { .. })),
+            !errors
+                .iter()
+                .any(|e| matches!(e, ConfigError::FuzzyCapRatioOutOfRange { .. })),
             "ratio=0.0 should not produce an error"
         );
     }
@@ -2109,7 +2147,9 @@ background_color = '#123456'
         config.search.fuzzy_history_cap_ratio = 1.0;
         let errors = config.validate();
         assert!(
-            !errors.iter().any(|e| matches!(e, ConfigError::FuzzyCapRatioOutOfRange { .. })),
+            !errors
+                .iter()
+                .any(|e| matches!(e, ConfigError::FuzzyCapRatioOutOfRange { .. })),
             "ratio=1.0 should not produce an error"
         );
     }
@@ -2526,12 +2566,16 @@ background_color = '#123456'
                 InstantCommand {
                     name: "google".to_string(),
                     description: String::new(),
-                    action: InstantAction::Url { url: "https://google.com".into() },
+                    action: InstantAction::Url {
+                        url: "https://google.com".into(),
+                    },
                 },
                 InstantCommand {
                     name: "google".to_string(),
                     description: String::new(),
-                    action: InstantAction::Url { url: "https://google.co.jp".into() },
+                    action: InstantAction::Url {
+                        url: "https://google.co.jp".into(),
+                    },
                 },
             ],
             ..Default::default()
@@ -2549,19 +2593,25 @@ background_color = '#123456'
                 InstantCommand {
                     name: "google".to_string(),
                     description: String::new(),
-                    action: InstantAction::Url { url: "https://google.com".into() },
+                    action: InstantAction::Url {
+                        url: "https://google.com".into(),
+                    },
                 },
                 InstantCommand {
                     name: "bing".to_string(),
                     description: String::new(),
-                    action: InstantAction::Url { url: "https://bing.com".into() },
+                    action: InstantAction::Url {
+                        url: "https://bing.com".into(),
+                    },
                 },
             ],
             ..Default::default()
         };
         let errors = config.validate();
         assert!(
-            !errors.iter().any(|e| matches!(e, ConfigError::InstantCommandDuplicateName { .. })),
+            !errors
+                .iter()
+                .any(|e| matches!(e, ConfigError::InstantCommandDuplicateName { .. })),
         );
     }
 
@@ -2578,10 +2628,12 @@ background_color = '#123456'
             ..Default::default()
         };
         let errors = config.validate();
-        assert!(errors.contains(&ConfigError::InstantCommandUnknownModifier {
-            name: "g".to_string(),
-            modifier: "bogus".to_string(),
-        }));
+        assert!(
+            errors.contains(&ConfigError::InstantCommandUnknownModifier {
+                name: "g".to_string(),
+                modifier: "bogus".to_string(),
+            })
+        );
     }
 
     #[test]
@@ -2598,10 +2650,12 @@ background_color = '#123456'
             ..Default::default()
         };
         let errors = config.validate();
-        assert!(errors.contains(&ConfigError::InstantCommandUnknownModifier {
-            name: "ev".to_string(),
-            modifier: "nope".to_string(),
-        }));
+        assert!(
+            errors.contains(&ConfigError::InstantCommandUnknownModifier {
+                name: "ev".to_string(),
+                modifier: "nope".to_string(),
+            })
+        );
     }
 
     #[test]
@@ -2647,9 +2701,15 @@ background_color = '#123456'
         config.apply_migrations();
         assert_eq!(config.instant_commands.len(), 2);
         assert_eq!(config.instant_commands[0].name, "g");
-        assert!(matches!(config.instant_commands[0].action, InstantAction::Url { .. }));
+        assert!(matches!(
+            config.instant_commands[0].action,
+            InstantAction::Url { .. }
+        ));
         assert_eq!(config.instant_commands[1].name, "memo");
-        assert!(matches!(config.instant_commands[1].action, InstantAction::Url { .. }));
+        assert!(matches!(
+            config.instant_commands[1].action,
+            InstantAction::Url { .. }
+        ));
     }
 
     #[test]
@@ -2729,10 +2789,14 @@ background_color = '#123456'
         let mut config = Config::default();
         config.hotkey.modifier = "Alt+Alt".to_string();
         config.hotkey.key = "F4".to_string();
-        assert!(config.validate().contains(&ConfigError::HotkeySystemConflict {
-            modifier: "Alt+Alt".to_string(),
-            key: "F4".to_string(),
-        }));
+        assert!(
+            config
+                .validate()
+                .contains(&ConfigError::HotkeySystemConflict {
+                    modifier: "Alt+Alt".to_string(),
+                    key: "F4".to_string(),
+                })
+        );
     }
 
     #[test]
@@ -2763,13 +2827,19 @@ background_color = '#123456'
         config.hotkey.key.clear();
         assert_eq!(
             config.validate_hotkey(),
-            vec![ConfigError::HotkeyModifierEmpty, ConfigError::HotkeyKeyEmpty]
+            vec![
+                ConfigError::HotkeyModifierEmpty,
+                ConfigError::HotkeyKeyEmpty
+            ]
         );
 
         config.hotkey.modifier = "++".to_string();
         assert_eq!(
             config.validate_hotkey(),
-            vec![ConfigError::HotkeyModifierEmpty, ConfigError::HotkeyKeyEmpty]
+            vec![
+                ConfigError::HotkeyModifierEmpty,
+                ConfigError::HotkeyKeyEmpty
+            ]
         );
     }
 
@@ -2791,10 +2861,13 @@ background_color = '#123456'
         config.hotkey.modifier = "Alt".to_string();
         config.hotkey.key = "Q".to_string();
         let errors = config.validate();
-        let has_conflict = errors.iter().any(|e| {
-            matches!(e, ConfigError::HotkeySystemConflict { .. })
-        });
-        assert!(!has_conflict, "Alt+Q should not produce a system conflict error");
+        let has_conflict = errors
+            .iter()
+            .any(|e| matches!(e, ConfigError::HotkeySystemConflict { .. }));
+        assert!(
+            !has_conflict,
+            "Alt+Q should not produce a system conflict error"
+        );
     }
 
     // ---- CustomTheme / ThemePreset::Custom tests ----
@@ -2900,7 +2973,11 @@ background_color = '#123456'
         let config: Config = toml::from_str(toml_str).unwrap();
         let errors = config.validate();
         // Should have errors for empty hotkey and invalid visible_rows/window_width
-        assert!(errors.len() >= 2, "Expected at least 2 errors, got: {:?}", errors);
+        assert!(
+            errors.len() >= 2,
+            "Expected at least 2 errors, got: {:?}",
+            errors
+        );
     }
 
     #[test]
@@ -3322,47 +3399,76 @@ foo = 42
 
     // ---- InstantAction serde gate (release gate: 失敗は全設定リセットを意味する) ----
     fn cfg_with_instant(cmds: Vec<InstantCommand>) -> Config {
-        Config { instant_commands: cmds, ..Default::default() }
+        Config {
+            instant_commands: cmds,
+            ..Default::default()
+        }
     }
 
     #[test] // T2: legacy 行が deserialize できる（最重要・データ損失検出器）
     fn instant_legacy_command_deserializes() {
         let legacy = cfg_with_instant(vec![InstantCommand {
-            name: "g".into(), description: String::new(),
-            action: InstantAction::Legacy { command: "https://x/?q={query}".into() },
+            name: "g".into(),
+            description: String::new(),
+            action: InstantAction::Legacy {
+                command: "https://x/?q={query}".into(),
+            },
         }]);
         let s = toml::to_string(&legacy).expect("serialize legacy");
         // Legacy は `command = "..."` 形（=旧オンディスク形式）で出力される
         assert!(s.contains("command ="));
         let parsed: Config = toml::from_str(&s).expect("legacy deserialize must succeed");
-        assert!(matches!(parsed.instant_commands[0].action, InstantAction::Legacy { .. }));
+        assert!(matches!(
+            parsed.instant_commands[0].action,
+            InstantAction::Legacy { .. }
+        ));
     }
 
     #[test] // T15 + T17: legacy → Url 移行（自動分割しない）・冪等
     fn instant_legacy_migrates_to_url_idempotently() {
         let mut cfg = cfg_with_instant(vec![InstantCommand {
-            name: "ev".into(), description: String::new(),
-            action: InstantAction::Legacy { command: "C:\\tools\\editor.exe".into() },
+            name: "ev".into(),
+            description: String::new(),
+            action: InstantAction::Legacy {
+                command: "C:\\tools\\editor.exe".into(),
+            },
         }]);
         assert!(cfg.apply_migrations());
-        assert_eq!(cfg.instant_commands[0].action,
-            InstantAction::Url { url: "C:\\tools\\editor.exe".into() }); // Exec にしない
+        assert_eq!(
+            cfg.instant_commands[0].action,
+            InstantAction::Url {
+                url: "C:\\tools\\editor.exe".into()
+            }
+        ); // Exec にしない
         // 冪等: 2回目は Legacy が残っていないので action は Url のまま
         cfg.apply_migrations();
-        assert_eq!(cfg.instant_commands[0].action,
-            InstantAction::Url { url: "C:\\tools\\editor.exe".into() });
+        assert_eq!(
+            cfg.instant_commands[0].action,
+            InstantAction::Url {
+                url: "C:\\tools\\editor.exe".into()
+            }
+        );
     }
 
     #[test] // T1: Config 全体の serialize 往復で変種が保たれる
     fn instant_exec_roundtrip_preserves_variant() {
         let cfg = cfg_with_instant(vec![InstantCommand {
-            name: "ev".into(), description: "Everything".into(),
-            action: InstantAction::Exec { exe: "everything.exe".into(), args: "-s {query}".into() },
+            name: "ev".into(),
+            description: "Everything".into(),
+            action: InstantAction::Exec {
+                exe: "everything.exe".into(),
+                args: "-s {query}".into(),
+            },
         }]);
         let s = toml::to_string_pretty(&cfg).expect("serialize");
         let parsed: Config = toml::from_str(&s).expect("deserialize");
-        assert_eq!(parsed.instant_commands[0].action,
-            InstantAction::Exec { exe: "everything.exe".into(), args: "-s {query}".into() });
+        assert_eq!(
+            parsed.instant_commands[0].action,
+            InstantAction::Exec {
+                exe: "everything.exe".into(),
+                args: "-s {query}".into()
+            }
+        );
     }
 
     #[test] // T3: url と exe を両方書いた行は Url 先勝ち（untagged 宣言順）
@@ -3381,7 +3487,10 @@ foo = 42
             exe = "y.exe"
         "#;
         let cfg: Config = toml::from_str(toml_str).expect("parse");
-        assert!(matches!(cfg.instant_commands[0].action, InstantAction::Url { .. }));
+        assert!(matches!(
+            cfg.instant_commands[0].action,
+            InstantAction::Url { .. }
+        ));
     }
 
     #[test] // T4: Exec で args 省略 → 空文字
@@ -3399,8 +3508,13 @@ foo = 42
             exe = "notepad.exe"
         "#;
         let cfg: Config = toml::from_str(toml_str).expect("parse");
-        assert_eq!(cfg.instant_commands[0].action,
-            InstantAction::Exec { exe: "notepad.exe".into(), args: String::new() });
+        assert_eq!(
+            cfg.instant_commands[0].action,
+            InstantAction::Exec {
+                exe: "notepad.exe".into(),
+                args: String::new()
+            }
+        );
     }
 
     #[test]
@@ -3411,17 +3525,23 @@ foo = 42
             InstantCommand {
                 name: "gh".into(),
                 description: String::new(),
-                action: InstantAction::Url { url: "https://github.com/{q}".into() },
+                action: InstantAction::Url {
+                    url: "https://github.com/{q}".into(),
+                },
             },
             InstantCommand {
                 name: "gh".into(),
                 description: String::new(),
-                action: InstantAction::Url { url: "https://example.com/{q}".into() },
+                action: InstantAction::Url {
+                    url: "https://example.com/{q}".into(),
+                },
             },
             InstantCommand {
                 name: "g".into(),
                 description: String::new(),
-                action: InstantAction::Url { url: "https://google.com/{q}".into() },
+                action: InstantAction::Url {
+                    url: "https://google.com/{q}".into(),
+                },
             },
         ];
         config.apply_migrations();
@@ -3443,12 +3563,16 @@ foo = 42
             InstantCommand {
                 name: "gh".into(),
                 description: String::new(),
-                action: InstantAction::Url { url: "https://github.com/{q}".into() },
+                action: InstantAction::Url {
+                    url: "https://github.com/{q}".into(),
+                },
             },
             InstantCommand {
                 name: "gh".into(),
                 description: String::new(),
-                action: InstantAction::Url { url: "https://example.com/{q}".into() },
+                action: InstantAction::Url {
+                    url: "https://example.com/{q}".into(),
+                },
             },
         ];
         assert!(!config.apply_migrations());

--- a/snotra-core/src/engine.rs
+++ b/snotra-core/src/engine.rs
@@ -8,7 +8,7 @@ use crate::config::{Config, ScanPath};
 use crate::folder;
 use crate::history::{HistoryStore, PreparedHistorySave};
 use crate::indexer::{AppEntry, CachedMasks};
-use crate::search::{SearchOptions, SearchEngine, SearchMode};
+use crate::search::{SearchEngine, SearchMode, SearchOptions};
 use crate::ui_types::SearchResult;
 use std::path::Path;
 
@@ -188,10 +188,7 @@ impl Engine {
         self.history.record_folder_expansion(path);
     }
 
-    pub fn prepare_history_save_if_dirty(
-        &mut self,
-        threshold: u32,
-    ) -> Option<PreparedHistorySave> {
+    pub fn prepare_history_save_if_dirty(&mut self, threshold: u32) -> Option<PreparedHistorySave> {
         // top_n は現在の config から live-read で渡す（焼き込まない、issue #348）。
         self.history
             .prepare_save_if_dirty(threshold, self.config.search.effective_result_limit())
@@ -478,7 +475,9 @@ mod tests {
         let mut engine = Engine::new(make_entries(&["x"]), empty_history(), config);
         engine.mark_index_stale();
         assert!(engine.is_index_stale());
-        let inputs = engine.begin_index_drain().expect("stale なら snapshot を返す");
+        let inputs = engine
+            .begin_index_drain()
+            .expect("stale なら snapshot を返す");
         assert!(inputs.migemo_enabled);
         assert!(inputs.show_hidden_system);
     }
@@ -553,6 +552,9 @@ mod tests {
         let base = default_config();
         let mut c = base.clone();
         c.appearance.visible_rows = Some(base.appearance.effective_visible_rows() + 10);
-        assert_eq!(IndexInputs::from_config(&base), IndexInputs::from_config(&c));
+        assert_eq!(
+            IndexInputs::from_config(&base),
+            IndexInputs::from_config(&c)
+        );
     }
 }

--- a/snotra-core/src/error.rs
+++ b/snotra-core/src/error.rs
@@ -8,14 +8,8 @@ use std::fmt;
 /// Errors from binary file serialization/deserialization.
 #[derive(Debug)]
 pub enum BinError {
-    MagicMismatch {
-        expected: [u8; 4],
-        actual: [u8; 4],
-    },
-    VersionMismatch {
-        expected: u32,
-        actual: u32,
-    },
+    MagicMismatch { expected: [u8; 4], actual: [u8; 4] },
+    VersionMismatch { expected: u32, actual: u32 },
     DeserializeFailed,
     SerializeFailed,
     BufferTooShort,
@@ -33,11 +27,7 @@ impl fmt::Display for BinError {
                 )
             }
             Self::VersionMismatch { expected, actual } => {
-                write!(
-                    f,
-                    "version mismatch: expected {}, got {}",
-                    expected, actual
-                )
+                write!(f, "version mismatch: expected {}, got {}", expected, actual)
             }
             Self::DeserializeFailed => write!(f, "deserialization failed"),
             Self::SerializeFailed => write!(f, "serialization failed"),

--- a/snotra-core/src/folder.rs
+++ b/snotra-core/src/folder.rs
@@ -64,12 +64,7 @@ pub(crate) fn read_dir_entries(
         // シンボリックリンク挙動は変わらず、かつ追加の stat 呼び出しが不要になる。
         let meta = entry.metadata().ok();
 
-        if !show_hidden_system
-            && meta
-                .as_ref()
-                .map(is_hidden_or_system)
-                .unwrap_or(false)
-        {
+        if !show_hidden_system && meta.as_ref().map(is_hidden_or_system).unwrap_or(false) {
             continue;
         }
 
@@ -124,13 +119,21 @@ fn build_sort_keys(entries: &[SearchResult], history: &HistoryStore) -> Vec<(Str
 }
 
 /// keyed の順序で entries を並べ替えて所有権を取り出す（clone 回避の mem::replace・共有ヘルパー）。
-fn collect_by_keyed(mut entries: Vec<SearchResult>, keyed: Vec<(String, u32, usize)>) -> Vec<SearchResult> {
+fn collect_by_keyed(
+    mut entries: Vec<SearchResult>,
+    keyed: Vec<(String, u32, usize)>,
+) -> Vec<SearchResult> {
     keyed
         .into_iter()
         .map(|(_, _, i)| {
             std::mem::replace(
                 &mut entries[i],
-                SearchResult { name: String::new(), path: String::new(), is_folder: false, is_error: false },
+                SearchResult {
+                    name: String::new(),
+                    path: String::new(),
+                    is_folder: false,
+                    is_error: false,
+                },
             )
         })
         .collect()
@@ -144,7 +147,12 @@ pub fn sort_entries_unlimited(
 ) -> Vec<SearchResult> {
     let entries: Vec<SearchResult> = entries
         .into_iter()
-        .map(|e| SearchResult { name: e.name, path: e.path, is_folder: e.is_folder, is_error: false })
+        .map(|e| SearchResult {
+            name: e.name,
+            path: e.path,
+            is_folder: e.is_folder,
+            is_error: false,
+        })
         .collect();
     let mut keyed = build_sort_keys(&entries, history);
     keyed.sort_by(|a, b| folder_entry_cmp(&entries, a, b));
@@ -158,7 +166,12 @@ pub(crate) fn score_entries(
 ) -> Vec<SearchResult> {
     let entries: Vec<SearchResult> = entries
         .into_iter()
-        .map(|e| SearchResult { name: e.name, path: e.path, is_folder: e.is_folder, is_error: false })
+        .map(|e| SearchResult {
+            name: e.name,
+            path: e.path,
+            is_folder: e.is_folder,
+            is_error: false,
+        })
         .collect();
     let k = max_results.min(entries.len());
     if k == 0 {
@@ -406,7 +419,14 @@ mod tests {
             .status()
             .expect("attrib command failed");
 
-        let results = list_folder(&dir, "", SearchMode::Substring, false, &empty_history(), 100);
+        let results = list_folder(
+            &dir,
+            "",
+            SearchMode::Substring,
+            false,
+            &empty_history(),
+            100,
+        );
         let names: Vec<&str> = results.iter().map(|r| r.name.as_str()).collect();
         assert_eq!(results.len(), 1);
         assert!(names.contains(&"visible.txt"));
@@ -519,7 +539,9 @@ mod tests {
                 assert_eq!(results.len(), max_results);
             }
             let avg_us = total_ns / iters as u128 / 1000;
-            println!("[topk_sort] entries={n}, max_results={max_results}, avg={avg_us}µs ({iters} iters)");
+            println!(
+                "[topk_sort] entries={n}, max_results={max_results}, avg={avg_us}µs ({iters} iters)"
+            );
             let _ = fs::remove_dir_all(&dir);
         }
     }
@@ -626,16 +648,26 @@ mod tests {
         // empty_history() は既存 folder テストのヘルパー（HistoryStore::load()）。
         let hist = empty_history();
         let entries = vec![
-            DirEntryData { path: "C:\\d\\Cafe".into(), name: "Cafe".into(), is_folder: false },
-            DirEntryData { path: "C:\\d\\Café".into(), name: "Café".into(), is_folder: false },
+            DirEntryData {
+                path: "C:\\d\\Cafe".into(),
+                name: "Cafe".into(),
+                is_folder: false,
+            },
+            DirEntryData {
+                path: "C:\\d\\Café".into(),
+                name: "Café".into(),
+                is_folder: false,
+            },
         ];
         let a = sort_entries_unlimited(entries.clone(), &hist);
         // 入力順を反転しても同一順序（path 昇順で確定）
         let mut rev = entries;
         rev.reverse();
         let b = sort_entries_unlimited(rev, &hist);
-        assert_eq!(a.iter().map(|r| r.path.clone()).collect::<Vec<_>>(),
-                   b.iter().map(|r| r.path.clone()).collect::<Vec<_>>());
+        assert_eq!(
+            a.iter().map(|r| r.path.clone()).collect::<Vec<_>>(),
+            b.iter().map(|r| r.path.clone()).collect::<Vec<_>>()
+        );
         // path 昇順: "Cafe" < "Café"（バイト比較）
         assert_eq!(a[0].path, "C:\\d\\Cafe");
     }
@@ -647,9 +679,21 @@ mod tests {
         use crate::search::SearchMode;
         let hist = empty_history();
         let entries = vec![
-            DirEntryData { path: "C:\\d\\Café".into(), name: "Café".into(), is_folder: false },
-            DirEntryData { path: "C:\\d\\Cafe".into(), name: "Cafe".into(), is_folder: false },
-            DirEntryData { path: "C:\\d\\dog".into(), name: "dog".into(), is_folder: false },
+            DirEntryData {
+                path: "C:\\d\\Café".into(),
+                name: "Café".into(),
+                is_folder: false,
+            },
+            DirEntryData {
+                path: "C:\\d\\Cafe".into(),
+                name: "Cafe".into(),
+                is_folder: false,
+            },
+            DirEntryData {
+                path: "C:\\d\\dog".into(),
+                name: "dog".into(),
+                is_folder: false,
+            },
         ];
         // 経路 A: 全ソート → filter("cafe") → take(1)
         let sorted = sort_entries_unlimited(entries.clone(), &hist);
@@ -657,19 +701,27 @@ mod tests {
         // 経路 B: read_dir 相当の filter を read_dir_entries で（filter="cafe"）→ score_entries(max=1)
         let filtered = read_dir_entries_for_test(entries, "cafe", SearchMode::Substring);
         let b = score_entries(filtered, &hist, 1);
-        assert_eq!(a.iter().map(|r| r.path.clone()).collect::<Vec<_>>(),
-                   b.iter().map(|r| r.path.clone()).collect::<Vec<_>>());
+        assert_eq!(
+            a.iter().map(|r| r.path.clone()).collect::<Vec<_>>(),
+            b.iter().map(|r| r.path.clone()).collect::<Vec<_>>()
+        );
     }
 
     /// read_dir_entries のフィルタ段だけをテストで再現する（実 I/O を避ける）。matches_filter は
     /// private だが同一モジュールから呼べる。
     #[cfg(test)]
-    fn read_dir_entries_for_test(entries: Vec<DirEntryData>, filter: &str, mode: crate::search::SearchMode) -> Vec<DirEntryData> {
+    fn read_dir_entries_for_test(
+        entries: Vec<DirEntryData>,
+        filter: &str,
+        mode: crate::search::SearchMode,
+    ) -> Vec<DirEntryData> {
         let filter_lower = to_lower_folded(filter);
         let mut matcher = Matcher::new(MatcherConfig::DEFAULT);
         entries
             .into_iter()
-            .filter(|e| filter.is_empty() || matches_filter(&e.name, &filter_lower, mode, &mut matcher))
+            .filter(|e| {
+                filter.is_empty() || matches_filter(&e.name, &filter_lower, mode, &mut matcher)
+            })
             .collect()
     }
 
@@ -678,14 +730,22 @@ mod tests {
         use crate::search::SearchMode;
         let cached = vec![sr("a"), sr("b"), sr("c")];
         let out = filter_sorted(&cached, "", SearchMode::Substring, 2);
-        assert_eq!(out.iter().map(|r| r.name.clone()).collect::<Vec<_>>(), vec!["a", "b"]);
+        assert_eq!(
+            out.iter().map(|r| r.name.clone()).collect::<Vec<_>>(),
+            vec!["a", "b"]
+        );
     }
 
     #[test]
     fn filter_sorted_matches_display_name_not_path() {
         use crate::search::SearchMode;
         // path に "zzz" を含むが name には含まない → filter "zzz" は 0 件（表示名のみ・§6.3）
-        let cached = vec![SearchResult { name: "report".into(), path: "C:\\zzz\\report".into(), is_folder: false, is_error: false }];
+        let cached = vec![SearchResult {
+            name: "report".into(),
+            path: "C:\\zzz\\report".into(),
+            is_folder: false,
+            is_error: false,
+        }];
         let out = filter_sorted(&cached, "zzz", SearchMode::Substring, 8);
         assert!(out.is_empty());
     }
@@ -693,7 +753,12 @@ mod tests {
     // テスト用ヘルパー（既存 tests mod にあれば再利用）
     #[cfg(test)]
     fn sr(name: &str) -> SearchResult {
-        SearchResult { name: name.into(), path: format!("C:\\d\\{name}"), is_folder: false, is_error: false }
+        SearchResult {
+            name: name.into(),
+            path: format!("C:\\d\\{name}"),
+            is_folder: false,
+            is_error: false,
+        }
     }
 
     #[test]

--- a/snotra-core/src/history.rs
+++ b/snotra-core/src/history.rs
@@ -191,11 +191,7 @@ impl HistoryStore {
     }
 
     /// Testable directory-injected form of [`Self::prepare_flush`].
-    pub fn prepare_flush_in(
-        &mut self,
-        top_n: usize,
-        dir: &Path,
-    ) -> Option<PreparedHistorySave> {
+    pub fn prepare_flush_in(&mut self, top_n: usize, dir: &Path) -> Option<PreparedHistorySave> {
         let save = self.prepare_save_in(top_n, dir);
         if save.is_some() {
             self.dirty_count = 0;
@@ -432,12 +428,7 @@ mod tests {
             .or_default()
             .launch_count += 1;
         assert_eq!(store.global_count(path), 1);
-        store
-            .data
-            .global
-            .entry(key)
-            .or_default()
-            .launch_count += 1;
+        store.data.global.entry(key).or_default().launch_count += 1;
         assert_eq!(store.global_count(path), 2);
     }
 
@@ -545,11 +536,7 @@ mod tests {
         let folder = "C:\\Projects";
         let folder_key = normalize_entry_key(folder);
         assert_eq!(store.folder_expansion_count(folder), 0);
-        *store
-            .data
-            .folder_expansion
-            .entry(folder_key)
-            .or_insert(0) += 1;
+        *store.data.folder_expansion.entry(folder_key).or_insert(0) += 1;
         assert_eq!(store.folder_expansion_count(folder), 1);
     }
 
@@ -616,8 +603,9 @@ mod tests {
             .expect("serialize v2 postcard");
         let bf = HistoryStore::bin_file_in(&dir);
         std::fs::write(bf.path(), &bytes).unwrap();
-        let (loaded, version): (HistoryData, u32) =
-            bf.load_with_fallback(HISTORY_FALLBACKS).expect("load v2 postcard");
+        let (loaded, version): (HistoryData, u32) = bf
+            .load_with_fallback(HISTORY_FALLBACKS)
+            .expect("load v2 postcard");
         assert_eq!(version, HISTORY_VERSION_POSTCARD_V2);
         let migrated = migrate_time_unit_if_legacy(version, loaded);
         assert_eq!(
@@ -641,8 +629,9 @@ mod tests {
         );
         let bf = HistoryStore::bin_file_in(&dir);
         assert!(bf.save(&data));
-        let (loaded, version): (HistoryData, u32) =
-            bf.load_with_fallback(HISTORY_FALLBACKS).expect("load v3 postcard");
+        let (loaded, version): (HistoryData, u32) = bf
+            .load_with_fallback(HISTORY_FALLBACKS)
+            .expect("load v3 postcard");
         assert_eq!(version, HISTORY_VERSION);
         let migrated = migrate_time_unit_if_legacy(version, loaded);
         assert_eq!(
@@ -671,8 +660,9 @@ mod tests {
 
         let bytes =
             try_serialize_with_header(HISTORY_MAGIC, HISTORY_VERSION, &data).expect("serialize");
-        let roundtripped: HistoryData = try_deserialize_with_header(&bytes, HISTORY_MAGIC, HISTORY_VERSION)
-            .expect("deserialize");
+        let roundtripped: HistoryData =
+            try_deserialize_with_header(&bytes, HISTORY_MAGIC, HISTORY_VERSION)
+                .expect("deserialize");
 
         assert_eq!(roundtripped.global["C:\\app.lnk"].launch_count, 5);
         assert_eq!(roundtripped.query["notepad"]["C:\\app.lnk"], 3);
@@ -882,7 +872,10 @@ mod tests {
         let migrated = migrate_normalize_keys(data);
         assert_eq!(migrated.query.len(), 1);
         assert!(migrated.query.contains_key("tool\\editor"));
-        assert_eq!(migrated.query["tool\\editor"]["c:\\tool\\editor\\app.exe"], 5);
+        assert_eq!(
+            migrated.query["tool\\editor"]["c:\\tool\\editor\\app.exe"],
+            5
+        );
     }
 
     #[test]
@@ -895,7 +888,10 @@ mod tests {
             .insert("c:\\tool\\editor\\app.exe".to_string(), 4);
         let migrated = migrate_normalize_keys(data);
         assert!(migrated.query.contains_key("tool\\editor"));
-        assert_eq!(migrated.query["tool\\editor"]["c:\\tool\\editor\\app.exe"], 4);
+        assert_eq!(
+            migrated.query["tool\\editor"]["c:\\tool\\editor\\app.exe"],
+            4
+        );
     }
 
     #[test]

--- a/snotra-core/src/indexer.rs
+++ b/snotra-core/src/indexer.rs
@@ -11,8 +11,8 @@ use std::fs::Metadata;
 use std::hash::{Hash, Hasher};
 use std::os::windows::fs::MetadataExt;
 use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 use std::time::{SystemTime, UNIX_EPOCH};
 use windows::Win32::Storage::FileSystem::{FILE_ATTRIBUTE_HIDDEN, FILE_ATTRIBUTE_SYSTEM};
@@ -265,7 +265,6 @@ struct IndexCacheV2 {
     config_hash: u64,
 }
 
-
 fn compute_config_hash(scan: &[ScanPath], show_hidden_system: bool) -> u64 {
     let mut hasher = DefaultHasher::new();
     for sp in scan {
@@ -291,10 +290,7 @@ pub fn load_or_scan(scan: &[ScanPath], show_hidden_system: bool) -> (Vec<AppEntr
 /// Same as `load_or_scan`, but returns the full `LoadOrScanResult`: timing stats,
 /// cached bitmasks, and—on cache hit—a `BackgroundRescanTask` for the caller to
 /// run on a background thread.
-pub fn load_or_scan_with_stats(
-    scan: &[ScanPath],
-    show_hidden_system: bool,
-) -> LoadOrScanResult {
+pub fn load_or_scan_with_stats(scan: &[ScanPath], show_hidden_system: bool) -> LoadOrScanResult {
     let total_started = Instant::now();
 
     let hash_started = Instant::now();
@@ -416,8 +412,10 @@ fn save_cache_sorted_in(dir: &Path, entries: &[AppEntry], config_hash: u64) {
         .map(|n| file_char_mask(n.as_deref()))
         .collect();
     // A-3: normalized_keys もキャッシュに含める。起動時の Wave 1 計算を完全スキップするため。
-    let normalized_keys: Vec<String> =
-        entries.iter().map(|e| normalize_entry_key(&e.target_path)).collect();
+    let normalized_keys: Vec<String> = entries
+        .iter()
+        .map(|e| normalize_entry_key(&e.target_path))
+        .collect();
 
     // Cow::Borrowed で entries の全件 clone を避ける（派生 Vec も参照で渡す）。
     // 出力バイト列は Owned 版と同一（golden テストで保証）。
@@ -741,10 +739,8 @@ fn read_user_path() -> Option<String> {
         if data_type == REG_EXPAND_SZ {
             // null terminator を付加して ExpandEnvironmentStringsW に渡す
             buf.push(0);
-            let required = ExpandEnvironmentStringsW(
-                windows::core::PCWSTR::from_raw(buf.as_ptr()),
-                None,
-            );
+            let required =
+                ExpandEnvironmentStringsW(windows::core::PCWSTR::from_raw(buf.as_ptr()), None);
             if required == 0 {
                 buf.pop(); // remove null terminator
                 return Some(String::from_utf16_lossy(&buf));
@@ -1030,10 +1026,11 @@ mod tests {
             ]),
         };
 
-        let bytes = try_serialize_with_header(INDEX_MAGIC, INDEX_CACHE_VERSION, &cache)
-            .expect("serialize");
+        let bytes =
+            try_serialize_with_header(INDEX_MAGIC, INDEX_CACHE_VERSION, &cache).expect("serialize");
         let restored: IndexCache<'static> =
-            try_deserialize_with_header(&bytes, INDEX_MAGIC, INDEX_CACHE_VERSION).expect("deserialize");
+            try_deserialize_with_header(&bytes, INDEX_MAGIC, INDEX_CACHE_VERSION)
+                .expect("deserialize");
 
         assert_eq!(restored.built_at, 1700000000);
         assert_eq!(restored.entries.len(), 2);
@@ -1044,8 +1041,14 @@ mod tests {
         assert_eq!(restored.config_hash, 12345);
         // Cow フィールドは into_owned() で Vec に戻して比較（deserialize は Owned ゆえ move）。
         assert_eq!(restored.char_masks.into_owned(), vec![0xABu64, 0xCD]);
-        assert_eq!(restored.file_name_char_masks.into_owned(), vec![0x12u64, 0x34]);
-        assert_eq!(restored.lower_names.into_owned(), vec!["firefox", "projects"]);
+        assert_eq!(
+            restored.file_name_char_masks.into_owned(),
+            vec![0x12u64, 0x34]
+        );
+        assert_eq!(
+            restored.lower_names.into_owned(),
+            vec!["firefox", "projects"]
+        );
         assert_eq!(
             restored.lower_file_names.into_owned(),
             vec![Some("firefox.lnk".to_string()), None]
@@ -1079,8 +1082,10 @@ mod tests {
         let file_name_char_masks = vec![0x12u64, 0x34];
         let lower_names = vec!["firefox".to_string(), "projects".to_string()];
         let lower_file_names = vec![Some("firefox.lnk".to_string()), None];
-        let normalized_keys =
-            vec!["c:\\apps\\firefox.lnk".to_string(), "c:\\projects".to_string()];
+        let normalized_keys = vec![
+            "c:\\apps\\firefox.lnk".to_string(),
+            "c:\\projects".to_string(),
+        ];
 
         // save 経路と同じ Cow::Borrowed で構築する。
         let cache = IndexCache {
@@ -1093,8 +1098,8 @@ mod tests {
             lower_file_names: Cow::Borrowed(&lower_file_names),
             normalized_keys: Cow::Borrowed(&normalized_keys),
         };
-        let bytes = try_serialize_with_header(INDEX_MAGIC, INDEX_CACHE_VERSION, &cache)
-            .expect("serialize");
+        let bytes =
+            try_serialize_with_header(INDEX_MAGIC, INDEX_CACHE_VERSION, &cache).expect("serialize");
 
         // 凍結 golden（固定 fixture の serialize 出力・INDX magic + version 4 ヘッダー込み）。
         // 形式変更時のみ更新する。
@@ -1188,8 +1193,7 @@ mod tests {
             entries: entries.clone(),
             config_hash,
         };
-        let bytes =
-            try_serialize_with_header(INDEX_MAGIC, 2, &cache_v2).expect("serialize v2");
+        let bytes = try_serialize_with_header(INDEX_MAGIC, 2, &cache_v2).expect("serialize v2");
 
         // try_deserialize_with_header で v2 として読める
         let restored: IndexCacheV2 =
@@ -1198,7 +1202,8 @@ mod tests {
         assert_eq!(restored.config_hash, config_hash);
 
         // v4 として読もうとすると失敗する（フィールドが足りない）
-        let v4_result = try_deserialize_with_header::<IndexCache>(&bytes, INDEX_MAGIC, INDEX_CACHE_VERSION);
+        let v4_result =
+            try_deserialize_with_header::<IndexCache>(&bytes, INDEX_MAGIC, INDEX_CACHE_VERSION);
         assert!(v4_result.is_err(), "v2 bytes should not deserialize as v4");
     }
 
@@ -1227,7 +1232,8 @@ mod tests {
         assert_eq!(restored.char_masks, vec![0xAB]);
 
         // v4 として読もうとすると失敗する（lower_names フィールドがない）
-        let v4_result = try_deserialize_with_header::<IndexCache>(&bytes, INDEX_MAGIC, INDEX_CACHE_VERSION);
+        let v4_result =
+            try_deserialize_with_header::<IndexCache>(&bytes, INDEX_MAGIC, INDEX_CACHE_VERSION);
         assert!(v4_result.is_err(), "v3 bytes should not deserialize as v4");
     }
 
@@ -1442,7 +1448,9 @@ mod tests {
 
     #[test]
     fn try_background_rescan_skips_when_write_lock_held() {
-        let _serial = INDEX_LOCK_TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        let _serial = INDEX_LOCK_TEST_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // 権威的なインデックスビルドが書き込みロックを保持している状況を再現する。
         let _held = INDEX_WRITE_LOCK.lock().unwrap();
         // 背景再スキャンは書き込みロックを取得できないため、
@@ -1457,7 +1465,9 @@ mod tests {
 
     #[test]
     fn background_rescan_task_run_reports_unchanged_for_empty_inputs() {
-        let _serial = INDEX_LOCK_TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        let _serial = INDEX_LOCK_TEST_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // 空のスキャン対象 → scan_all は空 → 空のキャッシュと一致 → Unchanged。
         let task = BackgroundRescanTask {
             scan: Vec::new(),
@@ -1471,7 +1481,9 @@ mod tests {
 
     #[test]
     fn stale_background_rescan_cannot_overwrite_newer_index_generation() {
-        let _serial = INDEX_LOCK_TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        let _serial = INDEX_LOCK_TEST_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let dir = temp_dir("stale_background_rescan");
         let old_hash = 41;
         let new_hash = 42;
@@ -1502,7 +1514,9 @@ mod tests {
 
     #[test]
     fn rescan_generation_is_snapshotted_before_cache_load() {
-        let _serial = INDEX_LOCK_TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        let _serial = INDEX_LOCK_TEST_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let generation_before_load = current_index_generation();
 
         let (_, task_generation) = load_with_index_generation(|| {
@@ -1518,7 +1532,9 @@ mod tests {
     #[test]
     fn try_with_index_write_lock_skips_closure_when_lock_held() {
         use std::sync::atomic::{AtomicBool, Ordering};
-        let _serial = INDEX_LOCK_TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        let _serial = INDEX_LOCK_TEST_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // 権威的なインデックスビルドが書き込みロックを保持している状況を再現する。
         let _held = INDEX_WRITE_LOCK.lock().unwrap();
         // ロックを取得できないので、クロージャは実行されず None が返らねばならない。
@@ -1536,7 +1552,9 @@ mod tests {
 
     #[test]
     fn with_index_write_lock_holds_lock_during_closure() {
-        let _serial = INDEX_LOCK_TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        let _serial = INDEX_LOCK_TEST_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // with_index_write_lock がクロージャ実行中ずっとロックを保持していることを、
         // 「クロージャ内から try_lock すると失敗する」という形で決定論的に検証する。
         // ブロッキング取得なので、他テストがロック保持中でも待つだけで flaky にならない。
@@ -1550,7 +1568,9 @@ mod tests {
     #[test]
     fn try_with_index_write_lock_runs_closure_when_lock_free() {
         use std::sync::atomic::{AtomicBool, Ordering};
-        let _serial = INDEX_LOCK_TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        let _serial = INDEX_LOCK_TEST_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // ロックが空いていればクロージャを実行し、Some(結果) を返す。
         // 回帰テスト: 「スキップ」を通した最小実装が同じ2行でこの経路も満たすため即パスする。
         let ran = AtomicBool::new(false);

--- a/snotra-core/src/instant.rs
+++ b/snotra-core/src/instant.rs
@@ -330,63 +330,40 @@ mod tests {
 
     #[test]
     fn url_query_is_encoded() {
-        let result = expand_instant_command(
-            "https://google.com/search?q={query}",
-            "機械学習",
-            "",
-        );
+        let result = expand_instant_command("https://google.com/search?q={query}", "機械学習", "");
         assert!(result.contains("%E6%A9%9F%E6%A2%B0%E5%AD%A6%E7%BF%92"));
         assert!(!result.contains("機械学習"));
     }
 
     #[test]
     fn url_clip_is_encoded() {
-        let result = expand_instant_command(
-            "https://translate.com/?text={clip}",
-            "",
-            "hello world",
-        );
+        let result =
+            expand_instant_command("https://translate.com/?text={clip}", "", "hello world");
         assert!(result.contains("hello%20world"));
         assert!(!result.contains("hello world"));
     }
 
     #[test]
     fn url_symbols_are_encoded() {
-        let result = expand_instant_command(
-            "https://example.com/?q={query}",
-            "a&b=c",
-            "",
-        );
+        let result = expand_instant_command("https://example.com/?q={query}", "a&b=c", "");
         assert!(result.contains("a%26b%3Dc"));
     }
 
     #[test]
     fn non_url_query_is_raw() {
-        let result = expand_instant_command(
-            "C:\\editor.exe {query}",
-            "hello world",
-            "",
-        );
+        let result = expand_instant_command("C:\\editor.exe {query}", "hello world", "");
         assert_eq!(result, "C:\\editor.exe hello world");
     }
 
     #[test]
     fn non_url_clip_is_raw() {
-        let result = expand_instant_command(
-            "C:\\editor.exe {clip}",
-            "",
-            "clipboard text",
-        );
+        let result = expand_instant_command("C:\\editor.exe {clip}", "", "clipboard text");
         assert_eq!(result, "C:\\editor.exe clipboard text");
     }
 
     #[test]
     fn empty_query_expands_to_empty() {
-        let result = expand_instant_command(
-            "https://google.com/search?q={query}",
-            "",
-            "",
-        );
+        let result = expand_instant_command("https://google.com/search?q={query}", "", "");
         assert_eq!(result, "https://google.com/search?q=");
     }
 
@@ -398,11 +375,8 @@ mod tests {
 
     #[test]
     fn both_placeholders_in_url() {
-        let result = expand_instant_command(
-            "https://example.com/?q={query}&c={clip}",
-            "test",
-            "data",
-        );
+        let result =
+            expand_instant_command("https://example.com/?q={query}&c={clip}", "test", "data");
         assert_eq!(result, "https://example.com/?q=test&c=data");
     }
 
@@ -410,9 +384,27 @@ mod tests {
 
     fn sample_commands() -> Vec<InstantCommand> {
         vec![
-            InstantCommand { name: "g".to_string(), description: String::new(), action: InstantAction::Url { url: "https://google.com?q={query}".into() } },
-            InstantCommand { name: "gm".to_string(), description: String::new(), action: InstantAction::Url { url: "https://mail.google.com".into() } },
-            InstantCommand { name: "n".to_string(), description: String::new(), action: InstantAction::Url { url: "notepad.exe".into() } },
+            InstantCommand {
+                name: "g".to_string(),
+                description: String::new(),
+                action: InstantAction::Url {
+                    url: "https://google.com?q={query}".into(),
+                },
+            },
+            InstantCommand {
+                name: "gm".to_string(),
+                description: String::new(),
+                action: InstantAction::Url {
+                    url: "https://mail.google.com".into(),
+                },
+            },
+            InstantCommand {
+                name: "n".to_string(),
+                description: String::new(),
+                action: InstantAction::Url {
+                    url: "notepad.exe".into(),
+                },
+            },
         ]
     }
 
@@ -449,15 +441,21 @@ mod tests {
 
     #[test]
     fn filter_case_insensitive() {
-        let cmds = vec![
-            InstantCommand { name: "Google".to_string(), description: String::new(), action: InstantAction::Url { url: "https://google.com".into() } },
-        ];
+        let cmds = vec![InstantCommand {
+            name: "Google".to_string(),
+            description: String::new(),
+            action: InstantAction::Url {
+                url: "https://google.com".into(),
+            },
+        }];
         let result = filter_instant_commands(&cmds, "google");
         assert_eq!(result.len(), 1);
     }
 
     // ---- expand_exec_args tests ----
-    fn no_env(s: &str) -> String { s.to_string() }
+    fn no_env(s: &str) -> String {
+        s.to_string()
+    }
 
     #[test]
     fn exec_args_empty_is_no_tokens() {
@@ -512,11 +510,17 @@ mod tests {
     // ---- split_args (quote-aware splitting) tests ----
     #[test]
     fn split_args_quoted_token_preserves_spaces() {
-        assert_eq!(split_args(r#"--dir "My Documents""#), vec!["--dir", "My Documents"]);
+        assert_eq!(
+            split_args(r#"--dir "My Documents""#),
+            vec!["--dir", "My Documents"]
+        );
     }
     #[test]
     fn split_args_unclosed_quote_consumes_to_end() {
-        assert_eq!(split_args(r#"--dir "My Documents"#), vec!["--dir", "My Documents"]);
+        assert_eq!(
+            split_args(r#"--dir "My Documents"#),
+            vec!["--dir", "My Documents"]
+        );
     }
     #[test]
     fn split_args_adjacent_quotes_join() {
@@ -533,7 +537,10 @@ mod tests {
     #[test]
     fn split_args_keeps_braced_placeholder_with_spaces() {
         // `{...}` 内の空白は分割しない（修飾子パイプを1トークンに保つ）
-        assert_eq!(split_args("-s {query | trim}"), vec!["-s", "{query | trim}"]);
+        assert_eq!(
+            split_args("-s {query | trim}"),
+            vec!["-s", "{query | trim}"]
+        );
     }
     #[test]
     fn split_args_keeps_braced_default_with_spaces() {
@@ -684,7 +691,10 @@ mod tests {
     #[test]
     fn unknown_modifiers_works_with_date_uuid() {
         // date/uuid 変数でも修飾子検査が機能する
-        assert_eq!(collect_unknown_modifiers("{date:%Y | bogus}"), vec!["bogus"]);
+        assert_eq!(
+            collect_unknown_modifiers("{date:%Y | bogus}"),
+            vec!["bogus"]
+        );
         assert_eq!(collect_unknown_modifiers("{uuid | nope}"), vec!["nope"]);
         assert!(collect_unknown_modifiers("{date:%Y-%m-%d | upper}").is_empty());
         assert!(collect_unknown_modifiers("{uuid | upper}").is_empty());
@@ -779,10 +789,7 @@ mod tests {
             u.chars().all(|c| c == '-' || c.is_ascii_hexdigit()),
             "hex only: {u}"
         );
-        assert!(
-            u.chars().all(|c| !c.is_ascii_uppercase()),
-            "lowercase: {u}"
-        );
+        assert!(u.chars().all(|c| !c.is_ascii_uppercase()), "lowercase: {u}");
     }
 
     #[test]
@@ -882,6 +889,9 @@ mod tests {
         let r = expand_exec_args("{{date}", "", "", no_env);
         assert_eq!(r.len(), 1);
         assert!(r[0].starts_with('{'), "leading brace kept literal: {r:?}");
-        assert!(!r[0].contains("{date}"), "second brace opened a placeholder: {r:?}");
+        assert!(
+            !r[0].contains("{date}"),
+            "second brace opened a placeholder: {r:?}"
+        );
     }
 }

--- a/snotra-core/src/opener.rs
+++ b/snotra-core/src/opener.rs
@@ -39,7 +39,10 @@ pub fn extract_path_condition(target: &str) -> Option<&str> {
 
 /// ターゲットから拡張子リスト部分のみ取得する（パス条件を除外）。
 pub fn extract_ext_part(target: &str) -> &str {
-    debug_assert!(target.starts_with("ext:"), "extract_ext_part called on non-ext target: {target}");
+    debug_assert!(
+        target.starts_with("ext:"),
+        "extract_ext_part called on non-ext target: {target}"
+    );
     let after_ext = &target["ext:".len()..];
     if let Some(path_cond) = extract_path_condition(target) {
         // パス条件の直前のコロンまでが拡張子部分
@@ -80,14 +83,10 @@ pub fn find_matching_tools<'a>(
             // パス条件がパス境界で終わっていることを確認
             // 例: 条件 "C:\workspace" はパス "C:\workspace123" にマッチしない
             // 条件自体がパス区切りで終わっている場合はすでに境界OK
-            let cond_ends_with_sep =
-                cond_lower.ends_with('\\') || cond_lower.ends_with('/');
+            let cond_ends_with_sep = cond_lower.ends_with('\\') || cond_lower.ends_with('/');
             if !cond_ends_with_sep {
                 let next_byte = path_lower.as_bytes().get(cond_lower.len());
-                if next_byte.is_some()
-                    && next_byte != Some(&b'\\')
-                    && next_byte != Some(&b'/')
-                {
+                if next_byte.is_some() && next_byte != Some(&b'\\') && next_byte != Some(&b'/') {
                     continue;
                 }
             }
@@ -323,8 +322,8 @@ pub fn detect_opener_presets() -> Vec<OpenerPreset> {
     }
 
     // Explorer: 常に利用可能。find_in_path でフルパスを解決し、アイコン取得を確実にする
-    let explorer_exe = find_in_path("explorer.exe")
-        .unwrap_or_else(|| r"C:\Windows\explorer.exe".to_string());
+    let explorer_exe =
+        find_in_path("explorer.exe").unwrap_or_else(|| r"C:\Windows\explorer.exe".to_string());
     presets.push(OpenerPreset {
         name: "Explorer",
         exe: explorer_exe,
@@ -400,7 +399,10 @@ mod tests {
     fn normalize_openers_sorts_by_specificity() {
         let openers = vec![
             make_rule("ext:txt", &[("Notepad", "notepad.exe", "")]),
-            make_rule("folder:c:\\workspace\\snotra", &[("Terminal", "wt.exe", "-d {path}")]),
+            make_rule(
+                "folder:c:\\workspace\\snotra",
+                &[("Terminal", "wt.exe", "-d {path}")],
+            ),
             make_rule("ext:md:c:\\projects", &[("VSCode", "Code.exe", "")]),
             make_rule("folder", &[("Explorer", "explorer.exe", "")]),
             make_rule("folder:c:\\workspace", &[("VSCode", "Code.exe", "")]),
@@ -411,14 +413,17 @@ mod tests {
         let targets: Vec<&str> = normalized.iter().map(|r| r.target.as_str()).collect();
 
         // (1) パス付きフォルダ（パスが長い順）→ (2) パスなしフォルダ → (3) パス付き拡張子 → (4) パスなし拡張子
-        assert_eq!(targets, vec![
-            "folder:c:\\workspace\\snotra",
-            "folder:c:\\workspace",
-            "folder",
-            "ext:.md:c:\\projects",
-            "ext:.txt",
-            "ext:.md",
-        ]);
+        assert_eq!(
+            targets,
+            vec![
+                "folder:c:\\workspace\\snotra",
+                "folder:c:\\workspace",
+                "folder",
+                "ext:.md:c:\\projects",
+                "ext:.txt",
+                "ext:.md",
+            ]
+        );
     }
 
     #[test]
@@ -450,7 +455,10 @@ mod tests {
 
     #[test]
     fn find_matching_tools_ext_target_with_dot() {
-        let rules = vec![make_rule("ext:.png,jpg", &[("IrfanView", "i_view64.exe", "")])];
+        let rules = vec![make_rule(
+            "ext:.png,jpg",
+            &[("IrfanView", "i_view64.exe", "")],
+        )];
         let tools = find_matching_tools("C:\\image.PNG", false, &rules);
         assert_eq!(tools.len(), 1);
         assert_eq!(tools[0].name, "IrfanView");
@@ -458,7 +466,10 @@ mod tests {
 
     #[test]
     fn find_matching_tools_ext_target_without_dot() {
-        let rules = vec![make_rule("ext:png,jpg,gif", &[("IrfanView", "i_view64.exe", "")])];
+        let rules = vec![make_rule(
+            "ext:png,jpg,gif",
+            &[("IrfanView", "i_view64.exe", "")],
+        )];
         let tools = find_matching_tools("C:\\photo.jpg", false, &rules);
         assert_eq!(tools.len(), 1);
         assert_eq!(tools[0].name, "IrfanView");
@@ -503,7 +514,10 @@ mod tests {
     fn find_matching_tools_multiple_tools_in_rule() {
         let rules = vec![make_rule(
             "folder",
-            &[("TC", "TOTALCMD64.EXE", ""), ("Explorer", "explorer.exe", "")],
+            &[
+                ("TC", "TOTALCMD64.EXE", ""),
+                ("Explorer", "explorer.exe", ""),
+            ],
         )];
         let tools = find_matching_tools("C:\\Projects", true, &rules);
         assert_eq!(tools.len(), 2);
@@ -513,7 +527,10 @@ mod tests {
 
     #[test]
     fn find_matching_tools_case_insensitive_ext() {
-        let rules = vec![make_rule("ext:PNG,JPG", &[("IrfanView", "i_view64.exe", "")])];
+        let rules = vec![make_rule(
+            "ext:PNG,JPG",
+            &[("IrfanView", "i_view64.exe", "")],
+        )];
         let tools = find_matching_tools("C:\\Photo.png", false, &rules);
         assert_eq!(tools.len(), 1);
     }
@@ -546,7 +563,10 @@ mod tests {
     fn find_matching_tools_most_specific_path_wins() {
         let rules = vec![
             make_rule("folder:C:\\workspace", &[("VSCode", "Code.exe", "")]),
-            make_rule("folder:C:\\workspace\\Snotra", &[("Terminal", "wt.exe", "-d {path}")]),
+            make_rule(
+                "folder:C:\\workspace\\Snotra",
+                &[("Terminal", "wt.exe", "-d {path}")],
+            ),
             make_rule("folder", &[("Explorer", "explorer.exe", "")]),
         ];
         let tools = find_matching_tools("C:\\workspace\\Snotra\\src", true, &rules);
@@ -556,9 +576,10 @@ mod tests {
 
     #[test]
     fn find_matching_tools_path_condition_case_insensitive() {
-        let rules = vec![
-            make_rule("folder:C:\\Workspace", &[("VSCode", "Code.exe", "")]),
-        ];
+        let rules = vec![make_rule(
+            "folder:C:\\Workspace",
+            &[("VSCode", "Code.exe", "")],
+        )];
         let tools = find_matching_tools("c:\\workspace\\project", true, &rules);
         assert_eq!(tools.len(), 1);
         assert_eq!(tools[0].name, "VSCode");
@@ -599,9 +620,10 @@ mod tests {
 
     #[test]
     fn find_matching_tools_path_condition_slash_normalized() {
-        let rules = vec![
-            make_rule("folder:C:\\workspace", &[("VSCode", "Code.exe", "")]),
-        ];
+        let rules = vec![make_rule(
+            "folder:C:\\workspace",
+            &[("VSCode", "Code.exe", "")],
+        )];
         // パスにスラッシュが混在
         let tools = find_matching_tools("C:/workspace/project", true, &rules);
         assert_eq!(tools.len(), 1);
@@ -622,9 +644,10 @@ mod tests {
 
     #[test]
     fn find_matching_tools_path_condition_exact_match() {
-        let rules = vec![
-            make_rule("folder:C:\\workspace", &[("VSCode", "Code.exe", "")]),
-        ];
+        let rules = vec![make_rule(
+            "folder:C:\\workspace",
+            &[("VSCode", "Code.exe", "")],
+        )];
         // 完全一致もマッチする
         let tools = find_matching_tools("C:\\workspace", true, &rules);
         assert_eq!(tools.len(), 1);
@@ -722,9 +745,10 @@ mod tests {
         assert_eq!(tools[0].name, "VSCode");
 
         // 末尾 / 付き条件でも同様
-        let rules2 = vec![
-            make_rule("folder:C:\\workspace/", &[("VSCode", "Code.exe", "")]),
-        ];
+        let rules2 = vec![make_rule(
+            "folder:C:\\workspace/",
+            &[("VSCode", "Code.exe", "")],
+        )];
         let tools2 = find_matching_tools("C:\\workspace\\project", true, &rules2);
         assert_eq!(tools2.len(), 1);
         assert_eq!(tools2[0].name, "VSCode");
@@ -782,10 +806,7 @@ mod tests {
                 args: String::new(),
             }],
         }];
-        assert!(is_preset_already_added(
-            &rules,
-            r"C:\Windows\explorer.exe"
-        ));
+        assert!(is_preset_already_added(&rules, r"C:\Windows\explorer.exe"));
         // 逆方向: 設定にフルパス、プリセットが bare name
         let rules_full = vec![OpenerRule {
             target: "folder".to_string(),

--- a/snotra-core/src/query.rs
+++ b/snotra-core/src/query.rs
@@ -280,7 +280,10 @@ mod tests {
     #[test]
     fn history_query_key_collapses_spaces() {
         // normalize_query が連続スペースを圧縮することを確認
-        assert_eq!(normalize_history_query_key("my  tools\\foo"), "my tools\\foo");
+        assert_eq!(
+            normalize_history_query_key("my  tools\\foo"),
+            "my tools\\foo"
+        );
     }
 
     #[test]

--- a/snotra-core/src/search.rs
+++ b/snotra-core/src/search.rs
@@ -205,7 +205,8 @@ impl IncrementalCache {
 /// 衝突は候補を余計に通すだけで、kana マッチを棄却しない。
 #[inline]
 fn kana_char_mask(kana: &str) -> u64 {
-    kana.chars().fold(0, |mask, ch| mask | (1u64 << ((ch as u32) & 63)))
+    kana.chars()
+        .fold(0, |mask, ch| mask | (1u64 << ((ch as u32) & 63)))
 }
 
 impl SearchEngine {
@@ -220,13 +221,7 @@ impl SearchEngine {
         history: &HistoryStore,
         mode: SearchMode,
     ) -> Vec<SearchResult> {
-        self.search_with_options(
-            query,
-            max_results,
-            history,
-            mode,
-            SearchOptions::default(),
-        )
+        self.search_with_options(query, max_results, history, mode, SearchOptions::default())
     }
 
     pub fn search_with_options(

--- a/snotra-core/src/search/build.rs
+++ b/snotra-core/src/search/build.rs
@@ -14,7 +14,12 @@ use super::{IncrementalCache, SearchEngine, kana_char_mask};
 
 /// Wave 1 の出力: `(lower_names, lower_file_names, normalized_keys, kana_lower_names)`。
 /// いずれも構築後に伸長しないため `Box<str>` で保持する（容量ワード 8B/要素を節約）。
-type Wave1Strings = (Vec<Box<str>>, Vec<Option<Box<str>>>, Vec<Box<str>>, Vec<Box<str>>);
+type Wave1Strings = (
+    Vec<Box<str>>,
+    Vec<Option<Box<str>>>,
+    Vec<Box<str>>,
+    Vec<Box<str>>,
+);
 
 /// Wave 1: entries から文字列正規化データを並列構築する。
 /// lower_names / lower_file_names / normalized_keys / kana_lower_names は
@@ -61,7 +66,12 @@ fn compute_wave1(entries: &[AppEntry], migemo_enabled: bool) -> Wave1Strings {
             )
         },
     );
-    (lower_names, lower_file_names, normalized_keys, kana_lower_names)
+    (
+        lower_names,
+        lower_file_names,
+        normalized_keys,
+        kana_lower_names,
+    )
 }
 
 /// Wave 2: lower_names / lower_file_names からビットマスクを並列構築する。
@@ -74,7 +84,12 @@ fn compute_wave2(
     lower_file_names: &[Option<Box<str>>],
 ) -> (Vec<u64>, Vec<u64>) {
     rayon::join(
-        || lower_names.iter().map(|n| name_char_mask(n)).collect::<Vec<_>>(),
+        || {
+            lower_names
+                .iter()
+                .map(|n| name_char_mask(n))
+                .collect::<Vec<_>>()
+        },
         || {
             // None → 0: entries without a file_name cannot match via the file_name path,
             // so failing the bitmask check (and being skipped when the name also fails) is correct.
@@ -88,7 +103,10 @@ fn compute_wave2(
 
 /// migemo 有効時の kana pre-filter 用並列 Vec を構築する。kana 未構築時は空 Vec を保つ。
 fn compute_kana_char_masks(kana_lower_names: &[Box<str>]) -> Vec<u64> {
-    kana_lower_names.iter().map(|name| kana_char_mask(name)).collect()
+    kana_lower_names
+        .iter()
+        .map(|name| kana_char_mask(name))
+        .collect()
 }
 
 impl SearchEngine {
@@ -145,8 +163,7 @@ impl SearchEngine {
     pub fn new_with_migemo(entries: Vec<AppEntry>, migemo_enabled: bool) -> Self {
         let (lower_names, lower_file_names, normalized_keys, kana_lower_names) =
             compute_wave1(&entries, migemo_enabled);
-        let (char_masks, file_name_char_masks) =
-            compute_wave2(&lower_names, &lower_file_names);
+        let (char_masks, file_name_char_masks) = compute_wave2(&lower_names, &lower_file_names);
         let kana_char_masks = compute_kana_char_masks(&kana_lower_names);
         Self::assemble(
             entries,
@@ -177,9 +194,11 @@ impl SearchEngine {
         migemo_enabled: bool,
     ) -> Self {
         let (lower_names, lower_file_names, normalized_keys, kana_lower_names) =
-            if let (Some(ln), Some(lfn), Some(nk)) =
-                (cached_lower_names, cached_lower_file_names, cached_normalized_keys)
-            {
+            if let (Some(ln), Some(lfn), Some(nk)) = (
+                cached_lower_names,
+                cached_lower_file_names,
+                cached_normalized_keys,
+            ) {
                 // A-3: v4 キャッシュヒット → Wave 1 完全スキップ（kana_lower_names は毎起動再計算）。
                 // キャッシュ由来の Vec<String> を Box<str> へ移す。postcard デシリアライズ後の
                 // String は capacity == len のため into_boxed_str は再アロケーションを伴わない。
@@ -192,12 +211,18 @@ impl SearchEngine {
                 } else {
                     Vec::new()
                 };
-                let ln = ln.into_iter().map(String::into_boxed_str).collect::<Vec<_>>();
+                let ln = ln
+                    .into_iter()
+                    .map(String::into_boxed_str)
+                    .collect::<Vec<_>>();
                 let lfn = lfn
                     .into_iter()
                     .map(|o| o.map(String::into_boxed_str))
                     .collect::<Vec<_>>();
-                let nk = nk.into_iter().map(String::into_boxed_str).collect::<Vec<_>>();
+                let nk = nk
+                    .into_iter()
+                    .map(String::into_boxed_str)
+                    .collect::<Vec<_>>();
                 (ln, lfn, nk, kana)
             } else {
                 // v3 フォールバック: Wave 1 を並列実行（migemo フラグを反映）

--- a/snotra-core/src/search/query_plan.rs
+++ b/snotra-core/src/search/query_plan.rs
@@ -54,7 +54,11 @@ pub(super) fn prepare_query_plan<'a>(
 
     let has_dot = norm_query.contains('.');
     // Bitmask pre-filter is only used in Fuzzy mode; skip the computation for others.
-    let query_mask = if mode == SearchMode::Fuzzy { char_bitmask(&norm_query) } else { 0 };
+    let query_mask = if mode == SearchMode::Fuzzy {
+        char_bitmask(&norm_query)
+    } else {
+        0
+    };
 
     // Migemo: ローマ字 ASCII クエリをひらがなに変換した kana_query を生成する。
     // kana に ASCII アルファベットが残留する場合（"dok" → "どk" 等）は None にする。

--- a/snotra-core/src/search/scoring.rs
+++ b/snotra-core/src/search/scoring.rs
@@ -150,9 +150,9 @@ fn match_score_single_cached(
                 None
             }
         }
-        SearchMode::Substring => {
-            lower_name.find(query).map(|idx| score_tier::SUBSTRING_BASE - idx as i64)
-        }
+        SearchMode::Substring => lower_name
+            .find(query)
+            .map(|idx| score_tier::SUBSTRING_BASE - idx as i64),
         SearchMode::Fuzzy => {
             let h = haystack_u32.expect("Fuzzy mode requires UTF-32 haystack");
             let haystack = h.slice(..);
@@ -385,13 +385,13 @@ impl SearchEngine {
 
         let base_score = score?;
 
-        let (global_launches, last_launched) = history.get_global_stats_normalized(v.normalized_key);
+        let (global_launches, last_launched) =
+            history.get_global_stats_normalized(v.normalized_key);
         // 履歴キーは record_launch の保存形式に合わせる:
         // normalize_query() + パス区切り統一。path_query は生クエリベースで
         // スペース/アクセントが異なるため履歴キーには使わない。
         let history_query_key = plan.path_history_key.as_deref().unwrap_or(norm_query_str);
-        let qcount =
-            history.query_count_pre_normalized(history_query_key, v.normalized_key) as i64;
+        let qcount = history.query_count_pre_normalized(history_query_key, v.normalized_key) as i64;
 
         let folder_boost = if v.entry.is_folder {
             history.folder_expansion_count_normalized(v.normalized_key) as i64

--- a/snotra-core/src/search/tests/ranking.rs
+++ b/snotra-core/src/search/tests/ranking.rs
@@ -183,7 +183,10 @@ fn topk_names(limit: usize, scores: &[(i64, usize)], entries: &[AppEntry]) -> Ve
     for &(score, index) in scores {
         t.push(se(score, index, entries));
     }
-    t.into_results(entries).into_iter().map(|r| r.name).collect()
+    t.into_results(entries)
+        .into_iter()
+        .map(|r| r.name)
+        .collect()
 }
 
 #[test]
@@ -248,11 +251,19 @@ fn topk_merge_is_order_independent() {
 
     let mut a1 = build(&[(10, 0), (40, 1)]);
     a1.merge(build(&[(20, 2), (30, 3)]));
-    let names_ab: Vec<String> = a1.into_results(&entries).into_iter().map(|r| r.name).collect();
+    let names_ab: Vec<String> = a1
+        .into_results(&entries)
+        .into_iter()
+        .map(|r| r.name)
+        .collect();
 
     let mut b1 = build(&[(20, 2), (30, 3)]);
     b1.merge(build(&[(10, 0), (40, 1)]));
-    let names_ba: Vec<String> = b1.into_results(&entries).into_iter().map(|r| r.name).collect();
+    let names_ba: Vec<String> = b1
+        .into_results(&entries)
+        .into_iter()
+        .map(|r| r.name)
+        .collect();
 
     assert_eq!(names_ab, vec!["e1", "e3"]); // top2 of {10,40,20,30} = 40,30
     assert_eq!(names_ab, names_ba); // merge 順に依存しない

--- a/snotra-core/src/window_data.rs
+++ b/snotra-core/src/window_data.rs
@@ -152,7 +152,10 @@ mod tests {
         let migrated = load_state_v5_in(&dir).expect("load v4 via v5 path");
 
         // (a) search（絶対座標）はモニター相対座標として無意味なため破棄され None になる。
-        assert_eq!(migrated.search, None, "V4 absolute search coords must be discarded");
+        assert_eq!(
+            migrated.search, None,
+            "V4 absolute search coords must be discarded"
+        );
         // settings/settings_size は V4 でも絶対座標のまま意味を保つため引き継がれる。
         assert_eq!(migrated.settings, v4_state.settings);
         assert_eq!(migrated.settings_size, v4_state.settings_size);
@@ -166,7 +169,10 @@ mod tests {
         assert_eq!(reloaded_v5, migrated);
         let as_v4: Result<WindowPlacementState, _> =
             try_deserialize_with_header(&raw, WINDOW_MAGIC, WINDOW_VERSION_V4);
-        assert!(as_v4.is_err(), "persisted file should no longer be readable as V4");
+        assert!(
+            as_v4.is_err(),
+            "persisted file should no longer be readable as V4"
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -184,7 +190,8 @@ mod tests {
         let bytes =
             try_serialize_with_header(WINDOW_MAGIC, WINDOW_VERSION_V4, &state).expect("serialize");
         let restored: WindowPlacementState =
-            try_deserialize_with_header(&bytes, WINDOW_MAGIC, WINDOW_VERSION_V4).expect("deserialize");
+            try_deserialize_with_header(&bytes, WINDOW_MAGIC, WINDOW_VERSION_V4)
+                .expect("deserialize");
         assert_eq!(state, restored);
     }
 
@@ -201,7 +208,8 @@ mod tests {
         let bytes =
             try_serialize_with_header(WINDOW_MAGIC, WINDOW_VERSION_V5, &state).expect("serialize");
         let restored: WindowPlacementState =
-            try_deserialize_with_header(&bytes, WINDOW_MAGIC, WINDOW_VERSION_V5).expect("deserialize");
+            try_deserialize_with_header(&bytes, WINDOW_MAGIC, WINDOW_VERSION_V5)
+                .expect("deserialize");
         assert_eq!(state, restored);
     }
 

--- a/snotra-core/tests/memory_footprint.rs
+++ b/snotra-core/tests/memory_footprint.rs
@@ -135,8 +135,11 @@ fn synthetic_entries(n: usize) -> Vec<AppEntry> {
     (0..n)
         .map(|i| {
             let name = format!("entry{i:05}");
-            let target_path =
-                format!("C:\\workspace\\project{:03}\\src\\module{:04}\\{name}", i % 512, i % 997);
+            let target_path = format!(
+                "C:\\workspace\\project{:03}\\src\\module{:04}\\{name}",
+                i % 512,
+                i % 997
+            );
             AppEntry {
                 name,
                 target_path,
@@ -188,7 +191,12 @@ fn measure_real_index_footprint() {
     );
     report("index.bin ロード（entries + masks）", t0, t1, n);
 
-    let LoadOrScanResult { entries, cached_masks, rescan_task, .. } = result;
+    let LoadOrScanResult {
+        entries,
+        cached_masks,
+        rescan_task,
+        ..
+    } = result;
     // 背景再スキャンタスクは src-tauri 側で別スレッドが消費する。常駐計測の対象外。
     drop(rescan_task);
 

--- a/snotra-egui-runtime/src/input.rs
+++ b/snotra-egui-runtime/src/input.rs
@@ -434,7 +434,10 @@ mod tests {
         // 可視アイドルが 2fps → 11.5fps）。値そのものを固定して回帰を検出する。
         let mut input = InputState::new(1.0);
         let raw = input.take(4096, PhysicalSize::new(100, 100), 1.0);
-        assert_eq!(raw.predicted_dt, 0.0, "先取りしない（要求どおりの時刻に起きる）");
+        assert_eq!(
+            raw.predicted_dt, 0.0,
+            "先取りしない（要求どおりの時刻に起きる）"
+        );
         // 2 フレーム目以降も持ち越しで戻らないこと（RawInput::take は値を保持する）。
         let raw2 = input.take(4096, PhysicalSize::new(100, 100), 1.0);
         assert_eq!(raw2.predicted_dt, 0.0);

--- a/snotra-egui-runtime/src/monitor.rs
+++ b/snotra-egui-runtime/src/monitor.rs
@@ -15,8 +15,7 @@
 pub(crate) fn window_monitor(hwnd: isize) -> Option<isize> {
     use windows::Win32::Foundation::HWND;
     use windows::Win32::Graphics::Gdi::{MONITOR_DEFAULTTONEAREST, MonitorFromWindow};
-    let monitor =
-        unsafe { MonitorFromWindow(HWND(hwnd as *mut _), MONITOR_DEFAULTTONEAREST) };
+    let monitor = unsafe { MonitorFromWindow(HWND(hwnd as *mut _), MONITOR_DEFAULTTONEAREST) };
     (!monitor.is_invalid()).then_some(monitor.0 as isize)
 }
 
@@ -31,8 +30,7 @@ pub(crate) fn monitor_refresh_hz(hwnd: isize) -> Option<u32> {
     use windows::Win32::Foundation::HWND;
     use windows::Win32::Graphics::Gdi::{
         DEVMODEW, ENUM_CURRENT_SETTINGS, ENUM_REGISTRY_SETTINGS, EnumDisplaySettingsW,
-        GetMonitorInfoW, MONITOR_DEFAULTTONEAREST, MONITORINFO, MONITORINFOEXW,
-        MonitorFromWindow,
+        GetMonitorInfoW, MONITOR_DEFAULTTONEAREST, MONITORINFO, MONITORINFOEXW, MonitorFromWindow,
     };
     use windows::core::PCWSTR;
 
@@ -56,8 +54,7 @@ pub(crate) fn monitor_refresh_hz(hwnd: isize) -> Option<u32> {
                 dmSize: std::mem::size_of::<DEVMODEW>() as u16,
                 ..Default::default()
             };
-            if EnumDisplaySettingsW(PCWSTR(info.szDevice.as_ptr()), mode, &mut devmode)
-                .as_bool()
+            if EnumDisplaySettingsW(PCWSTR(info.szDevice.as_ptr()), mode, &mut devmode).as_bool()
                 && devmode.dmDisplayFrequency > 1
             {
                 return Some(devmode.dmDisplayFrequency);

--- a/snotra-egui-runtime/src/raster.rs
+++ b/snotra-egui-runtime/src/raster.rs
@@ -54,10 +54,10 @@ impl CpuTexture {
         }
         match self.filter {
             TexFilter::Nearest => {
-                let x = ((u * self.width as f32) as isize)
-                    .clamp(0, self.width as isize - 1) as usize;
-                let y = ((v * self.height as f32) as isize)
-                    .clamp(0, self.height as isize - 1) as usize;
+                let x =
+                    ((u * self.width as f32) as isize).clamp(0, self.width as isize - 1) as usize;
+                let y =
+                    ((v * self.height as f32) as isize).clamp(0, self.height as isize - 1) as usize;
                 self.pixels[y * self.width + x]
             }
             // half-texel 規約 uv*size - 0.5 で 4 近傍を ClampToEdge 補間(egui-wgpu 一致)。
@@ -112,8 +112,12 @@ pub(crate) fn fill_mesh(
         }
         let min_x = x0.min(x1).min(x2).floor().max(clip_min.0 as f32) as usize;
         let min_y = y0.min(y1).min(y2).floor().max(clip_min.1 as f32) as usize;
-        let max_x = (x0.max(x1).max(x2).ceil() as usize).min(clip_max.0).min(width);
-        let max_y = (y0.max(y1).max(y2).ceil() as usize).min(clip_max.1).min(height);
+        let max_x = (x0.max(x1).max(x2).ceil() as usize)
+            .min(clip_max.0)
+            .min(width);
+        let max_y = (y0.max(y1).max(y2).ceil() as usize)
+            .min(clip_max.1)
+            .min(height);
         for y in min_y..max_y {
             let py = y as f32 + 0.5;
             for x in min_x..max_x {
@@ -212,9 +216,15 @@ mod tests {
     #[test]
     fn raster_core_matches_soft_probe_invariants() {
         assert!(edge(0.0, 0.0, 4.0, 0.0, 1.0, 1.0) > 0.0);
-        assert_eq!(blend_premultiplied(0x0000_0000, [255, 0, 0, 255]), 0x00FF_0000);
+        assert_eq!(
+            blend_premultiplied(0x0000_0000, [255, 0, 0, 255]),
+            0x00FF_0000
+        );
         assert_eq!(blend_premultiplied(0x0012_3456, [0, 0, 0, 0]), 0x0012_3456);
-        assert_eq!(modulate([200, 100, 50, 255], [255, 255, 255, 255]), [200, 100, 50, 255]);
+        assert_eq!(
+            modulate([200, 100, 50, 255], [255, 255, 255, 255]),
+            [200, 100, 50, 255]
+        );
 
         let mut buffer = vec![0u32; 8 * 8];
         let vertex = |x: f32, y: f32| egui::epaint::Vertex {
@@ -223,8 +233,23 @@ mod tests {
             color: egui::Color32::from_rgba_premultiplied(255, 255, 255, 255),
         };
         let vertices = [vertex(0.0, 0.0), vertex(8.0, 0.0), vertex(0.0, 8.0)];
-        let white = CpuTexture { width: 0, height: 0, pixels: Vec::new(), filter: TexFilter::Nearest };
-        fill_mesh(&mut buffer, 8, 8, &vertices, &[0, 1, 2], &white, (0, 0), (8, 8), 1.0);
+        let white = CpuTexture {
+            width: 0,
+            height: 0,
+            pixels: Vec::new(),
+            filter: TexFilter::Nearest,
+        };
+        fill_mesh(
+            &mut buffer,
+            8,
+            8,
+            &vertices,
+            &[0, 1, 2],
+            &white,
+            (0, 0),
+            (8, 8),
+            1.0,
+        );
         assert_eq!(buffer[8 + 1], 0x00FF_FFFF);
         assert_eq!(buffer[7 * 8 + 7], 0);
     }
@@ -246,8 +271,15 @@ mod tests {
         // 左端手前 (u=0.0) は左 texel へ clamp → 黒。
         assert_eq!(tex.sample(0.0, 0.5), [0, 0, 0, 255]);
         // nearest は補間しない（同入力で二値のまま）。
-        let nearest = CpuTexture { filter: TexFilter::Nearest, ..CpuTexture {
-            width: 2, height: 1, pixels: vec![[0,0,0,255],[255,255,255,255]], filter: TexFilter::Nearest } };
+        let nearest = CpuTexture {
+            filter: TexFilter::Nearest,
+            ..CpuTexture {
+                width: 2,
+                height: 1,
+                pixels: vec![[0, 0, 0, 255], [255, 255, 255, 255]],
+                filter: TexFilter::Nearest,
+            }
+        };
         let n = nearest.sample(0.5, 0.5);
         assert!(n == [0, 0, 0, 255] || n == [255, 255, 255, 255]);
     }
@@ -256,7 +288,15 @@ mod tests {
         // egui::ColorImage::new は source_size を size と同値で埋める（テスト用合成画像に SVG 由来の別サイズは無い）。
         let img = egui::ColorImage::new(
             [w, h],
-            vec![egui::Color32::from_rgba_premultiplied(id_pixels[0], id_pixels[1], id_pixels[2], id_pixels[3]); w * h],
+            vec![
+                egui::Color32::from_rgba_premultiplied(
+                    id_pixels[0],
+                    id_pixels[1],
+                    id_pixels[2],
+                    id_pixels[3]
+                );
+                w * h
+            ],
         );
         ImageDelta::full(ImageData::Color(std::sync::Arc::new(img)), filter)
     }
@@ -266,13 +306,21 @@ mod tests {
         let mut store: HashMap<egui::TextureId, CpuTexture> = HashMap::new();
         let id = egui::TextureId::Managed(0);
         // pos=None 全面（Linear）。
-        apply_texture_delta(&mut store, id, &solid([10, 20, 30, 255], 2, 2, egui::TextureOptions::LINEAR));
+        apply_texture_delta(
+            &mut store,
+            id,
+            &solid([10, 20, 30, 255], 2, 2, egui::TextureOptions::LINEAR),
+        );
         assert_eq!(store[&id].filter, TexFilter::Linear);
         // pos=Some 部分上書き（filter は既存 Linear を保持）。
         let mut partial = solid([99, 99, 99, 255], 1, 1, egui::TextureOptions::NEAREST);
         partial.pos = Some([0, 0]);
         apply_texture_delta(&mut store, id, &partial);
-        assert_eq!(store[&id].filter, TexFilter::Linear, "部分更新は filter を変えない");
+        assert_eq!(
+            store[&id].filter,
+            TexFilter::Linear,
+            "部分更新は filter を変えない"
+        );
         assert_eq!(store[&id].pixels[0], [99, 99, 99, 255]);
     }
 

--- a/snotra-egui-runtime/src/renderer.rs
+++ b/snotra-egui-runtime/src/renderer.rs
@@ -131,7 +131,9 @@ impl EguiRenderer {
         let t_raster = trace.then(std::time::Instant::now);
         // present は buffer を消費する。結果を保持し、free を present 成否に依らず処理する
         // （free は CPU 側 HashMap から除くだけ・不変条件⑤。present 失敗で free を落とさない）。
-        let present_result = buffer.present().map_err(|e| RuntimeError::Present(e.to_string()));
+        let present_result = buffer
+            .present()
+            .map_err(|e| RuntimeError::Present(e.to_string()));
         for id in &output.textures_delta.free {
             self.textures.remove(id);
         }
@@ -166,9 +168,14 @@ mod tests {
     /// `background_color_premultiplies_alpha_rather_than_ignoring_it` が測る。
     #[test]
     fn clear_color_packs_rgb_and_drops_alpha() {
-        assert_eq!(clear_color_u32(Some(egui::Color32::from_rgb(0x4A, 0x2B, 0x5C))), 0x004A_2B5C);
         assert_eq!(
-            clear_color_u32(Some(egui::Color32::from_rgba_premultiplied(0x12, 0x34, 0x56, 0x80))),
+            clear_color_u32(Some(egui::Color32::from_rgb(0x4A, 0x2B, 0x5C))),
+            0x004A_2B5C
+        );
+        assert_eq!(
+            clear_color_u32(Some(egui::Color32::from_rgba_premultiplied(
+                0x12, 0x34, 0x56, 0x80
+            ))),
             0x0012_3456
         );
     }

--- a/snotra-egui-runtime/src/repaint.rs
+++ b/snotra-egui-runtime/src/repaint.rs
@@ -100,7 +100,9 @@ const FALLBACK_INTERVAL_NANOS: u64 = 1_000_000_000 / 60;
 /// （呼び出し側 `set_min_interval` が 60Hz フォールバックへ倒す）。
 fn interval_from_hz(hz: u32) -> Option<Duration> {
     // 上限 1000Hz: 異常値（間隔 0ns で gate が無効化する類）を防ぐ現実的な天井（レビュー L4）。
-    (2..=1_000).contains(&hz).then(|| Duration::from_nanos(1_000_000_000u64 / u64::from(hz)))
+    (2..=1_000)
+        .contains(&hz)
+        .then(|| Duration::from_nanos(1_000_000_000u64 / u64::from(hz)))
 }
 
 /// 次の dispatch 予定時刻（契約②・#737）: 要求 deadline と gate（前回 dispatch +
@@ -235,7 +237,9 @@ impl RepaintScheduler {
         let interval = hz
             .and_then(interval_from_hz)
             .map_or(FALLBACK_INTERVAL_NANOS, |d| d.as_nanos() as u64);
-        self.inner.min_interval_nanos.store(interval, Ordering::Relaxed);
+        self.inner
+            .min_interval_nanos
+            .store(interval, Ordering::Relaxed);
     }
 }
 
@@ -304,7 +308,10 @@ mod tests {
             },
         ];
         let rendered = format_repaint_causes(&causes);
-        assert_eq!(rendered, "text_selection/visuals.rs:313 ; view.rs:439 state changed");
+        assert_eq!(
+            rendered,
+            "text_selection/visuals.rs:313 ; view.rs:439 state changed"
+        );
         assert_eq!(rendered.split("; ").count(), 2, "件数ぶん連結される");
     }
 

--- a/snotra-egui-runtime/src/runtime.rs
+++ b/snotra-egui-runtime/src/runtime.rs
@@ -227,10 +227,8 @@ impl<T: UserEvent> Plugin<T> for RuntimePlugin<T> {
                             .ok()
                             .and_then(|h| crate::monitor::window_monitor(h.0 as isize));
                         if monitor != active.last_monitor {
-                            active.last_monitor = refresh_min_interval(
-                                &active.window.window,
-                                &active.scheduler,
-                            );
+                            active.last_monitor =
+                                refresh_min_interval(&active.window.window, &active.scheduler);
                         }
                     }
                     if active.window.on_window_event(event) {
@@ -363,8 +361,9 @@ impl EguiWindow {
 
     fn on_window_event(&mut self, event: &tauri_runtime_wry::tao::event::WindowEvent<'_>) -> bool {
         self.drain_native_ime();
-        if let tauri_runtime_wry::tao::event::WindowEvent::ScaleFactorChanged { scale_factor, .. } =
-            event
+        if let tauri_runtime_wry::tao::event::WindowEvent::ScaleFactorChanged {
+            scale_factor, ..
+        } = event
         {
             eprintln!("SNOTRA_EGUI_DPI_CHANGED scale_factor={scale_factor:.3}");
         }

--- a/snotra-egui-runtime/src/windows_ime.rs
+++ b/snotra-egui-runtime/src/windows_ime.rs
@@ -16,9 +16,7 @@ use windows::Win32::{
             ImmSetCompositionWindow, NI_COMPOSITIONSTR,
         },
         Shell::{DefSubclassProc, RemoveWindowSubclass, SetWindowSubclass},
-        WindowsAndMessaging::{
-            WM_IME_COMPOSITION, WM_IME_ENDCOMPOSITION, WM_IME_STARTCOMPOSITION,
-        },
+        WindowsAndMessaging::{WM_IME_COMPOSITION, WM_IME_ENDCOMPOSITION, WM_IME_STARTCOMPOSITION},
     },
 };
 

--- a/snotra-settings/src/app.rs
+++ b/snotra-settings/src/app.rs
@@ -103,7 +103,9 @@ impl TabId {
     /// 新セクション追加時は `SECTION_TABLE` の1箇所だけを更新すればよい
     /// （`section_table_covers_all_config_fields` テストが更新漏れを検出する）。
     fn has_changes(self, draft: &Config, saved: &Config) -> bool {
-        SECTION_TABLE.iter().any(|(tab, diff)| *tab == self && diff(draft, saved))
+        SECTION_TABLE
+            .iter()
+            .any(|(tab, diff)| *tab == self && diff(draft, saved))
     }
 }
 
@@ -124,7 +126,9 @@ const SECTION_TABLE: &[(TabId, SectionDiff)] = &[
     (TabId::Visual, |d, s| d.visual != s.visual),
     (TabId::Visual, |d, s| d.appearance != s.appearance),
     (TabId::Opener, |d, s| d.openers != s.openers),
-    (TabId::InstantCommand, |d, s| d.instant_commands != s.instant_commands),
+    (TabId::InstantCommand, |d, s| {
+        d.instant_commands != s.instant_commands
+    }),
 ];
 
 struct SettingsApp {
@@ -255,9 +259,10 @@ pub(crate) fn config_error_message(error: &ConfigError, tr: &Tr) -> String {
         ConfigError::WindowWidthTooSmall(w) => {
             tr.t_params(TrKey::ErrWindowWidthTooSmall, &[("value", &w.to_string())])
         }
-        ConfigError::FuzzyCapRatioOutOfRange { value } => {
-            tr.t_params(TrKey::ErrFuzzyCapRatioOutOfRange, &[("value", &value.to_string())])
-        }
+        ConfigError::FuzzyCapRatioOutOfRange { value } => tr.t_params(
+            TrKey::ErrFuzzyCapRatioOutOfRange,
+            &[("value", &value.to_string())],
+        ),
         ConfigError::ScanPathEmpty { index } => {
             tr.t_params(TrKey::ErrScanPathEmpty, &[("n", &(index + 1).to_string())])
         }
@@ -331,7 +336,9 @@ impl SettingsApp {
         // (e.g. programmatic focus), clear sidebar focus as well.
         if !self.hotkey_state.is_capturing()
             && self.sidebar_focused
-            && focused_id.map(|id| id != sidebar_sentinel_id).unwrap_or(false)
+            && focused_id
+                .map(|id| id != sidebar_sentinel_id)
+                .unwrap_or(false)
         {
             self.sidebar_focused = false;
         }
@@ -479,7 +486,11 @@ impl SettingsApp {
         // Footer (hide action buttons on Backup tab)
         egui::Panel::bottom("footer")
             .exact_size(40.0)
-            .frame(egui::Frame::NONE.fill(FOOTER_BG).inner_margin(egui::Margin::symmetric(12, 0)))
+            .frame(
+                egui::Frame::NONE
+                    .fill(FOOTER_BG)
+                    .inner_margin(egui::Margin::symmetric(12, 0)),
+            )
             .show(ui, |ui| {
                 ui.horizontal_centered(|ui| {
                     // Status (timer message takes priority; otherwise show persistent unsaved indicator)
@@ -525,7 +536,10 @@ impl SettingsApp {
 
                             // Discard button (always visible, disabled when no changes)
                             if ui
-                                .add_enabled(self.has_changes(), egui::Button::new(self.tr.t(TrKey::BtnDiscard)))
+                                .add_enabled(
+                                    self.has_changes(),
+                                    egui::Button::new(self.tr.t(TrKey::BtnDiscard)),
+                                )
                                 .clicked()
                             {
                                 self.draft = self.saved.clone();
@@ -549,7 +563,11 @@ impl SettingsApp {
             // ui.interact() does not advance the layout cursor, so rendering is unaffected.
             let sentinel_rect =
                 egui::Rect::from_min_size(ui.next_widget_position(), egui::vec2(0.0, 0.0));
-            ui.interact(sentinel_rect, sidebar_sentinel_id, egui::Sense::focusable_noninteractive());
+            ui.interact(
+                sentinel_rect,
+                sidebar_sentinel_id,
+                egui::Sense::focusable_noninteractive(),
+            );
 
             // finding C: read 失敗起因で既定値表示中の警告バナー + 保存確認チェック。
             // チェックを入れるまで Save は無効（下の footer 参照）。
@@ -558,10 +576,7 @@ impl SettingsApp {
                     .fill(BANNER_CAUTION_BG)
                     .inner_margin(egui::Margin::symmetric(10, 8))
                     .show(ui, |ui| {
-                        ui.colored_label(
-                            BANNER_CAUTION_FG,
-                            self.tr.t(TrKey::ReadFailedBanner),
-                        );
+                        ui.colored_label(BANNER_CAUTION_FG, self.tr.t(TrKey::ReadFailedBanner));
                         ui.checkbox(
                             &mut self.confirm_overwrite_despite_read_failure,
                             self.tr.t(TrKey::ReadFailedConfirm),
@@ -571,14 +586,24 @@ impl SettingsApp {
             }
 
             match self.active_tab {
-                TabId::General => tabs::general::ui(ui, &mut self.draft, &mut self.hotkey_state, &self.tr),
+                TabId::General => {
+                    tabs::general::ui(ui, &mut self.draft, &mut self.hotkey_state, &self.tr)
+                }
                 TabId::Search => tabs::search::ui(ui, &mut self.draft, &self.tr),
-                TabId::Index => tabs::index::ui(ui, &ctx, &mut self.draft, &mut self.index_state, &self.tr),
+                TabId::Index => {
+                    tabs::index::ui(ui, &ctx, &mut self.draft, &mut self.index_state, &self.tr)
+                }
                 TabId::Visual => tabs::visual::ui(ui, &mut self.draft, &self.font_list, &self.tr),
-                TabId::Opener => tabs::opener::ui(ui, &ctx, &mut self.draft, &mut self.opener_state, &self.tr),
-                TabId::InstantCommand => tabs::instant::ui(ui, &ctx, &mut self.draft, &mut self.instant_state, &self.tr),
+                TabId::Opener => {
+                    tabs::opener::ui(ui, &ctx, &mut self.draft, &mut self.opener_state, &self.tr)
+                }
+                TabId::InstantCommand => {
+                    tabs::instant::ui(ui, &ctx, &mut self.draft, &mut self.instant_state, &self.tr)
+                }
                 TabId::Backup => {
-                    if let Some(result) = tabs::backup::ui(ui, &ctx, &mut self.backup_state, &self.tr) {
+                    if let Some(result) =
+                        tabs::backup::ui(ui, &ctx, &mut self.backup_state, &self.tr)
+                    {
                         self.draft = result.imported_config.clone();
                         self.saved = result.imported_config;
                         self.tr = Tr(self.draft.general.language);
@@ -593,9 +618,7 @@ impl SettingsApp {
 
         // Track window position for save on exit (skip when minimized to avoid saving 0,0)
         let minimized = ctx.input(|i| i.viewport().minimized).unwrap_or(false);
-        if !minimized
-            && let Some(rect) = ctx.input(|i| i.viewport().outer_rect)
-        {
+        if !minimized && let Some(rect) = ctx.input(|i| i.viewport().outer_rect) {
             let pos = rect.left_top();
             self.last_position = Some(WindowPlacement {
                 x: pos.x as i32,
@@ -646,7 +669,12 @@ pub fn run(
             let heading_semibold = crate::font::configure_fonts(&cc.egui_ctx);
             apply_win11_theme(&cc.egui_ctx);
             style::apply_type_ramp(&cc.egui_ctx, heading_semibold);
-            Ok(Box::new(SettingsApp::new(config, first_run, initial_tab, load_outcome)))
+            Ok(Box::new(SettingsApp::new(
+                config,
+                first_run,
+                initial_tab,
+                load_outcome,
+            )))
         }),
     )
 }
@@ -654,7 +682,9 @@ pub fn run(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use snotra_core::config::{InstantAction, InstantCommand, Language, OpenerRule, OpenerTool, ScanPath};
+    use snotra_core::config::{
+        InstantAction, InstantCommand, Language, OpenerRule, OpenerTool, ScanPath,
+    };
 
     /// Config の全トップレベルフィールドを1つずつ変更する mutation の一覧。
     ///
@@ -680,7 +710,9 @@ mod tests {
             ("general", |c: &mut Config| {
                 c.general.show_on_startup = !c.general.show_on_startup;
             }),
-            ("appearance", |c: &mut Config| c.appearance.window_width += 10),
+            ("appearance", |c: &mut Config| {
+                c.appearance.window_width += 10
+            }),
             ("visual", |c: &mut Config| {
                 c.visual.background_color = "#123456".to_string();
             }),
@@ -708,7 +740,9 @@ mod tests {
                 c.instant_commands.push(InstantCommand {
                     name: "mutation".to_string(),
                     description: String::new(),
-                    action: InstantAction::Url { url: "https://example.com".to_string() },
+                    action: InstantAction::Url {
+                        url: "https://example.com".to_string(),
+                    },
                 });
             }),
         ]
@@ -722,7 +756,10 @@ mod tests {
         for (name, mutate) in field_mutations() {
             let mut draft = saved.clone();
             mutate(&mut draft);
-            assert_ne!(draft, saved, "mutation `{name}` must actually change the config");
+            assert_ne!(
+                draft, saved,
+                "mutation `{name}` must actually change the config"
+            );
             let any_tab_dirty = TabId::ALL.iter().any(|t| t.has_changes(&draft, &saved));
             assert!(
                 any_tab_dirty,
@@ -738,7 +775,10 @@ mod tests {
         let saved = Config::normalized_default();
         let draft = saved.clone();
         for &tab in TabId::ALL {
-            assert!(!tab.has_changes(&draft, &saved), "{tab:?} must not light when unchanged");
+            assert!(
+                !tab.has_changes(&draft, &saved),
+                "{tab:?} must not light when unchanged"
+            );
         }
     }
 
@@ -797,9 +837,14 @@ mod tests {
     #[test]
     fn kittest_checkbox_click_makes_draft_dirty() {
         let mut harness = en_harness(en_config());
-        assert!(!harness.state().has_changes(), "initial state must be clean");
+        assert!(
+            !harness.state().has_changes(),
+            "initial state must be clean"
+        );
 
-        harness.get_by_label(Tr(Language::En).t(TrKey::CbHotkeyToggle)).click();
+        harness
+            .get_by_label(Tr(Language::En).t(TrKey::CbHotkeyToggle))
+            .click();
         settle(&mut harness);
 
         assert!(
@@ -815,16 +860,23 @@ mod tests {
         let original_toggle = harness.state().saved.general.hotkey_toggle;
 
         // 編集して dirty にする（Discard は has_changes() で有効化されるため先に編集）。
-        harness.get_by_label(Tr(Language::En).t(TrKey::CbHotkeyToggle)).click();
+        harness
+            .get_by_label(Tr(Language::En).t(TrKey::CbHotkeyToggle))
+            .click();
         settle(&mut harness);
         assert!(harness.state().has_changes());
         assert_ne!(harness.state().draft.general.hotkey_toggle, original_toggle);
 
         // Discard → draft = saved.clone()。
-        harness.get_by_label(Tr(Language::En).t(TrKey::BtnDiscard)).click();
+        harness
+            .get_by_label(Tr(Language::En).t(TrKey::BtnDiscard))
+            .click();
         settle(&mut harness);
 
-        assert!(!harness.state().has_changes(), "discard must clear dirty state");
+        assert!(
+            !harness.state().has_changes(),
+            "discard must clear dirty state"
+        );
         assert_eq!(
             harness.state().draft.general.hotkey_toggle,
             original_toggle,
@@ -841,9 +893,14 @@ mod tests {
         let mut config = en_config();
         config.general.hotkey_toggle = !default_toggle;
         let mut harness = en_harness(config);
-        assert!(!harness.state().has_changes(), "saved==draft initially = clean");
+        assert!(
+            !harness.state().has_changes(),
+            "saved==draft initially = clean"
+        );
 
-        harness.get_by_label(Tr(Language::En).t(TrKey::BtnResetDefault)).click();
+        harness
+            .get_by_label(Tr(Language::En).t(TrKey::BtnResetDefault))
+            .click();
         settle(&mut harness);
 
         assert_eq!(
@@ -868,9 +925,14 @@ mod tests {
         // 中間状態を直接構築。テストが検証するのは Save ボタン→save()→validate 分岐の wiring）。
         // window_width を最小未満にすると ConfigError::WindowWidthTooSmall になる。
         harness.state_mut().draft.appearance.window_width = 1;
-        assert!(harness.state().has_changes(), "draft must be dirty so Save is enabled");
+        assert!(
+            harness.state().has_changes(),
+            "draft must be dirty so Save is enabled"
+        );
 
-        harness.get_by_label(Tr(Language::En).t(TrKey::BtnSave)).click();
+        harness
+            .get_by_label(Tr(Language::En).t(TrKey::BtnSave))
+            .click();
         settle(&mut harness);
 
         assert!(
@@ -878,7 +940,8 @@ mod tests {
             "validation error must surface a status message"
         );
         assert_eq!(
-            harness.state().saved, saved_before,
+            harness.state().saved,
+            saved_before,
             "saved must not be updated when validation fails"
         );
     }
@@ -913,11 +976,15 @@ mod tests {
         h.set_size(egui::vec2(760.0, 560.0));
 
         // dirty 化（status ラベルが出る = フッターの前置ウィジェットが増える）
-        h.get_by_label(Tr(Language::En).t(TrKey::CbHotkeyToggle)).click();
+        h.get_by_label(Tr(Language::En).t(TrKey::CbHotkeyToggle))
+            .click();
         settle(&mut h);
         assert!(h.state().has_changes());
 
-        let center = h.get_by_label(Tr(Language::En).t(TrKey::BtnDiscard)).rect().center();
+        let center = h
+            .get_by_label(Tr(Language::En).t(TrKey::BtnDiscard))
+            .rect()
+            .center();
         let button = |pressed: bool| egui::Event::PointerButton {
             pos: center,
             button: egui::PointerButton::Primary,
@@ -945,7 +1012,10 @@ mod tests {
                 "discard 遷移フレーム{i}で egui の id 不安定性警告（赤枠）が出た（#456 回帰）"
             );
         }
-        assert!(!h.state().has_changes(), "discard で dirty が解消しているはず");
+        assert!(
+            !h.state().has_changes(),
+            "discard で dirty が解消しているはず"
+        );
     }
 
     // ピン留めテスト（issue #438）: i18n テーブル駆動化のリファクタで `config_error_message` の
@@ -1043,8 +1113,14 @@ mod tests {
     #[test]
     fn config_error_message_window_width_too_small() {
         let err = ConfigError::WindowWidthTooSmall(150);
-        assert_eq!(config_error_message(&err, &tr_ja()), "150 は小さすぎます（200以上）");
-        assert_eq!(config_error_message(&err, &tr_en()), "150 is too small (min 200)");
+        assert_eq!(
+            config_error_message(&err, &tr_ja()),
+            "150 は小さすぎます（200以上）"
+        );
+        assert_eq!(
+            config_error_message(&err, &tr_en()),
+            "150 is too small (min 200)"
+        );
     }
 
     #[test]
@@ -1093,9 +1169,17 @@ mod tests {
 
     #[test]
     fn config_error_message_instant_command_duplicate_name() {
-        let err = ConfigError::InstantCommandDuplicateName { name: "g".to_string() };
-        assert_eq!(config_error_message(&err, &tr_ja()), "g はコマンド名が重複しています");
-        assert_eq!(config_error_message(&err, &tr_en()), "g has a duplicate command name");
+        let err = ConfigError::InstantCommandDuplicateName {
+            name: "g".to_string(),
+        };
+        assert_eq!(
+            config_error_message(&err, &tr_ja()),
+            "g はコマンド名が重複しています"
+        );
+        assert_eq!(
+            config_error_message(&err, &tr_en()),
+            "g has a duplicate command name"
+        );
     }
 
     #[test]

--- a/snotra-settings/src/font.rs
+++ b/snotra-settings/src/font.rs
@@ -262,7 +262,10 @@ mod tests {
     #[test]
     fn non_collection_rejects_nonzero_face() {
         // A single TTF (no "ttcf" tag) has only face 0.
-        assert!(!face_index_valid(b"\x00\x01\x00\x00 single-face ttf body", 1));
+        assert!(!face_index_valid(
+            b"\x00\x01\x00\x00 single-face ttf body",
+            1
+        ));
     }
 
     #[test]

--- a/snotra-settings/src/hotkey_input.rs
+++ b/snotra-settings/src/hotkey_input.rs
@@ -236,9 +236,11 @@ mod tests {
             .chain(('0'..='9').map(|ch| ch.to_string()))
             .chain((1..=12).map(|n| format!("F{n}")))
             .chain(
-                ["Space", "Enter", "Tab", "Home", "End", "PageUp", "PageDown", "Insert"]
-                    .into_iter()
-                    .map(str::to_string),
+                [
+                    "Space", "Enter", "Tab", "Home", "End", "PageUp", "PageDown", "Insert",
+                ]
+                .into_iter()
+                .map(str::to_string),
             )
             .collect();
         expected.sort();

--- a/snotra-settings/src/i18n.rs
+++ b/snotra-settings/src/i18n.rs
@@ -223,7 +223,9 @@ fn ja(key: TrKey) -> &'static str {
         TrKey::StatusValidationError => "検証エラー: ",
         TrKey::StatusSaveFailed => "保存失敗: ",
         // 読み込み失敗（finding C: 一時的 read 失敗で既定値表示中）の保存ガード
-        TrKey::ReadFailedBanner => "⚠ 設定ファイルを読み込めませんでした。既定値で表示しています。このまま保存すると既存の設定が失われる可能性があります。",
+        TrKey::ReadFailedBanner => {
+            "⚠ 設定ファイルを読み込めませんでした。既定値で表示しています。このまま保存すると既存の設定が失われる可能性があります。"
+        }
         TrKey::ReadFailedConfirm => "既存設定が失われる可能性を承知の上で保存する",
         TrKey::StatusReadFailedBlocked => "読み込み失敗中: 上のチェックを入れると保存できます",
         // Config error messages
@@ -237,7 +239,9 @@ fn ja(key: TrKey) -> &'static str {
         TrKey::ErrFuzzyCapRatioOutOfRange => "{value} は 0.0〜1.0 の範囲にしてください",
         TrKey::ErrScanPathEmpty => "{n}のパスが空です",
         TrKey::ErrInstantPrefixEmpty => "インスタントコマンドのプレフィックスが空です",
-        TrKey::ErrInstantPrefixSlash => "プレフィックスに / は使用できません（スラッシュコマンドと競合）",
+        TrKey::ErrInstantPrefixSlash => {
+            "プレフィックスに / は使用できません（スラッシュコマンドと競合）"
+        }
         TrKey::ErrInstantDuplicateName => "{name} はコマンド名が重複しています",
         TrKey::ErrInstantUnknownModifier => "{name}: 不明な修飾子「{modifier}」が含まれています",
         // General tab
@@ -336,14 +340,22 @@ fn ja(key: TrKey) -> &'static str {
         // Instant command tab
         TrKey::HeadingInstantPrefix => "プレフィックス",
         TrKey::LabelInstantPrefix => "プレフィックス:",
-        TrKey::HintInstantPrefix => "検索バーでこの文字を入力するとインスタントコマンドモードになります",
+        TrKey::HintInstantPrefix => {
+            "検索バーでこの文字を入力するとインスタントコマンドモードになります"
+        }
         TrKey::HeadingInstantCommands => "コマンド一覧",
-        TrKey::InstantDescription => "URL や実行ファイルを登録し、検索バーから即座に実行できます。{query} {clip} {date} {uuid} が変数として展開されます",
+        TrKey::InstantDescription => {
+            "URL や実行ファイルを登録し、検索バーから即座に実行できます。{query} {clip} {date} {uuid} が変数として展開されます"
+        }
         TrKey::LabelNoInstantCommands => "コマンドが登録されていません",
         TrKey::LabelInstantName => "名前:",
-        TrKey::HintInstantName => "プレフィックスの後に入力する文字列です（例: \"g\" と設定すると \"@g\" で呼び出し）",
+        TrKey::HintInstantName => {
+            "プレフィックスの後に入力する文字列です（例: \"g\" と設定すると \"@g\" で呼び出し）"
+        }
         TrKey::LabelInstantCommand => "コマンド:",
-        TrKey::HintInstantCommand => "{query} クエリ・{clip} クリップボード・{date:%Y-%m-%d} 日時・{uuid} を埋め込み。literal は {{ }}（{{date}}）。URL は自動エンコード",
+        TrKey::HintInstantCommand => {
+            "{query} クエリ・{clip} クリップボード・{date:%Y-%m-%d} 日時・{uuid} を埋め込み。literal は {{ }}（{{date}}）。URL は自動エンコード"
+        }
         TrKey::LabelInstantDescription => "説明（任意）:",
         TrKey::HintInstantDescription => "コマンドの用途を記述します。検索結果リストに表示されます",
         TrKey::LabelInstantPreview => "プレビュー:",
@@ -355,18 +367,26 @@ fn ja(key: TrKey) -> &'static str {
         TrKey::RadioInstantProgram => "プログラム（exe + 引数）",
         TrKey::LabelInstantExe => "実行ファイル (.exe)",
         TrKey::LabelInstantArgs => "引数",
-        TrKey::HintInstantProgram => ".exe のみ。スクリプトはインタプリタを実行ファイルに指定。{query} / {clip} / {date} / {uuid} と %VAR% が使えます。literal は {{ }}",
-        TrKey::HintInstantMigrate => "引数つきの可能性があります。プログラム種別へ作り直すと正しく起動します",
+        TrKey::HintInstantProgram => {
+            ".exe のみ。スクリプトはインタプリタを実行ファイルに指定。{query} / {clip} / {date} / {uuid} と %VAR% が使えます。literal は {{ }}"
+        }
+        TrKey::HintInstantMigrate => {
+            "引数つきの可能性があります。プログラム種別へ作り直すと正しく起動します"
+        }
         // Backup tab
         TrKey::TabBackup => "バックアップ",
         TrKey::HeadingExport => "エクスポート",
         TrKey::LabelExportDescription => "現在の設定ファイルを別の場所にコピーします。",
         TrKey::BtnExport => "設定をエクスポート…",
         TrKey::HeadingImport => "インポート",
-        TrKey::LabelImportDescription => "エクスポートした設定ファイルを読み込みます。現在の設定は上書きされます。",
+        TrKey::LabelImportDescription => {
+            "エクスポートした設定ファイルを読み込みます。現在の設定は上書きされます。"
+        }
         TrKey::BtnImport => "設定をインポート…",
         TrKey::HeadingDataFolder => "データフォルダ",
-        TrKey::LabelDataFolderDescription => "設定ファイルやキャッシュが保存されているフォルダを開きます。",
+        TrKey::LabelDataFolderDescription => {
+            "設定ファイルやキャッシュが保存されているフォルダを開きます。"
+        }
         TrKey::BtnOpenFolder => "設定フォルダを開く",
         TrKey::StatusExportSuccess => "エクスポートしました",
         TrKey::StatusExportFailed => "エクスポート失敗: ",
@@ -384,7 +404,9 @@ fn ja(key: TrKey) -> &'static str {
         TrKey::ErrMigemoMinCharsZero => "migemo 最小文字数は 1 以上である必要があります",
         TrKey::HeadingMigemo => "ローマ字検索（Migemo）",
         TrKey::CbMigemoEnabled => "ローマ字入力で日本語名ファイルを検索する",
-        TrKey::HintMigemo => "例: \"dokyu\" と入力すると \"ドキュメント\" がヒットします。漢字名は対象外",
+        TrKey::HintMigemo => {
+            "例: \"dokyu\" と入力すると \"ドキュメント\" がヒットします。漢字名は対象外"
+        }
         TrKey::LabelMigemoMinChars => "最小文字数:",
         TrKey::TooltipMigemoDisabled => "ローマ字検索（Migemo）を有効にすると設定できます",
         TrKey::TooltipFuzzyCapDisabled => "正規化を「Fuzzy 相対キャップ」にすると設定できます",
@@ -417,7 +439,9 @@ fn en(key: TrKey) -> &'static str {
         TrKey::StatusValidationError => "Validation error: ",
         TrKey::StatusSaveFailed => "Save failed: ",
         // 読み込み失敗（finding C: 一時的 read 失敗で既定値表示中）の保存ガード
-        TrKey::ReadFailedBanner => "⚠ Could not read the settings file. Showing defaults. Saving now may overwrite your existing settings.",
+        TrKey::ReadFailedBanner => {
+            "⚠ Could not read the settings file. Showing defaults. Saving now may overwrite your existing settings."
+        }
         TrKey::ReadFailedConfirm => "Save anyway (I understand existing settings may be lost)",
         TrKey::StatusReadFailedBlocked => "Load failed: check the box above to enable saving",
         // Config error messages
@@ -530,16 +554,26 @@ fn en(key: TrKey) -> &'static str {
         // Instant command tab
         TrKey::HeadingInstantPrefix => "Prefix",
         TrKey::LabelInstantPrefix => "Prefix:",
-        TrKey::HintInstantPrefix => "Type this character in the search bar to enter instant command mode",
+        TrKey::HintInstantPrefix => {
+            "Type this character in the search bar to enter instant command mode"
+        }
         TrKey::HeadingInstantCommands => "Commands",
-        TrKey::InstantDescription => "Register URLs or executables to run instantly from the search bar. {query}, {clip}, {date}, {uuid} are expanded as variables",
+        TrKey::InstantDescription => {
+            "Register URLs or executables to run instantly from the search bar. {query}, {clip}, {date}, {uuid} are expanded as variables"
+        }
         TrKey::LabelNoInstantCommands => "No commands registered",
         TrKey::LabelInstantName => "Name:",
-        TrKey::HintInstantName => "Text typed after the prefix to invoke this command (e.g. name \"g\" → type \"@g\")",
+        TrKey::HintInstantName => {
+            "Text typed after the prefix to invoke this command (e.g. name \"g\" → type \"@g\")"
+        }
         TrKey::LabelInstantCommand => "Command:",
-        TrKey::HintInstantCommand => "Embed {query}, {clip}, {date:%Y-%m-%d}, {uuid}; literal via {{ }}. URLs are auto-encoded",
+        TrKey::HintInstantCommand => {
+            "Embed {query}, {clip}, {date:%Y-%m-%d}, {uuid}; literal via {{ }}. URLs are auto-encoded"
+        }
         TrKey::LabelInstantDescription => "Description (optional):",
-        TrKey::HintInstantDescription => "Describe what this command does. Shown in the search results list",
+        TrKey::HintInstantDescription => {
+            "Describe what this command does. Shown in the search results list"
+        }
         TrKey::LabelInstantPreview => "Preview:",
         TrKey::BtnDuplicate => "Duplicate",
         TrKey::ModalAddInstant => "Add Command",
@@ -549,18 +583,26 @@ fn en(key: TrKey) -> &'static str {
         TrKey::RadioInstantProgram => "Program (exe + args)",
         TrKey::LabelInstantExe => "Executable (.exe)",
         TrKey::LabelInstantArgs => "Arguments",
-        TrKey::HintInstantProgram => ".exe only. For scripts, set the interpreter as the executable. {query} / {clip} / {date} / {uuid} and %VAR% are supported; literal via {{ }}",
-        TrKey::HintInstantMigrate => "This may contain arguments. Recreate it as a Program command to launch correctly",
+        TrKey::HintInstantProgram => {
+            ".exe only. For scripts, set the interpreter as the executable. {query} / {clip} / {date} / {uuid} and %VAR% are supported; literal via {{ }}"
+        }
+        TrKey::HintInstantMigrate => {
+            "This may contain arguments. Recreate it as a Program command to launch correctly"
+        }
         // Backup tab
         TrKey::TabBackup => "Backup",
         TrKey::HeadingExport => "Export",
         TrKey::LabelExportDescription => "Copy the current settings file to another location.",
         TrKey::BtnExport => "Export settings…",
         TrKey::HeadingImport => "Import",
-        TrKey::LabelImportDescription => "Load an exported settings file. Current settings will be overwritten.",
+        TrKey::LabelImportDescription => {
+            "Load an exported settings file. Current settings will be overwritten."
+        }
         TrKey::BtnImport => "Import settings…",
         TrKey::HeadingDataFolder => "Data folder",
-        TrKey::LabelDataFolderDescription => "Open the folder where settings and cache files are stored.",
+        TrKey::LabelDataFolderDescription => {
+            "Open the folder where settings and cache files are stored."
+        }
         TrKey::BtnOpenFolder => "Open settings folder",
         TrKey::StatusExportSuccess => "Exported",
         TrKey::StatusExportFailed => "Export failed: ",
@@ -578,10 +620,14 @@ fn en(key: TrKey) -> &'static str {
         TrKey::ErrMigemoMinCharsZero => "Migemo min chars must be at least 1",
         TrKey::HeadingMigemo => "Romaji Search (Migemo)",
         TrKey::CbMigemoEnabled => "Search Japanese filenames with romaji input",
-        TrKey::HintMigemo => "e.g. type \"dokyu\" to find \"ドキュメント\". Kanji names are not supported",
+        TrKey::HintMigemo => {
+            "e.g. type \"dokyu\" to find \"ドキュメント\". Kanji names are not supported"
+        }
         TrKey::LabelMigemoMinChars => "Min chars:",
         TrKey::TooltipMigemoDisabled => "Available when Romaji Search (Migemo) is enabled",
-        TrKey::TooltipFuzzyCapDisabled => "Available when normalization is set to Fuzzy relative cap",
+        TrKey::TooltipFuzzyCapDisabled => {
+            "Available when normalization is set to Fuzzy relative cap"
+        }
         TrKey::HeadingAutoUpdate => "Auto Update",
         TrKey::AutoUpdateFull => "Check and install",
         TrKey::AutoUpdateCheckOnly => "Check only (notify)",

--- a/snotra-settings/src/style.rs
+++ b/snotra-settings/src/style.rs
@@ -145,7 +145,9 @@ pub fn modal_header(ui: &mut egui::Ui, title: &str) {
 
 /// 破壊的操作のボタン（[`STATUS_ERROR`] 文字色）。削除ボタンの規範。
 pub fn danger_button(ui: &mut egui::Ui, text: &str) -> egui::Response {
-    ui.add(egui::Button::new(egui::RichText::new(text).color(STATUS_ERROR)))
+    ui.add(egui::Button::new(
+        egui::RichText::new(text).color(STATUS_ERROR),
+    ))
 }
 
 /// リスト行の規範スキャフォールド: 本文を左、アクションを右寄せ、末尾に区切り線。
@@ -182,10 +184,7 @@ pub enum ReorderDir {
 /// `can_up` / `can_down` は呼び出し側が算出する（端で disabled）。
 pub fn reorder_controls(ui: &mut egui::Ui, can_up: bool, can_down: bool) -> Option<ReorderDir> {
     let mut dir = None;
-    if ui
-        .add_enabled(can_down, egui::Button::new("▼"))
-        .clicked()
-    {
+    if ui.add_enabled(can_down, egui::Button::new("▼")).clicked() {
         dir = Some(ReorderDir::Down);
     }
     if ui.add_enabled(can_up, egui::Button::new("▲")).clicked() {

--- a/snotra-settings/src/tabs/backup.rs
+++ b/snotra-settings/src/tabs/backup.rs
@@ -75,7 +75,10 @@ pub fn ui(
         style::hint(ui, tr.t(TrKey::LabelExportDescription));
         ui.add_space(style::SPACE_GROUP);
         if ui
-            .add_enabled(!state.export_active, egui::Button::new(tr.t(TrKey::BtnExport)))
+            .add_enabled(
+                !state.export_active,
+                egui::Button::new(tr.t(TrKey::BtnExport)),
+            )
             .clicked()
         {
             state.message.clear();
@@ -89,7 +92,10 @@ pub fn ui(
         style::hint(ui, tr.t(TrKey::LabelImportDescription));
         ui.add_space(style::SPACE_GROUP);
         if ui
-            .add_enabled(!state.import_active, egui::Button::new(tr.t(TrKey::BtnImport)))
+            .add_enabled(
+                !state.import_active,
+                egui::Button::new(tr.t(TrKey::BtnImport)),
+            )
             .clicked()
         {
             state.message.clear();
@@ -235,11 +241,24 @@ fn handle_export_result(path: Option<PathBuf>, tr: &Tr) -> (Option<String>, bool
         return (None, false); // Cancelled
     };
     let Some(src) = Config::config_path() else {
-        return (Some(format!("{}config dir not found", tr.t(TrKey::StatusExportFailed))), true);
+        return (
+            Some(format!(
+                "{}config dir not found",
+                tr.t(TrKey::StatusExportFailed)
+            )),
+            true,
+        );
     };
     match std::fs::copy(&src, &dest) {
         Ok(_) => (Some(tr.t(TrKey::StatusExportSuccess).to_string()), false),
-        Err(e) => (Some(format!("{}{}", tr.t(TrKey::StatusExportFailed), first_line(&e.to_string()))), true),
+        Err(e) => (
+            Some(format!(
+                "{}{}",
+                tr.t(TrKey::StatusExportFailed),
+                first_line(&e.to_string())
+            )),
+            true,
+        ),
     }
 }
 
@@ -266,25 +285,61 @@ fn handle_import_result(path: Option<PathBuf>, tr: &Tr) -> (Option<String>, bool
     let content = match std::fs::read_to_string(&src) {
         Ok(c) => c,
         Err(e) => {
-            return (Some(format!("{}{}", tr.t(TrKey::StatusImportFailed), first_line(&e.to_string()))), true, None);
+            return (
+                Some(format!(
+                    "{}{}",
+                    tr.t(TrKey::StatusImportFailed),
+                    first_line(&e.to_string())
+                )),
+                true,
+                None,
+            );
         }
     };
     let config = match Config::from_toml_str(&content) {
         Ok(c) => c,
         Err(e) => {
-            return (Some(format!("{}{}", tr.t(TrKey::StatusImportFailed), localize_toml_error(&e, tr))), true, None);
+            return (
+                Some(format!(
+                    "{}{}",
+                    tr.t(TrKey::StatusImportFailed),
+                    localize_toml_error(&e, tr)
+                )),
+                true,
+                None,
+            );
         }
     };
     let config = match prepare_import_config(config) {
         Ok(config) => config,
         Err(error) => {
-            return (Some(format!("{}{}", tr.t(TrKey::StatusImportValidationError), config_error_message(&error, tr))), true, None);
+            return (
+                Some(format!(
+                    "{}{}",
+                    tr.t(TrKey::StatusImportValidationError),
+                    config_error_message(&error, tr)
+                )),
+                true,
+                None,
+            );
         }
     };
     if let Err(e) = config.save() {
-        return (Some(format!("{}{}", tr.t(TrKey::StatusImportFailed), first_line(&e))), true, None);
+        return (
+            Some(format!(
+                "{}{}",
+                tr.t(TrKey::StatusImportFailed),
+                first_line(&e)
+            )),
+            true,
+            None,
+        );
     }
-    (Some(tr.t(TrKey::StatusImportSuccess).to_string()), false, Some(config))
+    (
+        Some(tr.t(TrKey::StatusImportSuccess).to_string()),
+        false,
+        Some(config),
+    )
 }
 
 #[cfg(test)]
@@ -310,34 +365,74 @@ mod tests {
     fn localize_toml_error_ja_missing_field_extracts_name_and_line() {
         let msg = "TOML parse error at line 1, column 1\n  |\n1 | [search]\n  | ^\nmissing field `hotkey`";
         let out = localize_toml_error(msg, &tr_ja());
-        assert!(out.starts_with("行 1:"), "should start with line number: {}", out);
-        assert!(out.contains("\"hotkey\" が必要です"), "should contain field name: {}", out);
-        assert!(out.contains(msg), "should include original English: {}", out);
+        assert!(
+            out.starts_with("行 1:"),
+            "should start with line number: {}",
+            out
+        );
+        assert!(
+            out.contains("\"hotkey\" が必要です"),
+            "should contain field name: {}",
+            out
+        );
+        assert!(
+            out.contains(msg),
+            "should include original English: {}",
+            out
+        );
     }
 
     #[test]
     fn localize_toml_error_ja_invalid_type_with_line() {
         let msg = "TOML parse error at line 2, column 15\n  |\n2 | max_results = \"ten\"\n  |               ^^^^^\ninvalid type: string \"ten\", expected u32";
         let out = localize_toml_error(msg, &tr_ja());
-        assert!(out.starts_with("行 2:"), "should start with line number: {}", out);
-        assert!(out.contains("値の型が違います"), "should contain type error message: {}", out);
-        assert!(out.contains(msg), "should include original English: {}", out);
+        assert!(
+            out.starts_with("行 2:"),
+            "should start with line number: {}",
+            out
+        );
+        assert!(
+            out.contains("値の型が違います"),
+            "should contain type error message: {}",
+            out
+        );
+        assert!(
+            out.contains(msg),
+            "should include original English: {}",
+            out
+        );
     }
 
     #[test]
     fn localize_toml_error_ja_syntax_error_fallback() {
         let msg = "TOML parse error at line 5, column 3\n  |\n5 | key value\n  |   ^\nexpected '='";
         let out = localize_toml_error(msg, &tr_ja());
-        assert!(out.starts_with("行 5:"), "should start with line number: {}", out);
-        assert!(out.contains("構文エラー"), "should contain generic message: {}", out);
+        assert!(
+            out.starts_with("行 5:"),
+            "should start with line number: {}",
+            out
+        );
+        assert!(
+            out.contains("構文エラー"),
+            "should contain generic message: {}",
+            out
+        );
     }
 
     #[test]
     fn localize_toml_error_ja_no_line_number_falls_back_gracefully() {
         let msg = "some unknown error without line info";
         let out = localize_toml_error(msg, &tr_ja());
-        assert!(!out.starts_with("行"), "should not have line prefix: {}", out);
-        assert!(out.contains("構文エラー"), "should contain generic message: {}", out);
+        assert!(
+            !out.starts_with("行"),
+            "should not have line prefix: {}",
+            out
+        );
+        assert!(
+            out.contains("構文エラー"),
+            "should contain generic message: {}",
+            out
+        );
         assert!(out.contains(msg), "should include original: {}", out);
     }
 

--- a/snotra-settings/src/tabs/common.rs
+++ b/snotra-settings/src/tabs/common.rs
@@ -110,7 +110,11 @@ impl PickerState {
         if !self.active {
             return None;
         }
-        let taken = self.result.try_lock().ok().and_then(|mut guard| guard.take());
+        let taken = self
+            .result
+            .try_lock()
+            .ok()
+            .and_then(|mut guard| guard.take());
         if taken.is_some() {
             self.active = false;
         }
@@ -145,7 +149,9 @@ mod tests {
     }
 
     fn fields(s: &str) -> Fields {
-        Fields { text: s.to_string() }
+        Fields {
+            text: s.to_string(),
+        }
     }
 
     // 不変条件: open_create はフィールドを Default に初期化し editing を消す
@@ -246,7 +252,10 @@ mod tests {
     }
 
     fn active_picker() -> PickerState {
-        PickerState { active: true, ..Default::default() }
+        PickerState {
+            active: true,
+            ..Default::default()
+        }
     }
 
     #[test]
@@ -270,6 +279,9 @@ mod tests {
         let mut p = active_picker();
         *p.result.lock().unwrap() = Some(None);
         assert_eq!(p.poll(), Some(None));
-        assert!(!p.active, "キャンセルでも active を戻す（ボタン永久無効化の防止）");
+        assert!(
+            !p.active,
+            "キャンセルでも active を戻す（ボタン永久無効化の防止）"
+        );
     }
 }

--- a/snotra-settings/src/tabs/general.rs
+++ b/snotra-settings/src/tabs/general.rs
@@ -21,8 +21,16 @@ pub fn ui(ui: &mut egui::Ui, config: &mut Config, hotkey_state: &mut HotkeyInput
             egui::ComboBox::from_id_salt("language")
                 .selected_text(lang_label)
                 .show_ui(ui, |ui| {
-                    ui.selectable_value(&mut config.general.language, Language::Ja, tr.t(TrKey::LanguageJa));
-                    ui.selectable_value(&mut config.general.language, Language::En, tr.t(TrKey::LanguageEn));
+                    ui.selectable_value(
+                        &mut config.general.language,
+                        Language::Ja,
+                        tr.t(TrKey::LanguageJa),
+                    );
+                    ui.selectable_value(
+                        &mut config.general.language,
+                        Language::En,
+                        tr.t(TrKey::LanguageEn),
+                    );
                 });
             ui.end_row();
         });
@@ -38,15 +46,24 @@ pub fn ui(ui: &mut egui::Ui, config: &mut Config, hotkey_state: &mut HotkeyInput
             ui.end_row();
         });
 
-        ui.checkbox(&mut config.general.hotkey_toggle, tr.t(TrKey::CbHotkeyToggle));
+        ui.checkbox(
+            &mut config.general.hotkey_toggle,
+            tr.t(TrKey::CbHotkeyToggle),
+        );
 
         style::section_gap(ui);
 
         // -- Behavior --
         style::section_heading(ui, tr.t(TrKey::HeadingBehavior));
 
-        ui.checkbox(&mut config.general.show_on_startup, tr.t(TrKey::CbShowOnStartup));
-        ui.checkbox(&mut config.general.auto_hide_on_focus_lost, tr.t(TrKey::CbAutoHide));
+        ui.checkbox(
+            &mut config.general.show_on_startup,
+            tr.t(TrKey::CbShowOnStartup),
+        );
+        ui.checkbox(
+            &mut config.general.auto_hide_on_focus_lost,
+            tr.t(TrKey::CbAutoHide),
+        );
         ui.checkbox(&mut config.general.show_tray_icon, tr.t(TrKey::CbTrayIcon));
         ui.checkbox(&mut config.general.ime_off_on_show, tr.t(TrKey::CbImeOff));
         ui.checkbox(

--- a/snotra-settings/src/tabs/index.rs
+++ b/snotra-settings/src/tabs/index.rs
@@ -38,7 +38,13 @@ fn parse_extensions(raw: &str) -> Vec<String> {
         .collect()
 }
 
-pub fn ui(ui: &mut egui::Ui, ctx: &egui::Context, config: &mut Config, state: &mut IndexTabState, tr: &Tr) {
+pub fn ui(
+    ui: &mut egui::Ui,
+    ctx: &egui::Context,
+    config: &mut Config,
+    state: &mut IndexTabState,
+    tr: &Tr,
+) {
     // Poll picker result
     if let Some(Some(path)) = state.picker.poll() {
         state.modal.fields.path = path.display().to_string();
@@ -119,12 +125,17 @@ fn show_modal(ctx: &egui::Context, config: &mut Config, state: &mut IndexTabStat
         ui.horizontal(|ui| {
             ui.text_edit_singleline(&mut state.modal.fields.path);
             if ui
-                .add_enabled(!state.picker.active, egui::Button::new(tr.t(TrKey::BtnBrowse)))
+                .add_enabled(
+                    !state.picker.active,
+                    egui::Button::new(tr.t(TrKey::BtnBrowse)),
+                )
                 .clicked()
             {
                 let dialog_title = tr.t(TrKey::DialogSelectFolder).to_string();
                 state.picker.launch(ctx, move || {
-                    rfd::FileDialog::new().set_title(&dialog_title).pick_folder()
+                    rfd::FileDialog::new()
+                        .set_title(&dialog_title)
+                        .pick_folder()
                 });
             }
         });
@@ -134,7 +145,10 @@ fn show_modal(ctx: &egui::Context, config: &mut Config, state: &mut IndexTabStat
         ui.text_edit_singleline(&mut state.modal.fields.extensions);
 
         ui.add_space(style::SPACE_HINT);
-        ui.checkbox(&mut state.modal.fields.include_folders, tr.t(TrKey::CbIncludeFolders));
+        ui.checkbox(
+            &mut state.modal.fields.include_folders,
+            tr.t(TrKey::CbIncludeFolders),
+        );
 
         ui.add_space(style::SPACE_GROUP);
         ui.separator();

--- a/snotra-settings/src/tabs/instant.rs
+++ b/snotra-settings/src/tabs/instant.rs
@@ -99,7 +99,11 @@ pub fn ui(
             style::list_item(
                 ui,
                 |ui| {
-                    ui.label(if cmd.name.is_empty() { tr.t(TrKey::LabelNoName) } else { &cmd.name });
+                    ui.label(if cmd.name.is_empty() {
+                        tr.t(TrKey::LabelNoName)
+                    } else {
+                        &cmd.name
+                    });
                     if !cmd.description.is_empty() {
                         style::hint(ui, &cmd.description);
                     }
@@ -189,12 +193,7 @@ enum RowAction {
     MoveDown(usize),
 }
 
-fn show_modal(
-    ctx: &egui::Context,
-    config: &mut Config,
-    state: &mut InstantTabState,
-    tr: &Tr,
-) {
+fn show_modal(ctx: &egui::Context, config: &mut Config, state: &mut InstantTabState, tr: &Tr) {
     let title = if state.modal.is_edit() {
         tr.t(TrKey::ModalEditInstant)
     } else {
@@ -223,7 +222,11 @@ fn show_modal(
         // Kind
         ui.label(tr.t(TrKey::LabelInstantKind));
         ui.horizontal(|ui| {
-            ui.radio_value(&mut state.modal.fields.kind, EditKind::Url, tr.t(TrKey::RadioInstantUrl));
+            ui.radio_value(
+                &mut state.modal.fields.kind,
+                EditKind::Url,
+                tr.t(TrKey::RadioInstantUrl),
+            );
             ui.radio_value(
                 &mut state.modal.fields.kind,
                 EditKind::Program,
@@ -253,7 +256,10 @@ fn show_modal(
                 ui.horizontal(|ui| {
                     ui.text_edit_singleline(&mut state.modal.fields.exe);
                     if ui
-                        .add_enabled(!state.exe_picker.active, egui::Button::new(tr.t(TrKey::BtnBrowse)))
+                        .add_enabled(
+                            !state.exe_picker.active,
+                            egui::Button::new(tr.t(TrKey::BtnBrowse)),
+                        )
                         .clicked()
                     {
                         let dialog_title = tr.t(TrKey::DialogSelectExe).to_string();
@@ -316,7 +322,9 @@ fn show_modal(
 
 fn save_instant_command(config: &mut Config, modal: &ModalState<InstantFields>) {
     let action = match modal.fields.kind {
-        EditKind::Url => InstantAction::Url { url: modal.fields.url.clone() },
+        EditKind::Url => InstantAction::Url {
+            url: modal.fields.url.clone(),
+        },
         EditKind::Program => InstantAction::Exec {
             exe: modal.fields.exe.clone(),
             args: modal.fields.args.clone(),

--- a/snotra-settings/src/tabs/opener.rs
+++ b/snotra-settings/src/tabs/opener.rs
@@ -1,7 +1,9 @@
 //! オープナー設定タブ（ツール/ルール管理・プリセット検出/追加）。
 
 use eframe::egui;
-use snotra_core::config::{self, extract_path_condition, opener_specificity_order, Config, OpenerRule, OpenerTool};
+use snotra_core::config::{
+    self, Config, OpenerRule, OpenerTool, extract_path_condition, opener_specificity_order,
+};
 
 use crate::i18n::{Tr, TrKey};
 use crate::style;
@@ -47,7 +49,9 @@ impl OpenerFields {
     fn from_rule_tool(rule: &OpenerRule, tool: &OpenerTool) -> Self {
         let mut fields = Self {
             // パス条件の抽出
-            target_path: extract_path_condition(&rule.target).unwrap_or("").to_string(),
+            target_path: extract_path_condition(&rule.target)
+                .unwrap_or("")
+                .to_string(),
             tool_name: tool.name.clone(),
             tool_exe: tool.exe.clone(),
             tool_args: tool.args.clone(),
@@ -63,7 +67,13 @@ impl OpenerFields {
     }
 }
 
-pub fn ui(ui: &mut egui::Ui, ctx: &egui::Context, config: &mut Config, state: &mut OpenerTabState, tr: &Tr) {
+pub fn ui(
+    ui: &mut egui::Ui,
+    ctx: &egui::Context,
+    config: &mut Config,
+    state: &mut OpenerTabState,
+    tr: &Tr,
+) {
     // Poll exe picker result
     if let Some(Some(path)) = state.exe_picker.poll() {
         state.modal.fields.tool_exe = path.display().to_string();
@@ -145,7 +155,10 @@ pub fn ui(ui: &mut egui::Ui, ctx: &egui::Context, config: &mut Config, state: &m
                     ui.label(preset.name);
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         if already_added {
-                            ui.add_enabled(false, egui::Button::new(tr.t(TrKey::LabelAlreadyAdded)));
+                            ui.add_enabled(
+                                false,
+                                egui::Button::new(tr.t(TrKey::LabelAlreadyAdded)),
+                            );
                         } else if ui.button(tr.t(TrKey::BtnAddPreset)).clicked() {
                             preset_action = Some(i);
                         }
@@ -229,8 +242,16 @@ fn show_modal(ctx: &egui::Context, config: &mut Config, state: &mut OpenerTabSta
                 TargetKind::Extension => tr.t(TrKey::TargetKindExtension),
             })
             .show_ui(ui, |ui| {
-                ui.selectable_value(&mut state.modal.fields.target_kind, TargetKind::Folder, tr.t(TrKey::TargetKindFolder));
-                ui.selectable_value(&mut state.modal.fields.target_kind, TargetKind::Extension, tr.t(TrKey::TargetKindExtension));
+                ui.selectable_value(
+                    &mut state.modal.fields.target_kind,
+                    TargetKind::Folder,
+                    tr.t(TrKey::TargetKindFolder),
+                );
+                ui.selectable_value(
+                    &mut state.modal.fields.target_kind,
+                    TargetKind::Extension,
+                    tr.t(TrKey::TargetKindExtension),
+                );
             });
 
         if state.modal.fields.target_kind == TargetKind::Extension {
@@ -259,7 +280,10 @@ fn show_modal(ctx: &egui::Context, config: &mut Config, state: &mut OpenerTabSta
         ui.horizontal(|ui| {
             ui.text_edit_singleline(&mut state.modal.fields.tool_exe);
             if ui
-                .add_enabled(!state.exe_picker.active, egui::Button::new(tr.t(TrKey::BtnBrowse)))
+                .add_enabled(
+                    !state.exe_picker.active,
+                    egui::Button::new(tr.t(TrKey::BtnBrowse)),
+                )
                 .clicked()
             {
                 let dialog_title = tr.t(TrKey::DialogSelectExe).to_string();

--- a/snotra-settings/src/tabs/search.rs
+++ b/snotra-settings/src/tabs/search.rs
@@ -25,13 +25,19 @@ pub fn ui(ui: &mut egui::Ui, config: &mut Config, tr: &Tr) {
 
         // -- Visibility --
         style::section_heading(ui, tr.t(TrKey::HeadingVisibility));
-        ui.checkbox(&mut config.search.show_hidden_system, tr.t(TrKey::CbShowHiddenSystem));
+        ui.checkbox(
+            &mut config.search.show_hidden_system,
+            tr.t(TrKey::CbShowHiddenSystem),
+        );
 
         style::section_gap(ui);
 
         // -- PATH executables --
         style::section_heading(ui, tr.t(TrKey::HeadingPathEnv));
-        ui.checkbox(&mut config.search.include_path_env, tr.t(TrKey::CbIncludePathEnv));
+        ui.checkbox(
+            &mut config.search.include_path_env,
+            tr.t(TrKey::CbIncludePathEnv),
+        );
 
         style::section_gap(ui);
 
@@ -43,16 +49,26 @@ pub fn ui(ui: &mut egui::Ui, config: &mut Config, tr: &Tr) {
             let result_limit_default = config.search.effective_result_limit();
             ui.add_sized(
                 [style::FIELD_NUMERIC, ui.spacing().interact_size.y],
-                egui::DragValue::new(config.search.result_limit.get_or_insert(result_limit_default))
-                    .range(10..=1000),
+                egui::DragValue::new(
+                    config
+                        .search
+                        .result_limit
+                        .get_or_insert(result_limit_default),
+                )
+                .range(10..=1000),
             );
             ui.end_row();
             ui.label(tr.t(TrKey::LabelRecentLimit));
             let recent_limit_default = config.search.effective_recent_limit();
             ui.add_sized(
                 [style::FIELD_NUMERIC, ui.spacing().interact_size.y],
-                egui::DragValue::new(config.search.recent_limit.get_or_insert(recent_limit_default))
-                    .range(1..=50),
+                egui::DragValue::new(
+                    config
+                        .search
+                        .recent_limit
+                        .get_or_insert(recent_limit_default),
+                )
+                .range(1..=50),
             );
             ui.end_row();
         });
@@ -89,7 +105,10 @@ pub fn ui(ui: &mut egui::Ui, config: &mut Config, tr: &Tr) {
         // -- Migemo 検索 --
         style::section_heading(ui, tr.t(TrKey::HeadingMigemo));
 
-        ui.checkbox(&mut config.search.migemo_enabled, tr.t(TrKey::CbMigemoEnabled));
+        ui.checkbox(
+            &mut config.search.migemo_enabled,
+            tr.t(TrKey::CbMigemoEnabled),
+        );
         style::hint(ui, tr.t(TrKey::HintMigemo));
 
         ui.add_space(style::SPACE_HINT);
@@ -118,8 +137,16 @@ fn search_mode_combo(ui: &mut egui::Ui, id: &str, mode: &mut SearchModeConfig, t
     egui::ComboBox::from_id_salt(id)
         .selected_text(label)
         .show_ui(ui, |ui| {
-            ui.selectable_value(mode, SearchModeConfig::Prefix, tr.t(TrKey::SearchModePrefix));
-            ui.selectable_value(mode, SearchModeConfig::Substring, tr.t(TrKey::SearchModeSubstring));
+            ui.selectable_value(
+                mode,
+                SearchModeConfig::Prefix,
+                tr.t(TrKey::SearchModePrefix),
+            );
+            ui.selectable_value(
+                mode,
+                SearchModeConfig::Substring,
+                tr.t(TrKey::SearchModeSubstring),
+            );
             ui.selectable_value(mode, SearchModeConfig::Fuzzy, tr.t(TrKey::SearchModeFuzzy));
         });
 }
@@ -131,12 +158,18 @@ fn history_normalization_combo(
 ) {
     let label = match norm {
         SearchHistoryNormalizationConfig::Disabled => tr.t(TrKey::NormalizationDisabled),
-        SearchHistoryNormalizationConfig::FuzzyRelativeCap => tr.t(TrKey::NormalizationFuzzyRelativeCap),
+        SearchHistoryNormalizationConfig::FuzzyRelativeCap => {
+            tr.t(TrKey::NormalizationFuzzyRelativeCap)
+        }
     };
     egui::ComboBox::from_id_salt("history_normalization")
         .selected_text(label)
         .show_ui(ui, |ui| {
-            ui.selectable_value(norm, SearchHistoryNormalizationConfig::Disabled, tr.t(TrKey::NormalizationDisabled));
+            ui.selectable_value(
+                norm,
+                SearchHistoryNormalizationConfig::Disabled,
+                tr.t(TrKey::NormalizationDisabled),
+            );
             ui.selectable_value(
                 norm,
                 SearchHistoryNormalizationConfig::FuzzyRelativeCap,

--- a/snotra-settings/src/tabs/visual.rs
+++ b/snotra-settings/src/tabs/visual.rs
@@ -74,8 +74,8 @@ pub fn ui(ui: &mut egui::Ui, config: &mut Config, fonts: &[String], tr: &Tr) {
 
             // Custom theme card
             if let Some(ct) = &config.visual.custom_theme {
-                let is_active = config.visual.preset == ThemePreset::Custom
-                    && custom_theme_matches(config, ct);
+                let is_active =
+                    config.visual.preset == ThemePreset::Custom && custom_theme_matches(config, ct);
                 let ct_clone = ct.clone();
                 let response = custom_theme_card(ui, &ct_clone, is_active, tr);
                 if response.clicked() {
@@ -108,11 +108,31 @@ pub fn ui(ui: &mut egui::Ui, config: &mut Config, fonts: &[String], tr: &Tr) {
         style::section_heading(ui, tr.t(TrKey::HeadingColor));
 
         style::settings_grid("color_grid").show(ui, |ui| {
-            color_row(ui, tr.t(TrKey::LabelBgColor), &mut config.visual.background_color);
-            color_row(ui, tr.t(TrKey::LabelInputBg), &mut config.visual.input_background_color);
-            color_row(ui, tr.t(TrKey::LabelTextColor), &mut config.visual.text_color);
-            color_row(ui, tr.t(TrKey::LabelSelectedRow), &mut config.visual.selected_row_color);
-            color_row(ui, tr.t(TrKey::LabelHintText), &mut config.visual.hint_text_color);
+            color_row(
+                ui,
+                tr.t(TrKey::LabelBgColor),
+                &mut config.visual.background_color,
+            );
+            color_row(
+                ui,
+                tr.t(TrKey::LabelInputBg),
+                &mut config.visual.input_background_color,
+            );
+            color_row(
+                ui,
+                tr.t(TrKey::LabelTextColor),
+                &mut config.visual.text_color,
+            );
+            color_row(
+                ui,
+                tr.t(TrKey::LabelSelectedRow),
+                &mut config.visual.selected_row_color,
+            );
+            color_row(
+                ui,
+                tr.t(TrKey::LabelHintText),
+                &mut config.visual.hint_text_color,
+            );
         });
 
         style::section_gap(ui);
@@ -149,8 +169,13 @@ pub fn ui(ui: &mut egui::Ui, config: &mut Config, fonts: &[String], tr: &Tr) {
             let visible_default = config.appearance.effective_visible_rows();
             ui.add_sized(
                 [style::FIELD_NUMERIC, ui.spacing().interact_size.y],
-                egui::DragValue::new(config.appearance.visible_rows.get_or_insert(visible_default))
-                    .range(1..=50),
+                egui::DragValue::new(
+                    config
+                        .appearance
+                        .visible_rows
+                        .get_or_insert(visible_default),
+                )
+                .range(1..=50),
             );
             ui.end_row();
 
@@ -275,10 +300,8 @@ fn theme_card(ui: &mut egui::Ui, label: &str, colors: &[&str; 5], active: bool) 
     let card_width = total_width + 8.0; // padding
     let card_height = SWATCH_SIZE + 24.0; // swatch + label
 
-    let (rect, response) = ui.allocate_exact_size(
-        egui::vec2(card_width, card_height),
-        egui::Sense::click(),
-    );
+    let (rect, response) =
+        ui.allocate_exact_size(egui::vec2(card_width, card_height), egui::Sense::click());
 
     if ui.is_rect_visible(rect) {
         let painter = ui.painter();
@@ -298,10 +321,17 @@ fn theme_card(ui: &mut egui::Ui, label: &str, colors: &[&str; 5], active: bool) 
         for (i, hex) in colors.iter().enumerate() {
             let color = Color32::from_hex(hex).unwrap_or(Color32::BLACK);
             let x = rect.min.x + 4.0 + i as f32 * (SWATCH_SIZE + 4.0);
-            let swatch_rect =
-                egui::Rect::from_min_size(egui::pos2(x, swatch_y), egui::vec2(SWATCH_SIZE, SWATCH_SIZE));
+            let swatch_rect = egui::Rect::from_min_size(
+                egui::pos2(x, swatch_y),
+                egui::vec2(SWATCH_SIZE, SWATCH_SIZE),
+            );
             painter.rect_filled(swatch_rect, 2.0, color);
-            painter.rect_stroke(swatch_rect, 2.0, (1.0, Color32::GRAY), egui::StrokeKind::Outside);
+            painter.rect_stroke(
+                swatch_rect,
+                2.0,
+                (1.0, Color32::GRAY),
+                egui::StrokeKind::Outside,
+            );
         }
 
         // Label
@@ -372,12 +402,20 @@ mod tests {
                 "{name} を変えても一致してしまう——preset_matches がその色を見ていない"
             );
         };
-        drifts("background_color", |c| c.visual.background_color = "#123456".to_string());
+        drifts("background_color", |c| {
+            c.visual.background_color = "#123456".to_string()
+        });
         drifts("input_background_color", |c| {
             c.visual.input_background_color = "#123456".to_string()
         });
-        drifts("text_color", |c| c.visual.text_color = "#123456".to_string());
-        drifts("selected_row_color", |c| c.visual.selected_row_color = "#123456".to_string());
-        drifts("hint_text_color", |c| c.visual.hint_text_color = "#123456".to_string());
+        drifts("text_color", |c| {
+            c.visual.text_color = "#123456".to_string()
+        });
+        drifts("selected_row_color", |c| {
+            c.visual.selected_row_color = "#123456".to_string()
+        });
+        drifts("hint_text_color", |c| {
+            c.visual.hint_text_color = "#123456".to_string()
+        });
     }
 }

--- a/src-tauri/src/commands/icon.rs
+++ b/src-tauri/src/commands/icon.rs
@@ -1,7 +1,7 @@
 use rayon::prelude::*;
 use tauri::State;
 
-use crate::icon::{extract_png, IconCache, IconCacheState, IconFailure};
+use crate::icon::{IconCache, IconCacheState, IconFailure, extract_png};
 use crate::state::AppState;
 
 pub(crate) fn ensure_icon_cache_loaded_if_enabled(

--- a/src-tauri/src/commands/launch.rs
+++ b/src-tauri/src/commands/launch.rs
@@ -1,4 +1,4 @@
-use snotra_core::config::{find_matching_tools, InstantAction, InstantCommand};
+use snotra_core::config::{InstantAction, InstantCommand, find_matching_tools};
 use snotra_core::instant::{expand_exec_args, split_args};
 use std::process::Stdio;
 
@@ -124,7 +124,12 @@ pub fn launch_item_with_state(path: &str, query: &str, state: &AppState) -> Laun
 }
 
 /// トレイ履歴のツール選択後の起動（同期版）。
-pub fn launch_with_tool_with_state(path: &str, exe: &str, args: &str, state: &AppState) -> LaunchResult {
+pub fn launch_with_tool_with_state(
+    path: &str,
+    exe: &str,
+    args: &str,
+    state: &AppState,
+) -> LaunchResult {
     // launch_with_tool_core does NOT use ShellExecuteW; COM STA は不要
     let result = launch_with_tool_core(path, exe, args);
     if result.is_ok() {
@@ -148,7 +153,10 @@ pub fn resolve_all_openers(path: &str, state: &AppState) -> Vec<(String, String,
     let is_folder = std::path::Path::new(path).is_dir();
     let engine = state.engine.lock().unwrap();
     let tools = find_matching_tools(path, is_folder, &engine.config().openers);
-    tools.iter().map(|t| (t.name.clone(), t.exe.clone(), t.args.clone())).collect()
+    tools
+        .iter()
+        .map(|t| (t.name.clone(), t.exe.clone(), t.args.clone()))
+        .collect()
 }
 
 fn shell_execute_error_message(code: i32) -> &'static str {
@@ -225,11 +233,19 @@ impl From<&InstantCommand> for InstantCommandDto {
         let display = match &c.action {
             InstantAction::Url { url } => url.clone(),
             InstantAction::Exec { exe, args } => {
-                if args.is_empty() { exe.clone() } else { format!("{exe} {args}") }
+                if args.is_empty() {
+                    exe.clone()
+                } else {
+                    format!("{exe} {args}")
+                }
             }
             InstantAction::Legacy { command } => command.clone(),
         };
-        Self { name: c.name.clone(), description: c.description.clone(), display }
+        Self {
+            name: c.name.clone(),
+            description: c.description.clone(),
+            display,
+        }
     }
 }
 
@@ -242,10 +258,14 @@ pub(crate) fn expand_env(input: &str) -> String {
         let src = HSTRING::from(input);
         unsafe {
             let needed = ExpandEnvironmentStringsW(&src, None);
-            if needed == 0 { return input.to_string(); }
+            if needed == 0 {
+                return input.to_string();
+            }
             let mut buf = vec![0u16; needed as usize];
             let written = ExpandEnvironmentStringsW(&src, Some(&mut buf));
-            if written == 0 { return input.to_string(); }
+            if written == 0 {
+                return input.to_string();
+            }
             // 末尾 NUL を除いて UTF-16 → String
             let len = (written as usize).saturating_sub(1).min(buf.len());
             String::from_utf16_lossy(&buf[..len])
@@ -258,13 +278,20 @@ pub(crate) fn expand_env(input: &str) -> String {
 }
 
 /// exec 種別の起動。COM 不要（CreateProcessW 直叩き）。コンソール窓抑止。
-pub(crate) fn launch_exec_core(exe: &str, args: &str, query: &str, clipboard: &str) -> LaunchResult {
+pub(crate) fn launch_exec_core(
+    exe: &str,
+    args: &str,
+    query: &str,
+    clipboard: &str,
+) -> LaunchResult {
     let exe_expanded = expand_env(exe);
     let arg_tokens = expand_exec_args(args, query, clipboard, expand_env);
 
     let mut cmd = std::process::Command::new(&exe_expanded);
     cmd.args(&arg_tokens);
-    cmd.stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null());
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
@@ -278,26 +305,46 @@ pub(crate) fn launch_exec_core(exe: &str, args: &str, query: &str, clipboard: &s
 
 #[cfg(test)]
 mod tests {
-    use super::build_launch_args;
     use super::InstantCommandDto;
+    use super::build_launch_args;
     use snotra_core::config::{InstantAction, InstantCommand};
 
     #[test]
     fn instant_dto_display_url() {
-        let c = InstantCommand { name: "g".into(), description: "d".into(),
-            action: InstantAction::Url { url: "https://x".into() } };
+        let c = InstantCommand {
+            name: "g".into(),
+            description: "d".into(),
+            action: InstantAction::Url {
+                url: "https://x".into(),
+            },
+        };
         assert_eq!(InstantCommandDto::from(&c).display, "https://x");
     }
     #[test]
     fn instant_dto_display_exec_with_args() {
-        let c = InstantCommand { name: "ev".into(), description: String::new(),
-            action: InstantAction::Exec { exe: "everything.exe".into(), args: "-s {query}".into() } };
-        assert_eq!(InstantCommandDto::from(&c).display, "everything.exe -s {query}");
+        let c = InstantCommand {
+            name: "ev".into(),
+            description: String::new(),
+            action: InstantAction::Exec {
+                exe: "everything.exe".into(),
+                args: "-s {query}".into(),
+            },
+        };
+        assert_eq!(
+            InstantCommandDto::from(&c).display,
+            "everything.exe -s {query}"
+        );
     }
     #[test]
     fn instant_dto_display_exec_no_args_has_no_trailing_space() {
-        let c = InstantCommand { name: "n".into(), description: String::new(),
-            action: InstantAction::Exec { exe: "notepad.exe".into(), args: String::new() } };
+        let c = InstantCommand {
+            name: "n".into(),
+            description: String::new(),
+            action: InstantAction::Exec {
+                exe: "notepad.exe".into(),
+                args: String::new(),
+            },
+        };
         assert_eq!(InstantCommandDto::from(&c).display, "notepad.exe");
     }
 

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -36,12 +36,16 @@ mod tests {
     use snotra_core::config::Config;
     use snotra_core::engine::Engine;
     use snotra_core::history::HistoryStore;
-    use std::sync::atomic::{AtomicBool, AtomicU64};
     use std::sync::Mutex;
+    use std::sync::atomic::{AtomicBool, AtomicU64};
 
     fn test_state(indexing: bool) -> AppState {
         AppState {
-            engine: Mutex::new(Engine::new(Vec::new(), HistoryStore::load(), Config::default())),
+            engine: Mutex::new(Engine::new(
+                Vec::new(),
+                HistoryStore::load(),
+                Config::default(),
+            )),
             indexing: AtomicBool::new(indexing),
             index_build_started: AtomicBool::new(false),
             main_visible: AtomicBool::new(false),

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -1,6 +1,6 @@
 use std::process::{Child, Command};
-use std::sync::atomic::Ordering;
 use std::sync::Mutex;
+use std::sync::atomic::Ordering;
 
 use serde_json::json;
 use tauri::{AppHandle, Manager, State};
@@ -69,7 +69,10 @@ pub(crate) fn launch_settings_process(app: &AppHandle, extra_args: &[&str]) -> R
     let settings_exe = exe_dir.join("snotra-settings.exe");
 
     if !settings_exe.exists() {
-        let msg = format!("snotra-settings.exe not found at {}", settings_exe.display());
+        let msg = format!(
+            "snotra-settings.exe not found at {}",
+            settings_exe.display()
+        );
         trace_command(
             "cmd:launch_settings_process:not_found",
             json!({ "path": settings_exe.display().to_string() }),
@@ -112,7 +115,9 @@ pub(crate) fn launch_settings_process(app: &AppHandle, extra_args: &[&str]) -> R
         loop {
             std::thread::sleep(std::time::Duration::from_millis(250));
             let Some(proc_state) = handle_for_monitor.try_state::<SettingsProcessState>() else {
-                eprintln!("[settings-monitor] SettingsProcessState not managed; exiting monitor thread");
+                eprintln!(
+                    "[settings-monitor] SettingsProcessState not managed; exiting monitor thread"
+                );
                 break;
             };
             let mut guard = proc_state.lock().unwrap();
@@ -144,9 +149,7 @@ pub(crate) fn launch_settings_process(app: &AppHandle, extra_args: &[&str]) -> R
         if let Some(main) = handle_for_monitor.get_window("main") {
             let _ = main.set_always_on_top(true);
         }
-        if let Some(results) =
-            handle_for_monitor.try_state::<crate::egui_shell::ResultsWindow>()
-        {
+        if let Some(results) = handle_for_monitor.try_state::<crate::egui_shell::ResultsWindow>() {
             results.set_topmost(true);
         }
 
@@ -171,4 +174,3 @@ pub fn open_settings(state: State<AppState>, app: AppHandle) -> Result<(), Strin
 
     launch_settings_process(&app, &[])
 }
-

--- a/src-tauri/src/config_watcher.rs
+++ b/src-tauri/src/config_watcher.rs
@@ -56,7 +56,9 @@ pub fn start(app_handle: &AppHandle) -> Option<notify::RecommendedWatcher> {
     .ok()?;
 
     // Watch the directory (not the file) because atomic write creates a new file
-    watcher.watch(config_dir, RecursiveMode::NonRecursive).ok()?;
+    watcher
+        .watch(config_dir, RecursiveMode::NonRecursive)
+        .ok()?;
 
     Some(watcher)
 }
@@ -217,7 +219,9 @@ mod tests {
         // 正常読込・first-run・破損復旧（#343 の意図的 default 適用）は適用する。
         assert!(should_apply_config_change(LoadOutcome::Loaded));
         assert!(should_apply_config_change(LoadOutcome::FirstRun));
-        assert!(should_apply_config_change(LoadOutcome::RecoveredFromCorrupt));
+        assert!(should_apply_config_change(
+            LoadOutcome::RecoveredFromCorrupt
+        ));
     }
 
     #[test]
@@ -266,7 +270,11 @@ mod tests {
         };
         let sleep = || sleeps.set(sleeps.get() + 1);
         let (_c, outcome) = load_with_read_failed_retry(load, sleep, 3);
-        assert_eq!(outcome, LoadOutcome::Loaded, "予算内でロック解除→成功結果を採用");
+        assert_eq!(
+            outcome,
+            LoadOutcome::Loaded,
+            "予算内でロック解除→成功結果を採用"
+        );
         assert_eq!(calls.get(), 3, "2 回 ReadFailed の後 3 回目で成功");
         assert_eq!(sleeps.get(), 2, "再試行ごとに backoff");
     }

--- a/src-tauri/src/egui_shell/font_stack.rs
+++ b/src-tauri/src/egui_shell/font_stack.rs
@@ -24,10 +24,8 @@ static JP_FONT_BYTES: OnceLock<Box<[u8]>> = OnceLock::new();
 /// 判定は「厳しすぎて jp_font を残す」方向へ倒す（安全側）。
 const CJK_PROBE: &[char] = &[
     // かな（必須）
-    'あ', 'ん', 'ア', 'ヴ', 'ー',
-    // JIS 第1水準（常用寄り）
-    '日', '本', '語', '漢', '字', '検', '索',
-    // JIS 第2水準・互換漢字
+    'あ', 'ん', 'ア', 'ヴ', 'ー', // JIS 第1水準（常用寄り）
+    '日', '本', '語', '漢', '字', '検', '索', // JIS 第2水準・互換漢字
     '彁', '﨑', '槇', '遙', '瑤', '兪',
 ];
 
@@ -88,7 +86,11 @@ fn font_definitions(
             if has_jp {
                 for family in [egui::FontFamily::Proportional, egui::FontFamily::Monospace] {
                     // 解決失敗時は jp_font 単一・先頭（#579: push=末尾だとベースラインずれ再発）。
-                    fonts.families.entry(family).or_default().insert(0, "jp_font".to_owned());
+                    fonts
+                        .families
+                        .entry(family)
+                        .or_default()
+                        .insert(0, "jp_font".to_owned());
                 }
             }
         }
@@ -140,10 +142,9 @@ fn resolve_font_family(name: &str) -> Option<(&'static [u8], u32)> {
         style: fontdb::Style::Normal,
     };
     let id = db.query(&query)?;
-    let resolved: (&'static [u8], u32) =
-        db.with_face_data(id, |data, face_index| {
-            (&*Box::leak(data.to_vec().into_boxed_slice()), face_index)
-        })?;
+    let resolved: (&'static [u8], u32) = db.with_face_data(id, |data, face_index| {
+        (&*Box::leak(data.to_vec().into_boxed_slice()), face_index)
+    })?;
     map.insert(name.to_owned(), resolved);
     Some(resolved)
 }
@@ -215,8 +216,11 @@ mod tests {
         let fonts = font_definitions(Some(dummy), None);
         for family in [egui::FontFamily::Proportional, egui::FontFamily::Monospace] {
             let list = fonts.families.get(&family).expect("family present");
-            assert_eq!(list.first().map(String::as_str), Some("jp_font"),
-                "解決失敗時は jp_font 単一・先頭（#579 再発防止）");
+            assert_eq!(
+                list.first().map(String::as_str),
+                Some("jp_font"),
+                "解決失敗時は jp_font 単一・先頭（#579 再発防止）"
+            );
         }
     }
 
@@ -229,10 +233,16 @@ mod tests {
         let fonts = font_definitions(Some(dummy), Some((user, 0)));
         for family in [egui::FontFamily::Proportional, egui::FontFamily::Monospace] {
             let list = fonts.families.get(&family).expect("family present");
-            assert_eq!(list.first().map(String::as_str), Some("user_font"),
-                "honor 時は user_font 先頭（font_family 優先）");
-            assert_eq!(list.get(1).map(String::as_str), Some("jp_font"),
-                "honor 時も jp_font は fallback として残す（CJK をカバー）");
+            assert_eq!(
+                list.first().map(String::as_str),
+                Some("user_font"),
+                "honor 時は user_font 先頭（font_family 優先）"
+            );
+            assert_eq!(
+                list.get(1).map(String::as_str),
+                Some("jp_font"),
+                "honor 時も jp_font は fallback として残す（CJK をカバー）"
+            );
         }
     }
 
@@ -242,14 +252,21 @@ mod tests {
         // font_data に残ると egui が eager parse してメモリを食うため、両方を検査する。
         let user: &'static [u8] = &[0u8; 4];
         let fonts = font_definitions(None, Some((user, 0)));
-        assert!(!fonts.font_data.contains_key("jp_font"),
-            "カバー済みなら jp_font のバイト列自体を積まない（削減の実体）");
+        assert!(
+            !fonts.font_data.contains_key("jp_font"),
+            "カバー済みなら jp_font のバイト列自体を積まない（削減の実体）"
+        );
         for family in [egui::FontFamily::Proportional, egui::FontFamily::Monospace] {
             let list = fonts.families.get(&family).expect("family present");
-            assert_eq!(list.first().map(String::as_str), Some("user_font"),
-                "カバー済みでも user_font 先頭（#579 のベースラインずれ防止）");
-            assert!(!list.iter().any(|n| n == "jp_font"),
-                "カバー済みなら jp_font をスタックに残さない");
+            assert_eq!(
+                list.first().map(String::as_str),
+                Some("user_font"),
+                "カバー済みでも user_font 先頭（#579 のベースラインずれ防止）"
+            );
+            assert!(
+                !list.iter().any(|n| n == "jp_font"),
+                "カバー済みなら jp_font をスタックに残さない"
+            );
         }
     }
 
@@ -266,8 +283,10 @@ mod tests {
         let fonts = font_definitions(Some(jp), Some((user, 0)));
         for key in ["jp_font", "user_font"] {
             let data = fonts.font_data.get(key).expect("font registered");
-            assert!(matches!(data.font, Cow::Borrowed(_)),
-                "{key} が Cow::Owned で積まれている（from_owned だと epaint が全体を複製し常駐が 2 倍になる）");
+            assert!(
+                matches!(data.font, Cow::Borrowed(_)),
+                "{key} が Cow::Owned で積まれている（from_owned だと epaint が全体を複製し常駐が 2 倍になる）"
+            );
         }
     }
 
@@ -284,11 +303,16 @@ mod tests {
         let defaults = egui::FontDefinitions::default();
         let mut checked = 0usize;
         for (name, data) in &defaults.font_data {
-            assert!(!super::font_covers_cjk(&data.font, data.index),
-                "egui 同梱フォント {name} が CJK をカバーすると誤判定された（判定が緩すぎる）");
+            assert!(
+                !super::font_covers_cjk(&data.font, data.index),
+                "egui 同梱フォント {name} が CJK をカバーすると誤判定された（判定が緩すぎる）"
+            );
             checked += 1;
         }
-        assert!(checked > 0, "egui 既定フォントが 0 件では negative を検査できていない");
+        assert!(
+            checked > 0,
+            "egui 既定フォントが 0 件では negative を検査できていない"
+        );
     }
 
     #[test]
@@ -300,7 +324,9 @@ mod tests {
             eprintln!("skip: YuGothM.ttc が無いため positive 検査を実施していない");
             return;
         };
-        assert!(super::font_covers_cjk(&bytes, 0),
-            "和文フォント YuGothM が CJK をカバーしないと判定された（判定が厳しすぎる）");
+        assert!(
+            super::font_covers_cjk(&bytes, 0),
+            "和文フォント YuGothM が CJK をカバーしないと判定された（判定が厳しすぎる）"
+        );
     }
 }

--- a/src-tauri/src/egui_shell/icon_textures.rs
+++ b/src-tauri/src/egui_shell/icon_textures.rs
@@ -88,8 +88,14 @@ mod tests {
         }
         let img = super::png_to_color_image(&png_buf).expect("decode");
         assert_eq!(img.size, [2, 2]);
-        assert_eq!(img.pixels[0], egui::Color32::from_rgba_unmultiplied(255, 0, 0, 255));
-        assert_eq!(img.pixels[3], egui::Color32::from_rgba_unmultiplied(255, 255, 255, 128));
+        assert_eq!(
+            img.pixels[0],
+            egui::Color32::from_rgba_unmultiplied(255, 0, 0, 255)
+        );
+        assert_eq!(
+            img.pixels[3],
+            egui::Color32::from_rgba_unmultiplied(255, 255, 255, 128)
+        );
     }
 
     // needs_extraction / retain_visible は値型 V でジェネリック化してある（egui::TextureHandle は
@@ -104,7 +110,10 @@ mod tests {
         attempts.insert("once.exe".into(), 1);
         attempts.insert("capped.exe".into(), ICON_MAX_ATTEMPTS);
 
-        assert!(super::needs_extraction("new.exe", &have, &attempts), "未知は要抽出");
+        assert!(
+            super::needs_extraction("new.exe", &have, &attempts),
+            "未知は要抽出"
+        );
         assert!(
             super::needs_extraction("once.exe", &have, &attempts),
             "1 度失敗しただけでは諦めない（#692: 一過性の失敗を恒久扱いしない）"
@@ -131,6 +140,9 @@ mod tests {
 
         assert_eq!(textures.len(), 1);
         assert!(textures.contains_key("keep.exe"), "可視集合内は保持される");
-        assert!(!textures.contains_key("drop.exe"), "可視集合外は drop される");
+        assert!(
+            !textures.contains_key("drop.exe"),
+            "可視集合外は drop される"
+        );
     }
 }

--- a/src-tauri/src/egui_shell/launcher_controller.rs
+++ b/src-tauri/src/egui_shell/launcher_controller.rs
@@ -54,12 +54,25 @@ enum FolderMsg {
 /// hide 中に完了した起動の記録消失 gap を閉じる）。Instant は記録しない（IPC 経路 parity）。
 enum LaunchWork {
     /// 通常起動（§4.8）。tools 先頭があれば launch_with_tool_core、無ければ launch_item_core。
-    Normal { path: String, query: String, tools: Vec<OpenerTool> },
+    Normal {
+        path: String,
+        query: String,
+        tools: Vec<OpenerTool>,
+    },
     /// ツール選択起動（§18.4）。
-    Tool { target_path: String, launch_query: String, exe: String, args: String },
+    Tool {
+        target_path: String,
+        launch_query: String,
+        exe: String,
+        args: String,
+    },
     /// instant 実行（§19.6）。clipboard 読み + 展開 + 実行の全体を worker で行う
     /// （engine ロック内の action 抽出だけ UI スレッド・spec C 節）。
-    Instant { name: String, action: snotra_core::config::InstantAction, instant_query: String },
+    Instant {
+        name: String,
+        action: snotra_core::config::InstantAction,
+        instant_query: String,
+    },
 }
 
 /// 起動成功時に drain が行う UI 後処理の種別（M1/M3 の同期版と同じ末尾へ合流させる）。
@@ -192,9 +205,7 @@ impl LauncherController {
         if already {
             return;
         }
-        let _ = self
-            .app_handle
-            .emit(crate::events::EGUI_HIDE_REQUESTED, ());
+        let _ = self.app_handle.emit(crate::events::EGUI_HIDE_REQUESTED, ());
     }
 
     /// index 行の起動を worker へ投げる（§4.8 シングルクリック / Enter・#631 async 化）。
@@ -213,7 +224,9 @@ impl LauncherController {
         ) {
             return;
         }
-        let Some(result) = self.state.results().get(index) else { return };
+        let Some(result) = self.state.results().get(index) else {
+            return;
+        };
         if result.is_error {
             return;
         }
@@ -225,7 +238,11 @@ impl LauncherController {
             "egui_launch",
             serde_json::json!({ "index": index, "opener": !tools.is_empty() }),
         );
-        self.start_launch(LaunchWork::Normal { path, query, tools }, LaunchTag::Normal, ctx);
+        self.start_launch(
+            LaunchWork::Normal { path, query, tools },
+            LaunchTag::Normal,
+            ctx,
+        );
     }
 
     /// 起動を per-launch worker スレッドへ投げる（#631・spec C 節）。single-flight:
@@ -238,13 +255,19 @@ impl LauncherController {
             return; // single-flight 拒否（拒否された Enter が後で再生されるキューは egui に無い）
         }
         let (tx, rx) = channel::<crate::commands::launch::LaunchResult>();
-        self.launching = Some(LaunchInFlight { started: Instant::now(), rx, tag });
+        self.launching = Some(LaunchInFlight {
+            started: Instant::now(),
+            rx,
+            tag,
+        });
         self.state.set_results(Vec::new());
         self.instant_rows_query = None; // 行が消えるため来歴も一体でクリア（finding 0 の規律）
         let app = self.app_handle.clone();
         let egui_ctx = ctx.clone();
         std::thread::spawn(move || {
-            use crate::commands::launch::{LaunchStatus, launch_item_core, launch_with_tool_core, record_and_save};
+            use crate::commands::launch::{
+                LaunchStatus, launch_item_core, launch_with_tool_core, record_and_save,
+            };
             let (outcome, record) = match work {
                 LaunchWork::Normal { path, query, tools } => {
                     let o = if let Some(first) = tools.first() {
@@ -254,17 +277,28 @@ impl LauncherController {
                     };
                     (o, Some((path, query)))
                 }
-                LaunchWork::Tool { target_path, launch_query, exe, args } => {
+                LaunchWork::Tool {
+                    target_path,
+                    launch_query,
+                    exe,
+                    args,
+                } => {
                     let o = launch_with_tool_core(&target_path, &exe, &args);
                     (o, Some((target_path, launch_query)))
                 }
-                LaunchWork::Instant { name, action, instant_query } => {
+                LaunchWork::Instant {
+                    name,
+                    action,
+                    instant_query,
+                } => {
                     // clipboard 読み（Win32）はロック外・worker 内（commands/instant.rs と同順）。
                     let clipboard = arboard::Clipboard::new()
                         .and_then(|mut cb| cb.get_text())
                         .unwrap_or_default();
                     let o = crate::commands::instant::execute_instant_action_core(
-                        action, &instant_query, &clipboard,
+                        action,
+                        &instant_query,
+                        &clipboard,
                     );
                     crate::trace_main(
                         "egui_instant",
@@ -336,7 +370,9 @@ impl LauncherController {
     /// フレーム毎の in-flight 回収（spec C 節 不変条件 2: **reset_pending 消費の後**に呼ぶ。
     /// 前に置くと show 直後フレームで stale Ok が reset より先に処理され再 show 窓を hide で撃つ）。
     fn drain_launch(&mut self, ctx: &egui::Context) {
-        let Some(inflight) = &self.launching else { return };
+        let Some(inflight) = &self.launching else {
+            return;
+        };
         match inflight.rx.try_recv() {
             Ok(outcome) => {
                 let tag = inflight.tag;
@@ -392,19 +428,28 @@ impl LauncherController {
     /// 同順: クエリ/結果クリア（clearCommandModeState 相当）→ action。`/r`（History）は結果注入型で
     /// ここへ来ない（changed ハンドラが run_search へ振る）。失敗通知は建てない（trace のみ・#631 一本化）。
     fn execute_slash(&mut self, cmd: SlashCmd) {
-        crate::trace_main("egui_slash", serde_json::json!({ "cmd": format!("{cmd:?}") }));
+        crate::trace_main(
+            "egui_slash",
+            serde_json::json!({ "cmd": format!("{cmd:?}") }),
+        );
         self.clear_search();
         let app = self.app_handle.clone();
         match cmd {
             // 到達しない: 呼び出し側（changed ハンドラ）が History を run_search へ振る。
             // 将来 execute_slash の呼び出しサイトが増えて誤配線したとき dev/test で loud に
             // 落とす（release は panic=abort ゆえ unreachable! は採らない）。
-            SlashCmd::History => debug_assert!(false, "History は execute_slash へ来ない（run_search が注入する）"),
+            SlashCmd::History => debug_assert!(
+                false,
+                "History は execute_slash へ来ない（run_search が注入する）"
+            ),
             SlashCmd::OpenSettings => {
                 // indexing 中の Err（ERR_INDEXING_IN_PROGRESS）は trace のみ（spec M3 実装確定・
                 // クエリクリア後は検索バーの indexing hint が可視＝degraded な理由提示）。
                 if let Err(e) = crate::commands::open_settings(app.state(), app.clone()) {
-                    crate::trace_main("egui_slash_error", serde_json::json!({ "cmd": "/o", "error": e }));
+                    crate::trace_main(
+                        "egui_slash_error",
+                        serde_json::json!({ "cmd": "/o", "error": e }),
+                    );
                 }
             }
             SlashCmd::RebuildIndex => {
@@ -412,7 +457,10 @@ impl LauncherController {
                 // rebuild は backend スレッド）。indexing 中の Err は意図的無音（#434 parity）。
                 self.emit_hide();
                 if let Err(e) = crate::commands::rebuild_index(app.state(), app.clone()) {
-                    crate::trace_main("egui_slash_error", serde_json::json!({ "cmd": "/s", "error": e }));
+                    crate::trace_main(
+                        "egui_slash_error",
+                        serde_json::json!({ "cmd": "/s", "error": e }),
+                    );
                 }
             }
             SlashCmd::Quit => {
@@ -429,12 +477,16 @@ impl LauncherController {
     /// ——`execute_instant_action_core` の契約）。instant は履歴を記録しない（§19.6）。
     /// 成功/失敗の後処理は `finish_launch` へ合流。
     fn execute_instant_selected(&mut self, index: usize, instant_query: &str, ctx: &egui::Context) {
-        let Some(sel) = self.state.results().get(index) else { return };
+        let Some(sel) = self.state.results().get(index) else {
+            return;
+        };
         if sel.is_error {
             return;
         }
         let name = sel.name.clone();
-        let Some(state) = self.app_handle.try_state::<crate::AppState>() else { return };
+        let Some(state) = self.app_handle.try_state::<crate::AppState>() else {
+            return;
+        };
         let Some(action) = ({
             let engine = state.engine.lock().unwrap();
             engine
@@ -454,7 +506,11 @@ impl LauncherController {
             return;
         };
         self.start_launch(
-            LaunchWork::Instant { name, action, instant_query: instant_query.to_string() },
+            LaunchWork::Instant {
+                name,
+                action,
+                instant_query: instant_query.to_string(),
+            },
             LaunchTag::Instant,
             ctx,
         );
@@ -493,7 +549,9 @@ impl LauncherController {
         ) {
             return;
         }
-        let Some(row) = self.state.results().get(index) else { return };
+        let Some(row) = self.state.results().get(index) else {
+            return;
+        };
         if row.is_error {
             return;
         }
@@ -599,7 +657,15 @@ impl LauncherController {
     fn instant_prefix(&self) -> String {
         self.app_handle
             .try_state::<crate::AppState>()
-            .map(|s| s.engine.lock().unwrap().config().search.instant_command_prefix.clone())
+            .map(|s| {
+                s.engine
+                    .lock()
+                    .unwrap()
+                    .config()
+                    .search
+                    .instant_command_prefix
+                    .clone()
+            })
             .unwrap_or_else(|| SearchConfig::default().instant_command_prefix)
     }
 
@@ -643,7 +709,9 @@ impl LauncherController {
         let app = self.app_handle.clone();
         let tx = self.folder_tx.clone();
         std::thread::spawn(move || {
-            let Some(state) = app.try_state::<crate::AppState>() else { return };
+            let Some(state) = app.try_state::<crate::AppState>() else {
+                return;
+            };
             let ctx = { state.engine.lock().unwrap().capture_folder_list_context() };
             let entries = match ctx.read_dir_entries(std::path::Path::new(&dir), "") {
                 Ok(e) => e,
@@ -654,7 +722,13 @@ impl LauncherController {
                     return;
                 }
             };
-            let sorted = { state.engine.lock().unwrap().finalize_folder_list_unlimited(entries) };
+            let sorted = {
+                state
+                    .engine
+                    .lock()
+                    .unwrap()
+                    .finalize_folder_list_unlimited(entries)
+            };
             let _ = tx.send(FolderMsg::Loaded(token, ctx, sorted));
             egui_ctx.request_repaint();
         });
@@ -718,7 +792,10 @@ impl LauncherController {
                         );
                         self.state.set_results(results);
                     }
-                    QueryIntent::Instant { filter_name, instant_query } => {
+                    QueryIntent::Instant {
+                        filter_name,
+                        instant_query,
+                    } => {
                         // §19.5: 前方一致フィルタ。毎打鍵同期（30ms debounce 撤廃・spec M3 実装確定）。
                         // indexing を見ない（§19.7: instant はインデックス非依存ゆえ構築中でも使用可）。
                         // 候補取得は IPC コマンドと同一 fn を共有（二重実装の drift 防止・finding 5）。
@@ -731,7 +808,11 @@ impl LauncherController {
                         .map(|dto| SearchResult {
                             name: dto.name,
                             // §19.5: description 設定時は優先、無ければ display（URL / exe args）
-                            path: if dto.description.is_empty() { dto.display } else { dto.description },
+                            path: if dto.description.is_empty() {
+                                dto.display
+                            } else {
+                                dto.description
+                            },
                             is_folder: false,
                             is_error: false,
                         })
@@ -744,7 +825,10 @@ impl LauncherController {
                     QueryIntent::Command => {
                         // §15.2 /r: 履歴を注入して留まる（冪等ゆえ trailing 再発火も無害）。
                         // 他（部分入力・実行済み直後）は候補なしクリア（§15.3: command 中は検索しない）。
-                        if matches!(find_slash_command(self.state.query()), Some(SlashCmd::History)) {
+                        if matches!(
+                            find_slash_command(self.state.query()),
+                            Some(SlashCmd::History)
+                        ) {
                             let rows = {
                                 let state = match self.app_handle.try_state::<crate::AppState>() {
                                     Some(s) => s,
@@ -771,7 +855,10 @@ impl LauncherController {
     /// 遅延 dispatch より前に完了している。ここで状態を変えても誰も次のフレームを起こさないため、
     /// 無関係な入力（マウス移動等）が来るまで旧 toast が画面に残る（dismiss 後の stale 表示）。
     pub(super) fn handle_toast_action(&mut self, action: ToastAction, ctx: &egui::Context) {
-        let Some(st) = self.app_handle.try_state::<crate::egui_shell::UpdaterUiState>() else {
+        let Some(st) = self
+            .app_handle
+            .try_state::<crate::egui_shell::UpdaterUiState>()
+        else {
             return;
         };
         match action {
@@ -798,7 +885,10 @@ impl LauncherController {
     /// Err 復帰時のみ InstallFailed へ遷移して toast をエラー表示にする（updaterError parity）。
     fn spawn_install(&self, update: Box<tauri_plugin_updater::Update>) {
         let handle = self.app_handle.clone();
-        crate::trace_main("egui_update_install_begin", serde_json::json!({ "version": update.version }));
+        crate::trace_main(
+            "egui_update_install_begin",
+            serde_json::json!({ "version": update.version }),
+        );
         tauri::async_runtime::spawn(async move {
             match update.download_and_install(|_, _| {}, || {}).await {
                 Ok(()) => {
@@ -832,7 +922,9 @@ impl LauncherController {
     pub(super) fn consume_reset_pending(&mut self) -> bool {
         // show 直後の resetForShow（EguiShellState.reset_pending を消費）。stale な debounce
         // armed 状態が再表示後に誤発火しないよう、debounce も併せて作り直す。
-        if let Some(sh) = self.app_handle.try_state::<crate::egui_shell::EguiShellState>()
+        if let Some(sh) = self
+            .app_handle
+            .try_state::<crate::egui_shell::EguiShellState>()
             && sh.reset_pending.swap(false, Ordering::SeqCst)
         {
             self.state.reset();
@@ -881,7 +973,9 @@ impl LauncherController {
         // lang() live-read: config-applied wake のフレームは update_config 後なので言語同時
         // 変更でも新言語で整形される。hidden 中の失敗は次 show のこの消費で表示される
         //（WebView2 は hidden 中に期限切れ・改善方向の受容差異・SU6 spec 追補 2）。
-        if let Some(sh) = self.app_handle.try_state::<crate::egui_shell::EguiShellState>()
+        if let Some(sh) = self
+            .app_handle
+            .try_state::<crate::egui_shell::EguiShellState>()
             && let Some((kind, hk)) = sh.pending_hotkey_failure.lock().unwrap().take()
         {
             let msg = match kind {
@@ -892,7 +986,11 @@ impl LauncherController {
                     crate::egui_shell::ui_strings::hotkey_change_failed(self.lang(), &hk)
                 }
             };
-            self.notice.set(msg, self.notice_base.elapsed(), crate::egui_shell::NOTICE_HOTKEY);
+            self.notice.set(
+                msg,
+                self.notice_base.elapsed(),
+                crate::egui_shell::NOTICE_HOTKEY,
+            );
             ctx.request_repaint();
         }
     }
@@ -1079,7 +1177,8 @@ impl LauncherController {
                     // interp 再導出でなく行来歴（instant_rows_query・prefix hot-change に頑健）。
                     // instant 行の path は description/display ゆえ compute_parent_dir が偶然 Some を
                     // 返して bogus folder 突入しうるのを塞ぐ。command（/r 履歴）中は許可＝→ と対称。
-                    if self.instant_rows_query.is_none() && let Some(sel) = self.state.results().get(self.state.selected())
+                    if self.instant_rows_query.is_none()
+                        && let Some(sel) = self.state.results().get(self.state.selected())
                         && !sel.is_error
                         && let Some(parent) = compute_parent_dir(&sel.path)
                     {

--- a/src-tauri/src/egui_shell/layout.rs
+++ b/src-tauri/src/egui_shell/layout.rs
@@ -92,7 +92,9 @@ pub fn results_window_height(result_count: usize, max_results: u32, row_height: 
 /// 「main を画面下端へ置くと結果が一切出ない」という別の欠陥になる。床を割ったぶんの
 /// はみ出しは受容する（行はスクロールで到達できる）。
 pub fn clamp_results_height(desired: f64, available: Option<f64>, row_height: f64) -> f64 {
-    let Some(avail) = available else { return desired };
+    let Some(avail) = available else {
+        return desired;
+    };
     if desired <= 0.0 {
         return desired;
     }
@@ -221,7 +223,11 @@ pub struct Debouncer {
 
 impl Debouncer {
     pub fn new(interval: Duration, leading: bool) -> Self {
-        Self { interval, leading, armed: false }
+        Self {
+            interval,
+            leading,
+            armed: false,
+        }
     }
 
     pub fn interval(&self) -> Duration {
@@ -268,12 +274,18 @@ mod tests {
     #[test]
     fn aux_text_sizes_scale_with_font_size() {
         // 既定 font_size=15 で従来の固定値 13px と実質同じ（この変更は見た目を変えない）。
-        assert!((status_size(15) - 13.05).abs() < 0.01, "既定で 13px 相当を保つ");
+        assert!(
+            (status_size(15) - 13.05).abs() < 0.01,
+            "既定で 13px 相当を保つ"
+        );
         // font_size を上げれば追従する（固定値なら 15 と 24 で同値になり、ここが落ちる）。
         assert!(status_size(24) > status_size(15), "font_size に連動する");
         assert!((status_size(24) - 20.88).abs() < 0.01);
         // 補助要素どうしの序列: パス行 < status 行 < 主要素（font_size 等倍）。
-        assert!(path_size(15) < status_size(15), "パス行より大きい（行の主メッセージゆえ）");
+        assert!(
+            path_size(15) < status_size(15),
+            "パス行より大きい（行の主メッセージゆえ）"
+        );
         assert!(status_size(15) < 15.0, "主要素より小さい");
         // 極小 font_size でも読める下限を持つ（path_size の 9.0 と同型の防御）。
         assert_eq!(status_size(1), 11.0);
@@ -284,8 +296,14 @@ mod tests {
         let mut d = Debouncer::new(Duration::from_millis(50), true);
         assert!(d.on_input(), "バースト先頭は leading 発火");
         assert!(!d.on_input(), "連打中は leading 抑止");
-        assert!(!d.poll(Duration::from_millis(30)), "50ms 未満は trailing 抑止");
-        assert!(d.poll(Duration::from_millis(50)), "50ms 経過で trailing 発火");
+        assert!(
+            !d.poll(Duration::from_millis(30)),
+            "50ms 未満は trailing 抑止"
+        );
+        assert!(
+            d.poll(Duration::from_millis(50)),
+            "50ms 経過で trailing 発火"
+        );
         assert!(!d.poll(Duration::from_millis(100)), "発火後は disarm");
     }
 
@@ -303,7 +321,10 @@ mod tests {
         assert!(d.is_armed());
         d.cancel();
         assert!(!d.is_armed());
-        assert!(!d.poll(Duration::from_millis(100)), "cancel 後は trailing 発火しない");
+        assert!(
+            !d.poll(Duration::from_millis(100)),
+            "cancel 後は trailing 発火しない"
+        );
         // cancel 後の次入力はバースト先頭扱い（leading 再発火）
         assert!(d.on_input());
     }
@@ -443,7 +464,10 @@ mod tests {
         let h = 3.0 * 37.0 + 8.0; // results_window_height(3, 8, 37.0)
 
         // ①true ③true（plain_hidden = false）
-        assert_eq!(present_results(inputs(true, false, 3, 8)), Visible { desired_height: h }); // ②t ④t: 唯一の可視
+        assert_eq!(
+            present_results(inputs(true, false, 3, 8)),
+            Visible { desired_height: h }
+        ); // ②t ④t: 唯一の可視
         assert_eq!(present_results(inputs(true, false, 3, 0)), Hidden); // ②t ④f（max_results=0）
         assert_eq!(present_results(inputs(true, false, 0, 8)), Hidden); // ②f ④f
         // ①true ③false（carve-out で隠す）
@@ -468,7 +492,10 @@ mod tests {
     /// ——表から 1 行落ちても、名前付きのこれが落ちる。
     #[test]
     fn results_hidden_while_main_is_hidden_even_with_rows() {
-        assert_eq!(present_results(inputs(false, false, 3, 8)), ResultsPresentation::Hidden);
+        assert_eq!(
+            present_results(inputs(false, false, 3, 8)),
+            ResultsPresentation::Hidden
+        );
         // 対照: main が可視なら同じ入力で出る（要石が効いているのは①だけだと示す）
         assert!(matches!(
             present_results(inputs(true, false, 3, 8)),

--- a/src-tauri/src/egui_shell/lifecycle.rs
+++ b/src-tauri/src/egui_shell/lifecycle.rs
@@ -91,20 +91,41 @@ mod tests {
     fn blur_grace_rearms_while_armed_and_hides_after() {
         let ms = Duration::from_millis;
         // 猶予中は残余で再要求する（契約③: 予約はフレームの到来を約束しない）。
-        assert_eq!(blur_grace_action(ms(0), false, true, false), BlurAction::Rearm(ms(100)));
-        assert_eq!(blur_grace_action(ms(99), false, true, false), BlurAction::Rearm(ms(1)));
+        assert_eq!(
+            blur_grace_action(ms(0), false, true, false),
+            BlurAction::Rearm(ms(100))
+        );
+        assert_eq!(
+            blur_grace_action(ms(99), false, true, false),
+            BlurAction::Rearm(ms(1))
+        );
         // 境界ちょうどは Hide 側（`>=`）——減算に落ちないことも兼ねて固定する。
-        assert_eq!(blur_grace_action(BLUR_GRACE, false, true, false), BlurAction::Hide);
-        assert_eq!(blur_grace_action(ms(150), false, true, false), BlurAction::Hide);
+        assert_eq!(
+            blur_grace_action(BLUR_GRACE, false, true, false),
+            BlurAction::Hide
+        );
+        assert_eq!(
+            blur_grace_action(ms(150), false, true, false),
+            BlurAction::Hide
+        );
     }
 
     #[test]
     fn blur_grace_stays_idle_when_time_cannot_resolve_it() {
         let ms = Duration::from_millis;
         // 猶予明けだが時計と無関係な条件で不成立 → **再要求しない**（永久スピンを作らない）。
-        assert_eq!(blur_grace_action(ms(150), false, false, false), BlurAction::Idle); // auto_hide off
-        assert_eq!(blur_grace_action(ms(150), false, true, true), BlurAction::Idle); // 設定起動中
-        assert_eq!(blur_grace_action(ms(150), true, true, false), BlurAction::Idle); // focus 復帰
+        assert_eq!(
+            blur_grace_action(ms(150), false, false, false),
+            BlurAction::Idle
+        ); // auto_hide off
+        assert_eq!(
+            blur_grace_action(ms(150), false, true, true),
+            BlurAction::Idle
+        ); // 設定起動中
+        assert_eq!(
+            blur_grace_action(ms(150), true, true, false),
+            BlurAction::Idle
+        ); // focus 復帰
     }
 
     #[test]
@@ -127,7 +148,10 @@ mod tests {
             plan_hotkey(true, true, false),
             HotkeyPlan::ShowAfterAltRelease // 表示+非toggle+Alt → 解放待ち show
         );
-        assert_eq!(plan_hotkey(false, true, true), HotkeyPlan::ShowAfterAltRelease);
+        assert_eq!(
+            plan_hotkey(false, true, true),
+            HotkeyPlan::ShowAfterAltRelease
+        );
         assert_eq!(plan_hotkey(false, false, true), HotkeyPlan::ShowNow);
         assert_eq!(plan_hotkey(false, false, false), HotkeyPlan::ShowNow);
     }

--- a/src-tauri/src/egui_shell/mod.rs
+++ b/src-tauri/src/egui_shell/mod.rs
@@ -6,10 +6,10 @@
 //! main のサイズだけは 2 か所に分かれている（`window_coordinator` の show 経路と `view.rs` の
 //! 毎フレーム。理由は `window_coordinator` の `//!`）。
 mod icon_textures;
-mod lifecycle;
-mod search_state;
 mod layout;
+mod lifecycle;
 mod notify;
+mod search_state;
 // launcher_controller.rs が起動 worker の in-flight 追跡・一時通知で消費する（#532 SU5 Task 4）。
 pub(crate) use notify::{LAUNCH_TIMEOUT, NOTICE_LAUNCH, NoticeSlot};
 // NOTICE_HOTKEY は launcher_controller.rs（hotkey 失敗通知の duration）が、OverlayKind /
@@ -20,11 +20,11 @@ pub(crate) use notify::{NOTICE_HOTKEY, OverlayKind, overlay_kind};
 // （#532 SU5 Task 6）。toast 描画は view.rs が、UpdaterPhase の遷移（install 失敗）は
 // launcher_controller.rs が消費する。
 pub(crate) use notify::{ToastKind, UpdaterPhase, UpdaterUi};
-pub(crate) mod strings;
-mod results_view;
-mod results_window;
 mod font_stack;
 mod launcher_controller;
+mod results_view;
+mod results_window;
+pub(crate) mod strings;
 mod view;
 mod visual;
 mod window_coordinator;
@@ -147,7 +147,9 @@ impl EguiShellState {
 /// （hidden に頑健・launching の channel edge-trigger との構造的対比は spec C 節）。
 /// dismissed は view-local に置かない——reset-on-show が view-local を一掃した際に
 /// `[閉じる]` 済み toast が復活するため（状態機械レビュー・spec A 節）。
-pub(crate) struct UpdaterUiState(pub(crate) Mutex<crate::egui_shell::UpdaterUi<Box<tauri_plugin_updater::Update>>>);
+pub(crate) struct UpdaterUiState(
+    pub(crate) Mutex<crate::egui_shell::UpdaterUi<Box<tauri_plugin_updater::Update>>>,
+);
 
 /// 起動時 updater check（§20.2・spec B 節）。`main.rs` の setup が**無条件で一回だけ**呼び、
 /// `auto_update` の判定はこの関数の中で行う（呼び出し側では絞っていない——下の視覚スモーク
@@ -216,12 +218,18 @@ pub(crate) fn spawn_update_check(app: &tauri::AppHandle) {
                 Ok(None) => crate::egui_shell::UpdaterPhase::UpToDate,
                 Err(e) => {
                     // check 失敗は無音（console.warn parity・trace のみ）。
-                    crate::trace_main("egui_update_check_failed", serde_json::json!({ "error": e.to_string() }));
+                    crate::trace_main(
+                        "egui_update_check_failed",
+                        serde_json::json!({ "error": e.to_string() }),
+                    );
                     crate::egui_shell::UpdaterPhase::Idle
                 }
             },
             Err(e) => {
-                crate::trace_main("egui_update_check_failed", serde_json::json!({ "error": e.to_string() }));
+                crate::trace_main(
+                    "egui_update_check_failed",
+                    serde_json::json!({ "error": e.to_string() }),
+                );
                 crate::egui_shell::UpdaterPhase::Idle
             }
         };
@@ -312,7 +320,8 @@ pub(crate) fn create(
     // attach は窓ごとの wake handle を返す（#671 PR D）。**results を先に attach する順序は
     // 変えない**——`ResultsWindow::new` は attach の move より前でなければならず（PR A′）、
     // main の Moved リスナー登録もこの間に入る。
-    let results_waker = runtime.attach(results, results_view::ResultsView::new(app_handle.clone()))?;
+    let results_waker =
+        runtime.attach(results, results_view::ResultsView::new(app_handle.clone()))?;
     // #646 PR2 決定 10: ドラッグ移動中の追従。ネイティブ移動ループ中は egui フレームが
     // 回る保証が無いため、tao の Moved イベント(tauri Window リスナー経由)で直接
     // results を追従させる。通常時の従属は main update() の drive が担う(二重呼びは
@@ -368,7 +377,11 @@ pub(crate) fn read_visual(app: &tauri::AppHandle, applied_font_family: &str) -> 
             let engine = s.engine.lock().unwrap();
             let config = engine.config();
             // guard 内で行うのは hex parse と算術と &str 比較まで。I/O や重い確保を足さない。
-            visual::visual_snapshot(&config.visual, config.appearance.show_icons, applied_font_family)
+            visual::visual_snapshot(
+                &config.visual,
+                config.appearance.show_icons,
+                applied_font_family,
+            )
         }
         // AppState 不在（setup 完了前の理論経路のみ）。既定は型から導く——`AppearanceConfig` に
         // `Default` 実装を与えたことで show_icons のリテラルが不要になった（#795）。

--- a/src-tauri/src/egui_shell/notify.rs
+++ b/src-tauri/src/egui_shell/notify.rs
@@ -89,7 +89,11 @@ pub enum UpdaterPhase<U> {
     Idle,
     Checking,
     UpToDate,
-    Available { version: String, can_install: bool, update: Option<U> },
+    Available {
+        version: String,
+        can_install: bool,
+        update: Option<U>,
+    },
     // version は toast() が Installing 局面で表示しない（update_installing は汎用文言・
     // 消費経路なし）ため保持しない。Available→Installing 遷移時に破棄する。
     Installing,
@@ -99,7 +103,9 @@ pub enum UpdaterPhase<U> {
     // （`toast()` と view の描画）は `..` で受けず**フィールドを明示束縛する**こと。`..` は
     // `-D warnings` でも「payload を足したが描いていない」を通し、dead payload を作った当の
     // 経路を再生産する。詳細は表示に出ない場合も trace（`egui_update_install_failed`）に残る。
-    InstallFailed { message: String },
+    InstallFailed {
+        message: String,
+    },
 }
 
 /// toast 1 行分の表示モデル（描画専用・U 非依存）。
@@ -115,10 +121,14 @@ pub struct ToastRow {
 
 #[derive(Debug, PartialEq)]
 pub enum ToastKind {
-    Available { version: String },
+    Available {
+        version: String,
+    },
     Installing,
     /// `message` は失敗理由（空なら generic 文言のみ）。描画は `ui_strings::update_failed`。
-    Failed { message: String },
+    Failed {
+        message: String,
+    },
 }
 
 /// updater toast の状態機械。dismiss/install の競合は本型のメソッド内で原子的に解決する
@@ -130,7 +140,10 @@ pub struct UpdaterUi<U> {
 
 impl<U> Default for UpdaterUi<U> {
     fn default() -> Self {
-        Self { phase: UpdaterPhase::Idle, dismissed: false }
+        Self {
+            phase: UpdaterPhase::Idle,
+            dismissed: false,
+        }
     }
 }
 
@@ -143,13 +156,25 @@ impl<U> UpdaterUi<U> {
         }
         let phase = std::mem::replace(&mut self.phase, UpdaterPhase::Idle);
         match phase {
-            UpdaterPhase::Available { can_install: true, update: Some(update), .. } => {
+            UpdaterPhase::Available {
+                can_install: true,
+                update: Some(update),
+                ..
+            } => {
                 self.phase = UpdaterPhase::Installing;
                 Some(update)
             }
-            UpdaterPhase::Available { version, can_install: true, update: None } => {
+            UpdaterPhase::Available {
+                version,
+                can_install: true,
+                update: None,
+            } => {
                 // fake 注入（SNOTRA_EGUI_FAKE_UPDATE・視覚スモーク専用）: install 実体なし。
-                self.phase = UpdaterPhase::Available { version, can_install: true, update: None };
+                self.phase = UpdaterPhase::Available {
+                    version,
+                    can_install: true,
+                    update: None,
+                };
                 None
             }
             other => {
@@ -174,8 +199,14 @@ impl<U> UpdaterUi<U> {
             return None;
         }
         match &self.phase {
-            UpdaterPhase::Available { version, can_install, .. } => Some(ToastRow {
-                kind: ToastKind::Available { version: version.clone() },
+            UpdaterPhase::Available {
+                version,
+                can_install,
+                ..
+            } => Some(ToastRow {
+                kind: ToastKind::Available {
+                    version: version.clone(),
+                },
                 show_install: *can_install,
                 buttons_enabled: true,
             }),
@@ -185,7 +216,9 @@ impl<U> UpdaterUi<U> {
                 buttons_enabled: false,
             }),
             UpdaterPhase::InstallFailed { message } => Some(ToastRow {
-                kind: ToastKind::Failed { message: message.clone() },
+                kind: ToastKind::Failed {
+                    message: message.clone(),
+                },
                 show_install: false,
                 buttons_enabled: true,
             }),
@@ -238,23 +271,42 @@ mod tests {
     fn install_takes_update_only_from_available_with_can_install() {
         let mut u: UpdaterUi<&'static str> = UpdaterUi::default();
         assert!(u.try_begin_install().is_none(), "Idle からは install 不可");
-        u.phase =
-            UpdaterPhase::Available { version: "1.2.3".into(), can_install: false, update: Some("U") };
-        assert!(u.try_begin_install().is_none(), "check_only は install 不可");
-        u.phase =
-            UpdaterPhase::Available { version: "1.2.3".into(), can_install: true, update: Some("U") };
+        u.phase = UpdaterPhase::Available {
+            version: "1.2.3".into(),
+            can_install: false,
+            update: Some("U"),
+        };
+        assert!(
+            u.try_begin_install().is_none(),
+            "check_only は install 不可"
+        );
+        u.phase = UpdaterPhase::Available {
+            version: "1.2.3".into(),
+            can_install: true,
+            update: Some("U"),
+        };
         assert_eq!(u.try_begin_install(), Some("U"));
         assert!(matches!(u.phase, UpdaterPhase::Installing), "原子遷移");
-        assert!(u.try_begin_install().is_none(), "二重 install は拒否（Update は一度しか取れない）");
+        assert!(
+            u.try_begin_install().is_none(),
+            "二重 install は拒否（Update は一度しか取れない）"
+        );
     }
 
     #[test]
     #[allow(clippy::field_reassign_with_default)]
     fn fake_available_without_update_cannot_install() {
         let mut u: UpdaterUi<&'static str> = UpdaterUi::default();
-        u.phase = UpdaterPhase::Available { version: "9.9.9".into(), can_install: true, update: None };
+        u.phase = UpdaterPhase::Available {
+            version: "9.9.9".into(),
+            can_install: true,
+            update: None,
+        };
         assert!(u.try_begin_install().is_none());
-        assert!(matches!(u.phase, UpdaterPhase::Available { .. }), "fake は Available のまま");
+        assert!(
+            matches!(u.phase, UpdaterPhase::Available { .. }),
+            "fake は Available のまま"
+        );
     }
 
     #[test]
@@ -262,9 +314,14 @@ mod tests {
     fn dismiss_is_refused_while_installing() {
         let mut u: UpdaterUi<()> = UpdaterUi::default();
         u.phase = UpdaterPhase::Installing;
-        assert!(!u.dismiss(), "Installing 中の dismiss は拒否（WebView2 disabled parity）");
+        assert!(
+            !u.dismiss(),
+            "Installing 中の dismiss は拒否（WebView2 disabled parity）"
+        );
         assert!(u.toast().is_some(), "toast は出たまま");
-        u.phase = UpdaterPhase::InstallFailed { message: "e".into() };
+        u.phase = UpdaterPhase::InstallFailed {
+            message: "e".into(),
+        };
         assert!(u.dismiss());
         assert!(u.toast().is_none(), "dismissed 後は導出も消える");
     }
@@ -297,9 +354,16 @@ mod tests {
     #[allow(clippy::field_reassign_with_default)] // 他のテストと同じ verbatim 形を保つ
     fn install_failure_reason_reaches_toast() {
         let mut u: UpdaterUi<()> = UpdaterUi::default();
-        u.phase = UpdaterPhase::InstallFailed { message: "boom".into() };
+        u.phase = UpdaterPhase::InstallFailed {
+            message: "boom".into(),
+        };
         let t = u.toast().expect("失敗局面では toast が出る");
-        assert_eq!(t.kind, ToastKind::Failed { message: "boom".into() });
+        assert_eq!(
+            t.kind,
+            ToastKind::Failed {
+                message: "boom".into()
+            }
+        );
         assert!(!t.show_install, "失敗時に [今すぐ更新] は出さない");
         assert!(t.buttons_enabled, "[閉じる] は押せる");
     }
@@ -309,11 +373,22 @@ mod tests {
         let mut u: UpdaterUi<()> = UpdaterUi::default();
         assert!(u.toast().is_none(), "Idle は非表示");
         u.phase = UpdaterPhase::Checking;
-        assert!(u.toast().is_none(), "Checking は非表示（WebView2 は check 中 UI 無し）");
-        u.phase =
-            UpdaterPhase::Available { version: "2.0.0".into(), can_install: true, update: Some(()) };
+        assert!(
+            u.toast().is_none(),
+            "Checking は非表示（WebView2 は check 中 UI 無し）"
+        );
+        u.phase = UpdaterPhase::Available {
+            version: "2.0.0".into(),
+            can_install: true,
+            update: Some(()),
+        };
         let t = u.toast().unwrap();
-        assert_eq!(t.kind, ToastKind::Available { version: "2.0.0".into() });
+        assert_eq!(
+            t.kind,
+            ToastKind::Available {
+                version: "2.0.0".into()
+            }
+        );
         assert!(t.show_install && t.buttons_enabled);
     }
 }

--- a/src-tauri/src/egui_shell/results_view.rs
+++ b/src-tauri/src/egui_shell/results_view.rs
@@ -380,11 +380,9 @@ pub(crate) fn draw_result_row(
         return response.clicked();
     }
     let path_font = egui::FontId::proportional(theme.path_size);
-    let path_full = ui.painter().layout_no_wrap(
-        result.path.clone(),
-        path_font.clone(),
-        theme.path_color,
-    );
+    let path_full =
+        ui.painter()
+            .layout_no_wrap(result.path.clone(), path_font.clone(), theme.path_color);
     let path_str = if path_full.size().x <= avail {
         result.path.clone()
     } else {
@@ -392,7 +390,9 @@ pub(crate) fn draw_result_row(
         let per_char_px = path_full.size().x / (result.path.chars().count().max(1) as f32);
         truncate_middle(&result.path, avail, per_char_px)
     };
-    let path_galley = ui.painter().layout_no_wrap(path_str, path_font, theme.path_color);
+    let path_galley = ui
+        .painter()
+        .layout_no_wrap(path_str, path_font, theme.path_color);
     // 鏡像ケース(folder 列挙エラー行・snotra-core/src/folder.rs の error_result は
     // name 空・path 非空): 上段を空白にせず path 1 行を縦中央に単独描画
     //(上の path 空分岐と対称・plan-review scout-egui 指摘)。
@@ -408,7 +408,8 @@ pub(crate) fn draw_result_row(
     let total_h = name_galley.size().y + 4.0 + path_galley.size().y;
     let top = rect.center().y - total_h / 2.0;
     let name_h = name_galley.size().y;
-    ui.painter().galley(egui::pos2(text_x, top), name_galley, theme.name_color);
+    ui.painter()
+        .galley(egui::pos2(text_x, top), name_galley, theme.name_color);
     ui.painter().galley(
         egui::pos2(text_x, top + name_h + 4.0),
         path_galley,
@@ -424,7 +425,11 @@ pub(crate) fn draw_result_row(
 fn draw_icon_fallback(ui: &egui::Ui, rect: egui::Rect, result: &SearchResult, theme: &RowTheme) {
     let center = egui::pos2(rect.left() + 14.0, rect.center().y);
     let r = egui::Rect::from_center_size(center, egui::vec2(14.0, 14.0));
-    let col = if result.is_folder { theme.name_color } else { theme.path_color };
+    let col = if result.is_folder {
+        theme.name_color
+    } else {
+        theme.path_color
+    };
     ui.painter().rect_filled(r, 2.0, col.linear_multiply(0.5));
 }
 
@@ -632,7 +637,10 @@ mod tests {
     fn clicked_is_discarded_on_generation_mismatch() {
         let shared = ResultsShared::default();
         shared.push_clicked(7, 2);
-        assert!(matches!(shared.take_clicked_for(8), ClickTake::Stale { stamped: 7 }));
+        assert!(matches!(
+            shared.take_clicked_for(8),
+            ClickTake::Stale { stamped: 7 }
+        ));
         assert!(
             matches!(shared.take_clicked_for(7), ClickTake::None),
             "破棄後は空であること（元の世代で引いても戻らない）"

--- a/src-tauri/src/egui_shell/results_window.rs
+++ b/src-tauri/src/egui_shell/results_window.rs
@@ -151,7 +151,11 @@ impl ResultsWindow {
             HWND_NOTOPMOST, HWND_TOPMOST, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SetWindowPos,
         };
         let Ok(hwnd) = self.window.hwnd() else { return };
-        let insert_after = if topmost { HWND_TOPMOST } else { HWND_NOTOPMOST };
+        let insert_after = if topmost {
+            HWND_TOPMOST
+        } else {
+            HWND_NOTOPMOST
+        };
         unsafe {
             let _ = SetWindowPos(
                 HWND(hwnd.0),

--- a/src-tauri/src/egui_shell/search_state.rs
+++ b/src-tauri/src/egui_shell/search_state.rs
@@ -62,7 +62,11 @@ pub fn interpret(raw_query: &str, prefix: &str, view_kind: ViewKind) -> QueryInt
 /// ——dead/slow UNC でロードが滞留すると、前ビューの誤項目を起動しうるため。前フレーム結果の保持は
 /// フリッカ回避の意図的設計（launcher_controller.rs run_search）ゆえ温存し、不可逆な起動だけを止める。Results
 /// モードや列挙完了（cache/error いずれか到着）後は false で、通常どおり起動できる。
-pub fn folder_load_pending(view_kind: ViewKind, has_folder_cache: bool, has_folder_error: bool) -> bool {
+pub fn folder_load_pending(
+    view_kind: ViewKind,
+    has_folder_cache: bool,
+    has_folder_error: bool,
+) -> bool {
     view_kind == ViewKind::Folder && !has_folder_cache && !has_folder_error
 }
 
@@ -280,7 +284,9 @@ impl SearchState {
 
     /// folder 中の親ディレクトリ（ルート終端で None）。
     pub fn parent_dir(&self) -> Option<String> {
-        self.folder.as_ref().and_then(|f| compute_parent_dir(&f.current_dir))
+        self.folder
+            .as_ref()
+            .and_then(|f| compute_parent_dir(&f.current_dir))
     }
 
     /// driver は token を `enter_folder`/`navigate_folder` の戻り値から直接得るため、独立した
@@ -301,7 +307,12 @@ impl SearchState {
     /// どちらでも）の表示状態を frame へ退避する。tools ≥ 2 の判定は driver 側
     /// （§18.3: ≤1 は通常 Enter と同一のため、そもそも呼ばれない）。driver からは
     /// `shift_activate` が呼ぶ（#532 SU3.5 Task 3）。
-    pub fn enter_tool(&mut self, target_path: String, target_is_folder: bool, tools: Vec<OpenerTool>) {
+    pub fn enter_tool(
+        &mut self,
+        target_path: String,
+        target_is_folder: bool,
+        tools: Vec<OpenerTool>,
+    ) {
         let rows: Vec<SearchResult> = tools
             .iter()
             .map(|t| SearchResult {
@@ -386,11 +397,7 @@ impl Default for SearchState {
 
 /// 選択 index を [0, len) へクランプ（len==0 は 0）。folderNav.clampSelectedIndex 相当。
 pub(crate) fn clamp_selected(len: usize, idx: usize) -> usize {
-    if len == 0 {
-        0
-    } else {
-        idx.min(len - 1)
-    }
+    if len == 0 { 0 } else { idx.min(len - 1) }
 }
 
 /// Enter 時の trailing flush 要否（#631 flush-on-Enter・SolidJS flushPendingRefresh 同型）。
@@ -413,7 +420,11 @@ pub(crate) fn compute_parent_dir(current_dir: &str) -> Option<String> {
     };
     // UNC ルート判定: \\server\share（2 セグメント以下）は終端。
     if let Some(rest) = normalized.strip_prefix("\\\\") {
-        let parts: Vec<&str> = rest.trim_end_matches('\\').split('\\').filter(|p| !p.is_empty()).collect();
+        let parts: Vec<&str> = rest
+            .trim_end_matches('\\')
+            .split('\\')
+            .filter(|p| !p.is_empty())
+            .collect();
         if parts.len() <= 2 {
             return None;
         }
@@ -422,7 +433,10 @@ pub(crate) fn compute_parent_dir(current_dir: &str) -> Option<String> {
     let cut = normalized.rfind('\\')?;
     let mut parent = normalized[..cut].to_string();
     // "X:" → "X:\"（ドライブルートは末尾 `\` 必須）。
-    if parent.len() == 2 && parent.as_bytes()[1] == b':' && parent.as_bytes()[0].is_ascii_alphabetic() {
+    if parent.len() == 2
+        && parent.as_bytes()[1] == b':'
+        && parent.as_bytes()[0].is_ascii_alphabetic()
+    {
         parent.push('\\');
     }
     if parent.is_empty() || parent == normalized {
@@ -430,7 +444,11 @@ pub(crate) fn compute_parent_dir(current_dir: &str) -> Option<String> {
     }
     // \\server（share 未満）は終端。
     if let Some(rest) = parent.strip_prefix("\\\\") {
-        let parts: Vec<&str> = rest.trim_end_matches('\\').split('\\').filter(|p| !p.is_empty()).collect();
+        let parts: Vec<&str> = rest
+            .trim_end_matches('\\')
+            .split('\\')
+            .filter(|p| !p.is_empty())
+            .collect();
         if parts.len() < 2 {
             return None;
         }
@@ -462,28 +480,49 @@ mod tests {
 
     #[test]
     fn plain_query_is_plain() {
-        assert_eq!(interpret("firefox", "@", ViewKind::Results), QueryIntent::Plain);
+        assert_eq!(
+            interpret("firefox", "@", ViewKind::Results),
+            QueryIntent::Plain
+        );
     }
 
     #[test]
     fn flush_on_enter_only_for_armed_plain_results() {
         assert!(should_flush_on_enter(ViewKind::Results, true, true));
-        assert!(!should_flush_on_enter(ViewKind::Results, true, false), "armed でなければ flush 不要");
-        assert!(!should_flush_on_enter(ViewKind::Results, false, true), "instant/command では flush しない");
-        assert!(!should_flush_on_enter(ViewKind::Folder, true, true), "folder は同期フィルタ");
-        assert!(!should_flush_on_enter(ViewKind::Tool, true, true), "tool 中は検索自体が凍結");
+        assert!(
+            !should_flush_on_enter(ViewKind::Results, true, false),
+            "armed でなければ flush 不要"
+        );
+        assert!(
+            !should_flush_on_enter(ViewKind::Results, false, true),
+            "instant/command では flush しない"
+        );
+        assert!(
+            !should_flush_on_enter(ViewKind::Folder, true, true),
+            "folder は同期フィルタ"
+        );
+        assert!(
+            !should_flush_on_enter(ViewKind::Tool, true, true),
+            "tool 中は検索自体が凍結"
+        );
     }
 
     #[test]
     fn slash_prefix_is_command() {
-        assert_eq!(interpret("/r", "@", ViewKind::Results), QueryIntent::Command);
+        assert_eq!(
+            interpret("/r", "@", ViewKind::Results),
+            QueryIntent::Command
+        );
     }
 
     #[test]
     fn instant_prefix_without_space() {
         assert_eq!(
             interpret("@goog", "@", ViewKind::Results),
-            QueryIntent::Instant { filter_name: "goog".into(), instant_query: String::new() }
+            QueryIntent::Instant {
+                filter_name: "goog".into(),
+                instant_query: String::new()
+            }
         );
     }
 
@@ -491,7 +530,10 @@ mod tests {
     fn instant_prefix_with_space_splits_filter_and_query() {
         assert_eq!(
             interpret("@google rust egui", "@", ViewKind::Results),
-            QueryIntent::Instant { filter_name: "google".into(), instant_query: "rust egui".into() }
+            QueryIntent::Instant {
+                filter_name: "google".into(),
+                instant_query: "rust egui".into()
+            }
         );
     }
 
@@ -513,12 +555,20 @@ mod tests {
     fn leading_whitespace_trimmed_for_detection() {
         assert_eq!(
             interpret("  @a", "@", ViewKind::Results),
-            QueryIntent::Instant { filter_name: "a".into(), instant_query: String::new() }
+            QueryIntent::Instant {
+                filter_name: "a".into(),
+                instant_query: String::new()
+            }
         );
     }
 
     fn res(name: &str) -> SearchResult {
-        SearchResult { name: name.into(), path: format!("C:/{name}.exe"), is_folder: false, is_error: false }
+        SearchResult {
+            name: name.into(),
+            path: format!("C:/{name}.exe"),
+            is_folder: false,
+            is_error: false,
+        }
     }
 
     // ---- rows_generation（#699）----
@@ -542,7 +592,11 @@ mod tests {
         s.set_results(vec![res("a"), res("b")]);
         let g = s.rows_generation();
         s.enter_tool("C:/t.txt".into(), false, make_tools());
-        assert_eq!(s.rows_generation(), g + 1, "ツール行への総入れ替えで進むこと");
+        assert_eq!(
+            s.rows_generation(),
+            g + 1,
+            "ツール行への総入れ替えで進むこと"
+        );
     }
 
     /// `on_escape` は **2 分岐とも** 行を差し替える。片方だけ直すと穴が残る。
@@ -594,7 +648,11 @@ mod tests {
         s.set_results(vec![res("a")]);
         let g = s.rows_generation();
         s.reset();
-        assert_eq!(s.rows_generation(), g + 1, "reset は hide を跨いだ stale クリックを失効させる");
+        assert_eq!(
+            s.rows_generation(),
+            g + 1,
+            "reset は hide を跨いだ stale クリックを失効させる"
+        );
     }
 
     /// **進めすぎの側**。選択の移動は行の差し替えではない——ここで進めると #699 の
@@ -654,7 +712,13 @@ mod tests {
     fn interp_reads_current_query() {
         let mut s = SearchState::new();
         s.set_query("@g".into());
-        assert_eq!(s.interp("@"), QueryIntent::Instant { filter_name: "g".into(), instant_query: String::new() });
+        assert_eq!(
+            s.interp("@"),
+            QueryIntent::Instant {
+                filter_name: "g".into(),
+                instant_query: String::new()
+            }
+        );
     }
 
     #[test]
@@ -662,7 +726,10 @@ mod tests {
         assert_eq!(compute_parent_dir("C:\\a\\b"), Some("C:\\a".to_string()));
         assert_eq!(compute_parent_dir("C:\\a"), Some("C:\\".to_string()));
         assert_eq!(compute_parent_dir("C:\\"), None); // ドライブルート終端
-        assert_eq!(compute_parent_dir("\\\\srv\\share\\x"), Some("\\\\srv\\share".to_string()));
+        assert_eq!(
+            compute_parent_dir("\\\\srv\\share\\x"),
+            Some("\\\\srv\\share".to_string())
+        );
         assert_eq!(compute_parent_dir("\\\\srv\\share"), None); // UNC 共有ルート終端
         assert_eq!(compute_parent_dir("\\\\srv"), None); // UNC 不完全
     }
@@ -673,8 +740,14 @@ mod tests {
         assert_eq!(compute_parent_dir("C:/a\\b"), Some("C:\\a".to_string()));
         assert_eq!(compute_parent_dir("C:/a"), Some("C:\\".to_string()));
         assert_eq!(compute_parent_dir("C:/"), None); // `/` 表記のドライブルートも終端
-        assert_eq!(compute_parent_dir("//srv/share/x"), Some("\\\\srv\\share".to_string()));
-        assert_eq!(compute_parent_dir("\\\\srv/share\\x"), Some("\\\\srv\\share".to_string()));
+        assert_eq!(
+            compute_parent_dir("//srv/share/x"),
+            Some("\\\\srv\\share".to_string())
+        );
+        assert_eq!(
+            compute_parent_dir("\\\\srv/share\\x"),
+            Some("\\\\srv\\share".to_string())
+        );
         assert_eq!(compute_parent_dir("//srv/share"), None); // `/` 表記の UNC 共有ルートも終端
     }
 
@@ -724,13 +797,20 @@ mod tests {
         let p1 = s.parent_dir().expect("孫フォルダからは親が取れる");
         assert_eq!(p1, "C:\\a\\b");
         let t1 = s.navigate_folder(p1);
-        assert_eq!(s.view_kind(), ViewKind::Folder, "上昇しても folder のままである");
+        assert_eq!(
+            s.view_kind(),
+            ViewKind::Folder,
+            "上昇しても folder のままである"
+        );
         assert_eq!(s.folder_current_dir(), Some("C:\\a\\b"));
         let p2 = s.parent_dir().expect("さらに親が取れる");
         assert_eq!(p2, "C:\\a");
         let t2 = s.navigate_folder(p2);
         assert_eq!(s.folder_current_dir(), Some("C:\\a"));
-        assert!(t0 < t1 && t1 < t2, "遷移ごとに token が進む（遅着の旧結果を失効させる）");
+        assert!(
+            t0 < t1 && t1 < t2,
+            "遷移ごとに token が進む（遅着の旧結果を失効させる）"
+        );
     }
 
     /// ルート終端では親が無い（§6.2）。driver の `if let Some(parent)` がここで無反応に落ちる。
@@ -776,7 +856,11 @@ mod tests {
         s.set_results(vec![res("a"), res("b"), res("c"), res("d")]);
         assert_eq!(s.selected(), 3, "範囲内なら保たれる（先頭へは戻さない）");
         s.set_results(vec![res("a"), res("b")]);
-        assert_eq!(s.selected(), 1, "範囲外は末尾へクランプされる（0 ではない）");
+        assert_eq!(
+            s.selected(),
+            1,
+            "範囲外は末尾へクランプされる（0 ではない）"
+        );
     }
 
     /// 0 件が到着したときは選択の指す行が無い（§6.1 の 2 段目の末尾）。**上の「先頭へ戻さない」
@@ -893,8 +977,16 @@ mod tests {
 
     fn make_tools() -> Vec<OpenerTool> {
         vec![
-            OpenerTool { name: "VSCode".into(), exe: "Code.exe".into(), args: String::new() },
-            OpenerTool { name: "Terminal".into(), exe: "wt.exe".into(), args: "-d {path}".into() },
+            OpenerTool {
+                name: "VSCode".into(),
+                exe: "Code.exe".into(),
+                args: String::new(),
+            },
+            OpenerTool {
+                name: "Terminal".into(),
+                exe: "wt.exe".into(),
+                args: "-d {path}".into(),
+            },
         ]
     }
 
@@ -903,7 +995,10 @@ mod tests {
         let mut s = SearchState::new();
         s.set_query("code".into());
         s.set_results(vec![SearchResult {
-            name: "proj".into(), path: "C:\\proj".into(), is_folder: true, is_error: false,
+            name: "proj".into(),
+            path: "C:\\proj".into(),
+            is_folder: true,
+            is_error: false,
         }]);
         s.enter_tool("C:\\proj".into(), true, make_tools());
         assert_eq!(s.view_kind(), ViewKind::Tool);
@@ -924,7 +1019,10 @@ mod tests {
         let mut s = SearchState::new();
         s.set_query("code".into());
         s.set_results(vec![SearchResult {
-            name: "proj".into(), path: "C:\\proj".into(), is_folder: true, is_error: false,
+            name: "proj".into(),
+            path: "C:\\proj".into(),
+            is_folder: true,
+            is_error: false,
         }]);
         s.enter_tool("C:\\proj".into(), true, make_tools());
         assert_eq!(s.on_escape(), EscapeOutcome::RestoredFromTool);
@@ -939,12 +1037,18 @@ mod tests {
         let mut s = SearchState::new();
         s.set_query("pre".into());
         s.set_results(vec![SearchResult {
-            name: "dir".into(), path: "C:\\dir".into(), is_folder: true, is_error: false,
+            name: "dir".into(),
+            path: "C:\\dir".into(),
+            is_folder: true,
+            is_error: false,
         }]);
         s.enter_folder("C:\\dir".into());
         s.set_folder_filter("fil".into());
         s.set_results(vec![SearchResult {
-            name: "child".into(), path: "C:\\dir\\child".into(), is_folder: false, is_error: false,
+            name: "child".into(),
+            path: "C:\\dir\\child".into(),
+            is_folder: false,
+            is_error: false,
         }]);
         s.enter_tool("C:\\dir\\child".into(), false, make_tools());
         assert_eq!(s.view_kind(), ViewKind::Tool);
@@ -965,7 +1069,10 @@ mod tests {
     fn reset_clears_tool_slot() {
         let mut s = SearchState::new();
         s.set_results(vec![SearchResult {
-            name: "f".into(), path: "C:\\f".into(), is_folder: false, is_error: false,
+            name: "f".into(),
+            path: "C:\\f".into(),
+            is_folder: false,
+            is_error: false,
         }]);
         s.enter_tool("C:\\f".into(), false, make_tools());
         s.reset(); // §18.5: ホットキー再表示（resetForShow）でツール選択はリセット
@@ -978,7 +1085,10 @@ mod tests {
         // §18.5 入力無効の状態面: tool 中はどんな query でも Plain（instant/command 化しない）
         let mut s = SearchState::new();
         s.set_results(vec![SearchResult {
-            name: "f".into(), path: "C:\\f".into(), is_folder: false, is_error: false,
+            name: "f".into(),
+            path: "C:\\f".into(),
+            is_folder: false,
+            is_error: false,
         }]);
         s.enter_tool("C:\\f".into(), false, make_tools());
         s.set_query("@gh".into());

--- a/src-tauri/src/egui_shell/strings.rs
+++ b/src-tauri/src/egui_shell/strings.rs
@@ -97,8 +97,12 @@ pub fn launch_timeout(l: Language, detail: &str) -> String {
 /// {hotkey} は書式挿入。英語文言に句点は付かない＝i18n.ts 実物どおり）。
 pub fn hotkey_change_failed(l: Language, hotkey: &str) -> String {
     match l {
-        Language::Ja => format!("ホットキー ({hotkey}) の登録に失敗しました。元のホットキーを維持します"),
-        Language::En => format!("Failed to register hotkey ({hotkey}). Keeping the previous hotkey"),
+        Language::Ja => {
+            format!("ホットキー ({hotkey}) の登録に失敗しました。元のホットキーを維持します")
+        }
+        Language::En => {
+            format!("Failed to register hotkey ({hotkey}). Keeping the previous hotkey")
+        }
     }
 }
 
@@ -107,8 +111,12 @@ pub fn hotkey_change_failed(l: Language, hotkey: &str) -> String {
 /// `change_failed` と別キーなのは意図（旧ホットキー維持ではなく「開く手段が無い」告知）。
 pub fn hotkey_initial_failed(l: Language, hotkey: &str) -> String {
     match l {
-        Language::Ja => format!("ホットキー ({hotkey}) の登録に失敗しました。他のアプリが使用中の可能性があります"),
-        Language::En => format!("Failed to register hotkey ({hotkey}). Another application may be using it"),
+        Language::Ja => format!(
+            "ホットキー ({hotkey}) の登録に失敗しました。他のアプリが使用中の可能性があります"
+        ),
+        Language::En => {
+            format!("Failed to register hotkey ({hotkey}). Another application may be using it")
+        }
     }
 }
 
@@ -154,7 +162,11 @@ pub fn update_failed(l: Language, reason: &str) -> String {
         Language::Ja => "更新に失敗しました",
         Language::En => "Update failed",
     };
-    if reason.is_empty() { base.to_string() } else { format!("{base}: {reason}") }
+    if reason.is_empty() {
+        base.to_string()
+    } else {
+        format!("{base}: {reason}")
+    }
 }
 
 #[cfg(test)]
@@ -177,16 +189,26 @@ mod tests {
 
     #[test]
     fn params_are_interpolated_in_both_languages() {
-        assert_eq!(launch_failed(Language::Ja, " (exe not found)"), "起動に失敗しました (exe not found)");
+        assert_eq!(
+            launch_failed(Language::Ja, " (exe not found)"),
+            "起動に失敗しました (exe not found)"
+        );
         assert_eq!(launch_failed(Language::En, ""), "Launch failed");
-        assert_eq!(update_available(Language::En, "1.2.3"), "v1.2.3 is available");
+        assert_eq!(
+            update_available(Language::En, "1.2.3"),
+            "v1.2.3 is available"
+        );
     }
 
     #[test]
     fn timeout_wording_is_indeterminate_not_failure() {
         // spec 決定 8: timeout は「失敗」でなく「結果不明」。文言に「失敗」を含めない。
         assert!(!launch_timeout(Language::Ja, "").contains("失敗"));
-        assert!(!launch_timeout(Language::En, "").to_lowercase().contains("failed"));
+        assert!(
+            !launch_timeout(Language::En, "")
+                .to_lowercase()
+                .contains("failed")
+        );
     }
 
     /// #836: フォルダ展開中のプレースホルダ。撤去済み WebView2 の
@@ -200,14 +222,26 @@ mod tests {
     /// が末尾 `\` 付きの `C:\` を返す一方でフォルダ列挙は末尾 `\` 無しを返すため、両方が実際に来る。
     #[test]
     fn folder_hint_matches_webview2_parity() {
-        assert_eq!(folder_hint(Language::Ja, "C:\\Toolbox\\ghost-launcher"), "C:\\Toolbox\\ghost-launcher 内を検索...");
-        assert_eq!(folder_hint(Language::En, "C:\\Toolbox\\ghost-launcher"), "Search in C:\\Toolbox\\ghost-launcher...");
+        assert_eq!(
+            folder_hint(Language::Ja, "C:\\Toolbox\\ghost-launcher"),
+            "C:\\Toolbox\\ghost-launcher 内を検索..."
+        );
+        assert_eq!(
+            folder_hint(Language::En, "C:\\Toolbox\\ghost-launcher"),
+            "Search in C:\\Toolbox\\ghost-launcher..."
+        );
         // ドライブルート（`compute_parent_dir` が末尾 `\` を付けて返す形）
         assert_eq!(folder_hint(Language::Ja, "C:\\"), "C:\\ 内を検索...");
         assert_eq!(folder_hint(Language::En, "C:\\"), "Search in C:\\...");
         // UNC 共有ルート（`compute_parent_dir` の終端）
-        assert_eq!(folder_hint(Language::Ja, "\\\\srv\\share"), "\\\\srv\\share 内を検索...");
-        assert_eq!(folder_hint(Language::En, "\\\\srv\\share"), "Search in \\\\srv\\share...");
+        assert_eq!(
+            folder_hint(Language::Ja, "\\\\srv\\share"),
+            "\\\\srv\\share 内を検索..."
+        );
+        assert_eq!(
+            folder_hint(Language::En, "\\\\srv\\share"),
+            "Search in \\\\srv\\share..."
+        );
     }
 
     /// 三点が ASCII であることを、上のリテラル比較とは**独立に**測る（リテラルどうしの比較は、

--- a/src-tauri/src/egui_shell/view.rs
+++ b/src-tauri/src/egui_shell/view.rs
@@ -116,8 +116,17 @@ fn draw_toast_button(
     *cursor_x -= w + 8.0;
     let id = ui.id().with(("toast_btn", label));
     let response = ui.interact(rect, id, egui::Sense::click());
-    let color = if enabled { theme.name_color } else { theme.path_color };
-    ui.painter().rect_stroke(rect, 4.0, egui::Stroke::new(1.0, color), egui::StrokeKind::Inside);
+    let color = if enabled {
+        theme.name_color
+    } else {
+        theme.path_color
+    };
+    ui.painter().rect_stroke(
+        rect,
+        4.0,
+        egui::Stroke::new(1.0, color),
+        egui::StrokeKind::Inside,
+    );
     ui.painter().galley(
         egui::pos2(rect.left() + 8.0, center_y - galley.size().y / 2.0),
         galley,
@@ -189,7 +198,14 @@ fn read_pre_widget_input(ctx: &egui::Context) -> PreWidgetInput {
     let right = ctx.input(|i| i.key_pressed(egui::Key::ArrowRight));
     let left = ctx.input(|i| i.key_pressed(egui::Key::ArrowLeft));
 
-    PreWidgetInput { focused, escape, nav_down, nav_up, right, left }
+    PreWidgetInput {
+        focused,
+        escape,
+        nav_down,
+        nav_up,
+        right,
+        left,
+    }
 }
 
 /// pre-widget 入力の読み取り値（段 13）。`nav_down`/`nav_up`/`right`/`left` は
@@ -502,9 +518,9 @@ impl EguiView for SearchWindowView {
             self.controller.is_launching(),
             self.controller.notice_message().is_some(),
         ) {
-            Some(crate::egui_shell::OverlayKind::Indexing) => {
-                Some(crate::egui_shell::ui_strings::indexing_hint(self.controller.lang()).to_string())
-            }
+            Some(crate::egui_shell::OverlayKind::Indexing) => Some(
+                crate::egui_shell::ui_strings::indexing_hint(self.controller.lang()).to_string(),
+            ),
             Some(crate::egui_shell::OverlayKind::Launching) => {
                 Some(crate::egui_shell::ui_strings::launching(self.controller.lang()).to_string())
             }
@@ -580,12 +596,26 @@ impl EguiView for SearchWindowView {
             let mut cursor_x = rect.right() - 8.0;
             let btn_y = rect.center().y;
             let dismiss_label = crate::egui_shell::ui_strings::update_dismiss(l);
-            if draw_toast_button(ui, &mut cursor_x, btn_y, dismiss_label, row.buttons_enabled, theme) {
+            if draw_toast_button(
+                ui,
+                &mut cursor_x,
+                btn_y,
+                dismiss_label,
+                row.buttons_enabled,
+                theme,
+            ) {
                 toast_action = Some(ToastAction::Dismiss);
             }
             if row.show_install {
                 let install_label = crate::egui_shell::ui_strings::update_install_now(l);
-                if draw_toast_button(ui, &mut cursor_x, btn_y, install_label, row.buttons_enabled, theme) {
+                if draw_toast_button(
+                    ui,
+                    &mut cursor_x,
+                    btn_y,
+                    install_label,
+                    row.buttons_enabled,
+                    theme,
+                ) {
                     toast_action = Some(ToastAction::Install);
                 }
             }

--- a/src-tauri/src/egui_shell/visual.rs
+++ b/src-tauri/src/egui_shell/visual.rs
@@ -142,7 +142,6 @@ mod tests {
         VisualConfig::default()
     }
 
-
     /// **本 PR が存在する理由の不変条件**（spec 決定 4 の効果）: 1 つの snapshot の中で、
     /// 行高（metrics）と文字サイズ（row）が**同じ font_size** から導かれる。別々に lock を
     /// 取っていた頃は、間に config 適用が挟まると新 font を旧行高で描く 1 フレームが生じえた。
@@ -172,7 +171,10 @@ mod tests {
         v.text_color = "not-a-color".into();
         let bad = visual_snapshot(&v, true, "");
         let d = VisualConfig::default();
-        assert_eq!(bad.row.name_color, egui::Color32::from_hex(&d.text_color).unwrap());
+        assert_eq!(
+            bad.row.name_color,
+            egui::Color32::from_hex(&d.text_color).unwrap()
+        );
     }
 
     /// #724: ホバー色は別の config キーを持たず、同じフレームの選択色から 50% 透明色を導く。
@@ -196,7 +198,10 @@ mod tests {
         let same = visual_snapshot(&v, true, &v.font_family);
         assert!(same.font_family_changed.is_none());
         let diff = visual_snapshot(&v, true, "Other");
-        assert_eq!(diff.font_family_changed.as_deref(), Some(v.font_family.as_str()));
+        assert_eq!(
+            diff.font_family_changed.as_deref(),
+            Some(v.font_family.as_str())
+        );
     }
 
     /// 背景色の parse は **1 本**（`Color32::from_hex`）になり、`#RGB` も通る（#680 の 1）。
@@ -205,7 +210,10 @@ mod tests {
     #[test]
     fn background_color_accepts_short_hex_and_falls_back_to_config_default() {
         assert_eq!(background_color("#FFF"), egui::Color32::WHITE);
-        assert_eq!(background_color("#4A2B5C"), egui::Color32::from_rgb(0x4A, 0x2B, 0x5C));
+        assert_eq!(
+            background_color("#4A2B5C"),
+            egui::Color32::from_rgb(0x4A, 0x2B, 0x5C)
+        );
         assert_eq!(background_color("#ffffff"), egui::Color32::WHITE);
         // 旧 `config_watcher::parse_hex_color` の 5 テストが固定していた命題（撤去に伴い移設）:
         // 不正形はいずれも既定色へ落ちる。**リテラルを再手打ちせず既定から導く**。

--- a/src-tauri/src/egui_shell/window_coordinator.rs
+++ b/src-tauri/src/egui_shell/window_coordinator.rs
@@ -101,7 +101,15 @@ pub(crate) fn apply_native_background(window: &tauri::Window, color: egui::Color
 pub(crate) fn read_background(app: &tauri::AppHandle) -> egui::Color32 {
     let hex = app
         .try_state::<crate::AppState>()
-        .map(|s| s.engine.lock().unwrap().config().visual.background_color.clone())
+        .map(|s| {
+            s.engine
+                .lock()
+                .unwrap()
+                .config()
+                .visual
+                .background_color
+                .clone()
+        })
         .unwrap_or_else(|| super::visual::default_visual().background_color.clone());
     super::visual::background_color(&hex)
 }
@@ -131,7 +139,14 @@ fn position_on_target_monitor(
     // Read follow_cursor_monitor from Engine config (refreshed on every show).
     let follow_cursor = app_handle
         .try_state::<crate::AppState>()
-        .map(|s| s.engine.lock().unwrap().config().general.follow_cursor_monitor)
+        .map(|s| {
+            s.engine
+                .lock()
+                .unwrap()
+                .config()
+                .general
+                .follow_cursor_monitor
+        })
         .unwrap_or_else(|| GeneralConfig::default().follow_cursor_monitor);
 
     // Determine target monitor work area.
@@ -143,7 +158,9 @@ fn position_on_target_monitor(
     let Some(target_wa) = target_wa else { return };
 
     // Get current window size (physical) for centering/clamping.
-    let Ok(win_size) = main.outer_size() else { return };
+    let Ok(win_size) = main.outer_size() else {
+        return;
+    };
     let win_w = win_size.width as i32;
     let win_h = win_size.height as i32;
 
@@ -189,7 +206,10 @@ pub(crate) fn show_egui_main(app: &tauri::AppHandle, t0: Instant) {
         let width = window
             .inner_size()
             .ok()
-            .map(|s| s.to_logical::<f64>(window.scale_factor().unwrap_or(1.0)).width)
+            .map(|s| {
+                s.to_logical::<f64>(window.scale_factor().unwrap_or(1.0))
+                    .width
+            })
             // **ここは `appearance.window_width` の消費者ではない**——読み元は OS の
             // `inner_size()` で、既定幅 600 と一致しているのは偶然である。参照へ寄せない理由は
             // `docs/adr/ADR-config-default-fallback-references.md`。読み元自体は #824 で決める。
@@ -249,11 +269,14 @@ pub(crate) fn show_egui_main(app: &tauri::AppHandle, t0: Instant) {
             .map(|s| s.engine.lock().unwrap().config().general.ime_off_on_show)
             .unwrap_or_else(|| GeneralConfig::default().ime_off_on_show);
         if ime_control
-            && let Some(bridge) = app.try_state::<std::sync::Mutex<crate::platform::PlatformBridge>>()
+            && let Some(bridge) =
+                app.try_state::<std::sync::Mutex<crate::platform::PlatformBridge>>()
             && let Ok(b) = bridge.lock()
             && let Ok(hwnd) = window.hwnd()
         {
-            b.send_command(crate::platform::PlatformCommand::TurnOffIme(hwnd.0 as usize));
+            b.send_command(crate::platform::PlatformCommand::TurnOffIme(
+                hwnd.0 as usize,
+            ));
             crate::trace_main("egui_show:ime_control", serde_json::json!({}));
         }
     }
@@ -301,7 +324,10 @@ pub(crate) fn hide_egui_main(app: &tauri::AppHandle) {
         // 呼び出し側に置く（spec 決定 7）。results の hide は 2 経路あり
         // （ここと同モジュールの drive_results_window）、trace は要求レベルゆえ
         // 既に隠れていても出る——smoke は presence のみを assert する。
-        crate::trace_main("egui_results:hide", serde_json::json!({ "from": "hide_main" }));
+        crate::trace_main(
+            "egui_results:hide",
+            serde_json::json!({ "from": "hide_main" }),
+        );
     }
     // hide 後に working set を trim する（**main の** hide 経路の合流点＝ここが唯一の呼び出し元・
     // #532 SU6.5）。results 単独 hide（drive_results_window）では main が可視のままゆえ trim しないのが正しい。
@@ -389,9 +415,11 @@ pub(crate) fn position_results_below_main(app: &tauri::AppHandle) -> Option<i32>
         .try_state::<crate::AppState>()
         .map(|s| s.engine.lock().unwrap().config().visual.window_gap)
         .unwrap_or_else(|| super::visual::default_visual().window_gap);
-    let (Ok(pos), Ok(size), Ok(scale)) =
-        (main.outer_position(), main.outer_size(), main.scale_factor())
-    else {
+    let (Ok(pos), Ok(size), Ok(scale)) = (
+        main.outer_position(),
+        main.outer_size(),
+        main.scale_factor(),
+    ) else {
         return None;
     };
     // 算術は layout::results_top_y（純粋核・#752 C1）。Win32 の読みはここで 1 回だけ行う。
@@ -433,7 +461,14 @@ fn results_available_height(_app: &tauri::AppHandle, _top_y: i32) -> Option<f64>
 /// （#749）——引数を増やすほど、呼び出し側で読み点の違う値を並べて書きたくなる。
 fn max_results(app: &tauri::AppHandle) -> u32 {
     app.try_state::<crate::AppState>()
-        .map(|s| s.engine.lock().unwrap().config().appearance.effective_visible_rows() as u32)
+        .map(|s| {
+            s.engine
+                .lock()
+                .unwrap()
+                .config()
+                .appearance
+                .effective_visible_rows() as u32
+        })
         .unwrap_or_else(|| AppearanceConfig::default().effective_visible_rows() as u32)
 }
 
@@ -550,7 +585,9 @@ mod tests {
     /// `background_color_premultiplies_alpha_rather_than_ignoring_it` が測る（そちらが正本）。
     #[test]
     fn native_brush_forces_opaque_alpha() {
-        let c = native_brush_color(egui::Color32::from_rgba_premultiplied(0x12, 0x34, 0x56, 0x80));
+        let c = native_brush_color(egui::Color32::from_rgba_premultiplied(
+            0x12, 0x34, 0x56, 0x80,
+        ));
         assert_eq!((c.0, c.1, c.2, c.3), (0x12, 0x34, 0x56, 0xff));
     }
 

--- a/src-tauri/src/icon.rs
+++ b/src-tauri/src/icon.rs
@@ -10,11 +10,11 @@ use serde::{Deserialize, Serialize};
 use std::sync::Mutex;
 
 use snotra_core::binfmt::BinFile;
+use windows::Win32::Foundation::GetLastError;
 use windows::Win32::Graphics::Gdi::{
     BI_RGB, BITMAPINFO, BITMAPINFOHEADER, CreateCompatibleDC, DIB_RGB_COLORS, DeleteDC,
     DeleteObject, GetDIBits, SelectObject,
 };
-use windows::Win32::Foundation::GetLastError;
 use windows::Win32::Storage::FileSystem::{FILE_FLAGS_AND_ATTRIBUTES, SearchPathW};
 use windows::Win32::UI::Shell::{SHFILEINFOW, SHGFI_ICON, SHGFI_SMALLICON, SHGetFileInfoW};
 use windows::Win32::UI::WindowsAndMessaging::{DestroyIcon, GetIconInfo, HICON, ICONINFO};
@@ -484,7 +484,11 @@ mod tests {
                     if g.is_none() {
                         let bf = BinFile::new_in(&dir2, ICON_MAGIC, ICON_VERSION, "icons.bin");
                         let data: IconCacheData = bf.load().unwrap_or_default();
-                        *g = Some(IconCache { data, cap: 100, dirty: false });
+                        *g = Some(IconCache {
+                            data,
+                            cap: 100,
+                            dirty: false,
+                        });
                         break;
                     }
                     drop(g);
@@ -516,8 +520,7 @@ mod tests {
     /// issue #522: 無効化後の事後条件（ファイル不在 かつ メモリ None）の決定論検証。
     #[test]
     fn invalidate_removes_file_and_clears_memory() {
-        let dir = std::env::temp_dir()
-            .join(format!("snotra_icon_522_det_{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("snotra_icon_522_det_{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
 
@@ -536,7 +539,10 @@ mod tests {
             Some(BinFile::new_in(&dir, ICON_MAGIC, ICON_VERSION, "icons.bin")),
         );
 
-        assert!(!dir.join("icons.bin").exists(), "icons.bin が削除されている");
+        assert!(
+            !dir.join("icons.bin").exists(),
+            "icons.bin が削除されている"
+        );
         assert!(state.lock().unwrap().is_none(), "メモリキャッシュが None");
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -606,7 +612,10 @@ mod tests {
         assert_eq!(evicted, 1, "超過 1 件を退避");
         assert_eq!(cache.data.png.len(), 2);
         assert!(cache.get("a").is_none(), "最古 a が退避");
-        assert!(cache.dirty, "退避したら dirty を立てる（永続側も頭打ちにする）");
+        assert!(
+            cache.dirty,
+            "退避したら dirty を立てる（永続側も頭打ちにする）"
+        );
     }
 
     #[test]
@@ -616,7 +625,10 @@ mod tests {
         cache.dirty = false;
         let evicted = cache.enforce_cap();
         assert_eq!(evicted, 0, "cap 以内なら退避なし");
-        assert!(!cache.dirty, "退避なしなら dirty を立てない（無駄な save を避ける）");
+        assert!(
+            !cache.dirty,
+            "退避なしなら dirty を立てない（無駄な save を避ける）"
+        );
     }
 
     #[test]
@@ -639,7 +651,10 @@ mod tests {
 
         let valid: std::collections::HashSet<String> = ["b".to_string()].into_iter().collect();
         cache.retain_paths(&valid);
-        assert!(cache.data.png.len() <= cache.cap, "retain 後も cap 不変条件を満たす");
+        assert!(
+            cache.data.png.len() <= cache.cap,
+            "retain 後も cap 不変条件を満たす"
+        );
         assert!(cache.get("a").is_none());
         assert!(cache.get("b").is_some());
     }
@@ -685,7 +700,10 @@ mod tests {
                     let t = Instant::now();
                     let out = extract_png(p);
                     us.push(t.elapsed().as_micros());
-                    assert!(out.is_ok(), "{p} の抽出が失敗（テスト前提の実在パス）: {out:?}");
+                    assert!(
+                        out.is_ok(),
+                        "{p} の抽出が失敗（テスト前提の実在パス）: {out:?}"
+                    );
                 }
             }
             println!(
@@ -750,9 +768,8 @@ mod tests {
         )
         .expect("serialize legacy");
 
-        let restored: IconCacheData =
-            try_deserialize_with_header(&bytes, ICON_MAGIC, ICON_VERSION)
-                .expect("deserialize into IndexMap-backed IconCacheData");
+        let restored: IconCacheData = try_deserialize_with_header(&bytes, ICON_MAGIC, ICON_VERSION)
+            .expect("deserialize into IndexMap-backed IconCacheData");
         assert_eq!(restored.png.len(), 2);
         assert_eq!(restored.png.get("c:/a.exe"), Some(&vec![1, 2, 3]));
         assert_eq!(restored.png.get("c:/b.exe"), Some(&vec![4, 5]));

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -20,8 +20,8 @@ mod state;
 mod trace;
 mod working_set;
 
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Instant;
 
 use serde_json::json;
@@ -90,17 +90,17 @@ fn wait_alt_release_or_timeout() {
 #[cfg(windows)]
 fn send_alt_key_up() {
     use windows::Win32::UI::Input::KeyboardAndMouse::{
-        INPUT, SendInput, VK_LMENU, VK_MENU, VK_RMENU, VIRTUAL_KEY,
+        INPUT, SendInput, VIRTUAL_KEY, VK_LMENU, VK_MENU, VK_RMENU,
     };
 
     const VK_MASK: VIRTUAL_KEY = VIRTUAL_KEY(0xE8); // unassigned — safe dummy key
 
     let inputs = [
-        make_key_input(VK_MASK, false),  // mask key down
-        make_key_input(VK_MASK, true),   // mask key up
-        make_key_input(VK_MENU, true),   // Alt (generic) up
-        make_key_input(VK_LMENU, true),  // Left Alt up
-        make_key_input(VK_RMENU, true),  // Right Alt up
+        make_key_input(VK_MASK, false), // mask key down
+        make_key_input(VK_MASK, true),  // mask key up
+        make_key_input(VK_MENU, true),  // Alt (generic) up
+        make_key_input(VK_LMENU, true), // Left Alt up
+        make_key_input(VK_RMENU, true), // Right Alt up
     ];
     unsafe {
         let _ = SendInput(&inputs, std::mem::size_of::<INPUT>() as i32);
@@ -116,7 +116,7 @@ fn make_key_input(
     is_up: bool,
 ) -> windows::Win32::UI::Input::KeyboardAndMouse::INPUT {
     use windows::Win32::UI::Input::KeyboardAndMouse::{
-        INPUT, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP, KEYBD_EVENT_FLAGS,
+        INPUT, INPUT_KEYBOARD, KEYBD_EVENT_FLAGS, KEYBDINPUT, KEYEVENTF_KEYUP,
     };
     let mut input = INPUT {
         r#type: INPUT_KEYBOARD,
@@ -160,7 +160,12 @@ fn main() {
                 s.cache_save_ms,
             );
         }
-        (result.entries, false, result.cached_masks, result.rescan_task)
+        (
+            result.entries,
+            false,
+            result.cached_masks,
+            result.rescan_task,
+        )
     };
 
     // PATH エントリのスキャン + マージ
@@ -207,10 +212,12 @@ fn main() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .plugin(tauri_plugin_single_instance::init(move |app, _args, _cwd| {
-            // When a second instance tries to start, show the main (egui) window.
-            egui_shell::show_egui_main(app, Instant::now());
-        }))
+        .plugin(tauri_plugin_single_instance::init(
+            move |app, _args, _cwd| {
+                // When a second instance tries to start, show the main (egui) window.
+                egui_shell::show_egui_main(app, Instant::now());
+            },
+        ))
         .manage(app_state)
         .manage(icon_cache_state)
         .manage(SettingsProcessState::default())
@@ -265,7 +272,9 @@ fn main() {
             // setup_hotkey_listener より前に登録される位置なので emit を取りこぼさない
             //（この egui ブロック自体が setup_platform_thread の直後・hotkey listener の前）。
             egui_shell::register_initial_hotkey_failure_listener(&app_handle);
-            app.manage(egui_shell::UpdaterUiState(std::sync::Mutex::new(Default::default())));
+            app.manage(egui_shell::UpdaterUiState(std::sync::Mutex::new(
+                Default::default(),
+            )));
             // main と results 窓が共有する一方向フローの入れ物（#646 PR2）。
             app.manage(egui_shell::ResultsShared::default());
             egui_shell::spawn_update_check(&app_handle);
@@ -313,8 +322,13 @@ fn main() {
 /// creation, and manage the resulting `PlatformBridge` once ready. The tray
 /// is NOT created here; `setup_tray` sends `SetTrayVisible` later, after all
 /// windows and listeners are ready (SPEC §7.5).
-fn setup_platform_thread(app_handle: &AppHandle, hotkey_config: HotkeyConfig, initial_language: Language) {
-    let platform_pending = PlatformBridge::begin(app_handle.clone(), hotkey_config, initial_language);
+fn setup_platform_thread(
+    app_handle: &AppHandle,
+    hotkey_config: HotkeyConfig,
+    initial_language: Language,
+) {
+    let platform_pending =
+        PlatformBridge::begin(app_handle.clone(), hotkey_config, initial_language);
 
     // Win32 init finishes in a few ms; by the time windows are created it is already done.
     if let Some(bridge) = platform_pending.and_then(PlatformBridgePending::wait) {
@@ -472,7 +486,10 @@ fn setup_config_watcher(app_handle: &AppHandle) {
 /// キャッシュヒット時のみ `Some` で渡される背景再スキャンタスクを低優先度スレッド
 /// で実行する（SPEC §3.3 ハイブリッド方式）。ロジックは snotra-core、spawn と結果の
 /// 後始末（アイコン無効化）は src-tauri の責務。
-fn setup_background_rescan(app_handle: &AppHandle, rescan_task: Option<indexer::BackgroundRescanTask>) {
+fn setup_background_rescan(
+    app_handle: &AppHandle,
+    rescan_task: Option<indexer::BackgroundRescanTask>,
+) {
     if let Some(task) = rescan_task {
         let handle_for_rescan = app_handle.clone();
         let _ = std::thread::Builder::new()

--- a/src-tauri/src/monitor.rs
+++ b/src-tauri/src/monitor.rs
@@ -6,8 +6,8 @@
 use windows::Win32::Foundation::{HWND, POINT};
 #[cfg(windows)]
 use windows::Win32::Graphics::Gdi::{
-    GetMonitorInfoW, MonitorFromPoint, MonitorFromWindow, MONITORINFO,
-    MONITOR_DEFAULTTONEAREST, MONITOR_DEFAULTTOPRIMARY,
+    GetMonitorInfoW, MONITOR_DEFAULTTONEAREST, MONITOR_DEFAULTTOPRIMARY, MONITORINFO,
+    MonitorFromPoint, MonitorFromWindow,
 };
 #[cfg(windows)]
 use windows::Win32::UI::WindowsAndMessaging::GetCursorPos;

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -1,5 +1,5 @@
-pub(crate) mod tray;
 pub mod hotkey;
+pub(crate) mod tray;
 mod wndproc;
 
 use std::sync::mpsc::{self, Receiver, Sender};
@@ -91,7 +91,10 @@ impl PlatformBridge {
             })
             .ok()?;
 
-        Some(PlatformBridgePending { command_tx, thread_id_rx })
+        Some(PlatformBridgePending {
+            command_tx,
+            thread_id_rx,
+        })
     }
 
     pub fn send_command(&self, command: PlatformCommand) {
@@ -282,8 +285,7 @@ fn process_commands(
                 let registered = hotkey::register(current_hotkey)
                     && !crate::trace::env_flag("SNOTRA_FAKE_INITIAL_HOTKEY_FAILURE");
                 if !registered {
-                    let hotkey_str =
-                        format!("{}+{}", current_hotkey.modifier, current_hotkey.key);
+                    let hotkey_str = format!("{}+{}", current_hotkey.modifier, current_hotkey.key);
                     // 独立イベント名で emit する（#673 spec 決定 3）。旧実装は汎用チャネル
                     // 1 本に `{event, hotkey}` を詰めており、内側種別は最後までこの 1 種
                     // だけだった——袋の中身は grep に映らず、受け口の有無を機構で問えない

--- a/src-tauri/src/platform/tray.rs
+++ b/src-tauri/src/platform/tray.rs
@@ -2,7 +2,8 @@ use tauri::{AppHandle, Emitter, Manager};
 use windows::Win32::Foundation::{HWND, LPARAM, WPARAM};
 use windows::Win32::UI::Shell::{
     ExtractIconW, NIF_ICON, NIF_INFO, NIF_MESSAGE, NIF_SHOWTIP, NIF_TIP, NIIF_WARNING, NIM_ADD,
-    NIM_DELETE, NIM_MODIFY, NIM_SETVERSION, NOTIFYICON_VERSION_4, NOTIFYICONDATAW, Shell_NotifyIconW,
+    NIM_DELETE, NIM_MODIFY, NIM_SETVERSION, NOTIFYICON_VERSION_4, NOTIFYICONDATAW,
+    Shell_NotifyIconW,
 };
 use windows::Win32::UI::WindowsAndMessaging::{
     AppendMenuW, CreatePopupMenu, DestroyIcon, DestroyMenu, GetCursorPos, GetMessageTime, HICON,
@@ -48,11 +49,7 @@ fn format_recent_history_label(item: &snotra_core::ui_types::SearchResult) -> St
     truncated
 }
 
-pub(super) fn handle_menu_command(
-    wparam: WPARAM,
-    app_handle: &AppHandle,
-    tray: &Option<TrayIcon>,
-) {
+pub(super) fn handle_menu_command(wparam: WPARAM, app_handle: &AppHandle, tray: &Option<TrayIcon>) {
     let id = wparam.0 & 0xFFFF;
     match id {
         ID_MENU_SETTINGS => {
@@ -166,7 +163,11 @@ enum RecentMenuEntry {
 
 /// `build_recent_menu_entries` の戻り値: (メニュー項目リスト, 0/1ツール項目の
 /// パス一覧 `recent_menu_paths`, 2+ツール項目の選択情報一覧 `recent_menu_tools`)。
-type RecentMenuBuild = (Vec<RecentMenuEntry>, Vec<String>, Vec<(String, String, String)>);
+type RecentMenuBuild = (
+    Vec<RecentMenuEntry>,
+    Vec<String>,
+    Vec<(String, String, String)>,
+);
 
 /// `recent`（履歴一覧）と `resolve_tools`（パス→ツール一覧の解決）から、純データと
 /// してのメニュー項目リストと ID→(path[, exe, args]) の対応表を組み立てる。
@@ -208,7 +209,10 @@ fn build_recent_menu_entries(
         } else {
             // 0/1 ツール: 直接起動（既存挙動）
             let direct_id = ID_MENU_RECENT_BASE + recent_menu_paths.len();
-            entries.push(RecentMenuEntry::Direct { id: direct_id, label });
+            entries.push(RecentMenuEntry::Direct {
+                id: direct_id,
+                label,
+            });
             recent_menu_paths.push(item.path.clone());
         }
     }
@@ -222,8 +226,10 @@ unsafe fn draw_recent_menu(hmenu: HMENU, entries: &[RecentMenuEntry], no_history
     for entry in entries {
         match entry {
             RecentMenuEntry::Empty => {
-                let text: Vec<u16> =
-                    no_history_label.encode_utf16().chain(std::iter::once(0)).collect();
+                let text: Vec<u16> = no_history_label
+                    .encode_utf16()
+                    .chain(std::iter::once(0))
+                    .collect();
                 let _ = unsafe { AppendMenuW(hmenu, MF_GRAYED, 0, PCWSTR(text.as_ptr())) };
             }
             RecentMenuEntry::Direct { id, label } => {
@@ -238,11 +244,15 @@ unsafe fn draw_recent_menu(hmenu: HMENU, entries: &[RecentMenuEntry], no_history
                     let text: Vec<u16> = name.encode_utf16().chain(std::iter::once(0)).collect();
                     let _ = unsafe { AppendMenuW(hsub, MF_STRING, *id, PCWSTR(text.as_ptr())) };
                 }
-                let label_wide: Vec<u16> =
-                    label.encode_utf16().chain(std::iter::once(0)).collect();
+                let label_wide: Vec<u16> = label.encode_utf16().chain(std::iter::once(0)).collect();
                 // MF_POPUP: uIDNewItem に hsub のハンドル値を渡す
                 let _ = unsafe {
-                    AppendMenuW(hmenu, MF_POPUP, hsub.0 as usize, PCWSTR(label_wide.as_ptr()))
+                    AppendMenuW(
+                        hmenu,
+                        MF_POPUP,
+                        hsub.0 as usize,
+                        PCWSTR(label_wide.as_ptr()),
+                    )
                 };
             }
         }
@@ -499,8 +509,8 @@ fn load_tray_icon_from_exe() -> Option<HICON> {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_recent_menu_entries, format_recent_history_label, RecentMenuEntry,
-        ID_MENU_RECENT_BASE, ID_MENU_TOOL_BASE,
+        ID_MENU_RECENT_BASE, ID_MENU_TOOL_BASE, RecentMenuEntry, build_recent_menu_entries,
+        format_recent_history_label,
     };
     use snotra_core::config::Language;
     use snotra_core::ui_types::SearchResult;
@@ -522,7 +532,8 @@ mod tests {
 
     #[test]
     fn name_equal_to_path_dedupes_to_path_only() {
-        let label = format_recent_history_label(&item("C:/Users/foo/bar.exe", "C:/Users/foo/bar.exe"));
+        let label =
+            format_recent_history_label(&item("C:/Users/foo/bar.exe", "C:/Users/foo/bar.exe"));
         assert_eq!(label, "C:/Users/foo/bar.exe");
     }
 
@@ -589,7 +600,10 @@ mod tests {
                 assert_eq!(*id, ID_MENU_RECENT_BASE);
                 assert_eq!(label, "bar.exe - C:/Users/foo/bar.exe");
             }
-            other => panic!("expected a single Direct entry, got {} entries", other.len()),
+            other => panic!(
+                "expected a single Direct entry, got {} entries",
+                other.len()
+            ),
         }
         assert_eq!(paths, vec!["C:/Users/foo/bar.exe".to_string()]);
         assert!(tools.is_empty());
@@ -601,10 +615,19 @@ mod tests {
         let items = vec![item("bar.exe", "C:/Users/foo/bar.exe")];
         let (entries, paths, tools) = build_recent_menu_entries(
             &items,
-            |_| vec![("Notepad".to_string(), "notepad.exe".to_string(), String::new())],
+            |_| {
+                vec![(
+                    "Notepad".to_string(),
+                    "notepad.exe".to_string(),
+                    String::new(),
+                )]
+            },
             Language::En,
         );
-        assert!(matches!(entries.as_slice(), [RecentMenuEntry::Direct { .. }]));
+        assert!(matches!(
+            entries.as_slice(),
+            [RecentMenuEntry::Direct { .. }]
+        ));
         assert_eq!(paths.len(), 1);
         assert!(tools.is_empty());
     }
@@ -616,7 +639,11 @@ mod tests {
             &items,
             |_| {
                 vec![
-                    ("Notepad".to_string(), "notepad.exe".to_string(), String::new()),
+                    (
+                        "Notepad".to_string(),
+                        "notepad.exe".to_string(),
+                        String::new(),
+                    ),
                     ("VS Code".to_string(), "code.exe".to_string(), String::new()),
                 ]
             },
@@ -631,11 +658,21 @@ mod tests {
                 assert_eq!(items[1].1, "Notepad");
                 assert_eq!(items[2].1, "VS Code");
             }
-            other => panic!("expected a single Submenu entry, got {} entries", other.len()),
+            other => panic!(
+                "expected a single Submenu entry, got {} entries",
+                other.len()
+            ),
         }
         assert!(paths.is_empty()); // サブメニュー項目は recent_menu_tools 側に積まれる
         assert_eq!(tools.len(), 3);
-        assert_eq!(tools[0], ("C:/Users/foo/bar.exe".to_string(), String::new(), String::new()));
+        assert_eq!(
+            tools[0],
+            (
+                "C:/Users/foo/bar.exe".to_string(),
+                String::new(),
+                String::new()
+            )
+        );
         assert_eq!(tools[1].1, "notepad.exe");
         assert_eq!(tools[2].1, "code.exe");
     }
@@ -644,10 +681,7 @@ mod tests {
     fn tool_ids_accumulate_across_multiple_submenu_items() {
         // 2 項目ともサブメニューになる場合、ID が項目をまたいで連番であることを確認する
         // （show_recent_history_menu の self.recent_menu_tools と同じ蓄積順序）。
-        let items = vec![
-            item("a.exe", "C:/a.exe"),
-            item("b.exe", "C:/b.exe"),
-        ];
+        let items = vec![item("a.exe", "C:/a.exe"), item("b.exe", "C:/b.exe")];
         let two_tools = |_: &str| {
             vec![
                 ("T1".to_string(), "t1.exe".to_string(), String::new()),

--- a/src-tauri/src/platform/wndproc.rs
+++ b/src-tauri/src/platform/wndproc.rs
@@ -1,8 +1,6 @@
 use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
 use windows::Win32::System::Threading::GetCurrentThreadId;
-use windows::Win32::UI::WindowsAndMessaging::{
-    DefWindowProcW, PostThreadMessageW, WM_CONTEXTMENU,
-};
+use windows::Win32::UI::WindowsAndMessaging::{DefWindowProcW, PostThreadMessageW, WM_CONTEXTMENU};
 
 use super::WM_TRAY_ICON;
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -55,7 +55,11 @@ mod tests {
 
     fn test_state() -> AppState {
         AppState {
-            engine: Mutex::new(Engine::new(Vec::new(), HistoryStore::load(), Config::default())),
+            engine: Mutex::new(Engine::new(
+                Vec::new(),
+                HistoryStore::load(),
+                Config::default(),
+            )),
             indexing: AtomicBool::new(false),
             index_build_started: AtomicBool::new(false),
             main_visible: AtomicBool::new(false),


### PR DESCRIPTION
## 概要

`cargo fmt --all` の出力をそのまま当てただけの PR です。**機械的整形以外を一切含みません**（63 ファイルすべてが `.rs`）。

#858 の 2 本のうち **1 本目**。ゲート（CI + PostToolUse hook）と判断の記録は PR2 で入れます。

## なぜ整形だけを分けるか

このリポジトリは **squash 専用**です（`allow_merge_commit: false` / `allow_rebase_merge: false` を実測）。整形と機構を 1 つの PR で出すと、squash コミットが CI・hook・docs を同梱して**意味を変える変更を含む**ため、`.git-blame-ignore-revs` に載せられなくなります。

一方、feature ブランチ上の整形コミットの SHA は **main の blame グラフに現れない**ので、それを記録しても no-op です。しかも**存在しない rev を無視しても git は静かに成功する**ため、腐っても誰も気づきません。

→ **整形だけの PR を先にマージし、その squash SHA を PR2 の `.git-blame-ignore-revs` へ書く。** SHA は本 PR がマージされるまで観測できないので、この順序は避けられません。判断の記録は PR2 に入る `docs/adr/ADR-rustfmt-gate.md`。

## 背景（drift の由来）

同一の rustfmt（`1.8.0-stable`）で過去コミットを検査した実測:

| コミット | 日付 | `cargo fmt --all -- --check` のハンク数 |
|---|---|---|
| `5589c13` init | 2026-02-16 | **0** |
| `92804be` | 2026-02-17 | **0** |
| `fd6cd42` | 2026-04-02 | 193 |
| `a1a95a7` | 2026-08-01 | **460** |

**初期コミットが drift 0 になります。** このリポジトリの様式は最初から rustfmt 既定そのもので、2026-02-17〜04-02 のどこかで `cargo fmt` を回す習慣が途切れ、以後 monotonic に積み上がりました。整形は当時**別のマシンで**行われていたため、リポジトリ側には痕跡が残っていません（`cargo fmt` は追跡ファイルに全履歴を通じて 0 件）。

**ゆえにこれは新しい様式の導入ではなく、本来の様式への復旧です。**

対立仮説も否定済みです。edition 2021→2024 移行が原因なら `style_edition` の固定で減るはずですが、`fd6cd42` で `style_edition = "2021"` を強制すると **202**（既定 193 より悪化）。設定で吸収する案も 7 通り測って既定が最小でした（詳細は PR2 の ADR）。

## ユーザーへの影響

ありません。整形は意味を変えず、製品の挙動は同一です。

## 検証

- `cargo fmt --all -- --check` — exit 0
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo test -p snotra-core`（499 passed）/ `-p snotra-egui-runtime`（24）/ `-p snotra`（184）/ `-p snotra-settings`（55）— **計 762 passed**
- `cargo doc --workspace --no-deps --document-private-items`
- 変更ファイル 63 件が**すべて `.rs`** であることを確認（`git diff --name-only main..HEAD | grep -vc '\.rs$'` = 0）

Refs #858
