### PR TITLE
fix: 画面ロック中のキャプチャを名指しして止める (#866)

### DIFF
--- a/docs/build-commands.md
+++ b/docs/build-commands.md
@@ -75,6 +75,7 @@ npm run check:colors -- -Interactive      # 判定せず起動し、目視項目
 - **既定色での確認はこの検証にならない。** config の既定 `#282828` は `snotra-egui-runtime` の `CLEAR_COLOR` と一致するため、色が届いていなくても正常に見える（原理は `docs/development-principles.md`「config の値は到達性の検出器を持たない」）
 - **自動判定するのは main と results の定常背景である。** results は専用 scan 3 件を seed し、キー注入で表示して実ピクセルを測る。残る 2 点は目視（`-Interactive`）に留まる——**show の一瞬のフラッシュ**は present 前の 1 フレーム未満で連写しても捉えられず、**results のリサイズ時のちらつき**は入力と描画のタイミングに依存して単一キャプチャでは不在を証明できない
 - **trace は判定に使わない。** 「`set_clear_color` を呼んだ」というログは、その色が画面へ出たことを意味しない（`src-tauri/CLAUDE.md`「trace の presence 検査は状態の検査ではない」）。判定の根拠は描かれたピクセルだけである
+- **画面がロックされていると実行できない**（#866）。ロック中は窓が可視のままでも画面に合成されず、`CopyFromScreen` は**ロック画面の中身を持つ有効な Bitmap** を返す（`IsWindowVisible` も矩形も DPI も真っ当な値なので、他のガードは全部通る）。`Get-SnotraWindowCapture` が起動前に名指しして止める。**ロック状態を判定できなかったときは警告のみで続行する**——読めないホストで実行そのものを拒めば、情報を足さずに道具を失うため
 - **ユーザーの実 config は読みも書きもしない。** `SNOTRA_CONFIG_DIR`（下記）で `target/visual-check/profile` を指し、そこへ検証用の config を 1 枚書いて起動する。退避も復元も無いので、異常終了しても実 config が検証色のまま残る経路が**構造的に無い**（#803）。残るのは使い捨てプロファイルだけで、`cargo clean` が掃く（`CARGO_TARGET_DIR` を設定している環境では対象外）
 - **seed が読めたかは本体の stderr で確かめる。** `[config] ` で始まる行が出たら赤にする。**`config.toml.bak` の不在では証明にならない**——退避は best-effort で、`fs::rename` が失敗すれば parse 失敗でも `.bak` は現れない（`snotra-core/src/config.rs` の `backup_invalid`）。seed が読めていないと既定色で起動するため、「色が届いていない」と誤読される
 - **`SNOTRA_CONFIG_DIR` が効いたことは肯定的に確かめる。** 実行後にプロファイル配下へ `*.bin` が生成されていることを見る。効いていなければ本体は実 config を読むため、ピクセルが赤いときに「色が届いていない」と「env が効いていない」を切り分けられない

--- a/scripts/lib/SnotraSmoke.Tests.ps1
+++ b/scripts/lib/SnotraSmoke.Tests.ps1
@@ -3,6 +3,22 @@ BeforeAll {
     Import-Module $modulePath -Force
 }
 
+BeforeDiscovery {
+    Import-Module (Join-Path $PSScriptRoot 'SnotraSmoke.psm1') -Force
+    # 画面がロックされていると Integration は**環境の都合で**落ちる（前面を奪えず打鍵が届かず、
+    # キャプチャはロック画面を返す・#866）。それを「赤」で残すと、実装の欠陥と区別できない。
+    # **確定してロック中のときだけ** skip し、判定不能なら従来どおり実行する（fail-open——
+    # 判定できないことを理由に検査を止めない）。
+    $sessionLocked = $false
+    try {
+        $lockState = Get-SnotraSessionLockState
+        $sessionLocked = $lockState.Locked
+        Write-Host "[#866] セッションのロック状態: Locked=$($lockState.Locked) SessionFlags=$($lockState.SessionFlags) SessionId=$($lockState.SessionId)"
+    } catch {
+        Write-Host "[#866] セッションのロック状態: 判定不能（$($_.Exception.Message)）— Integration は実行する"
+    }
+}
+
 Describe 'New-SnotraVerificationProfile' {
     It '必須セクションと呼び出し側固有の節を持つ seed を作り、古い成果物を除く' {
         $profile = Join-Path $TestDrive 'profile'
@@ -131,7 +147,76 @@ Describe 'Resolve-SnotraExistingProcess' {
     }
 }
 
-Describe '実機配管' -Tag Integration {
+Describe 'ConvertFrom-SnotraWtsInfoEx（#866 ロック検出の解釈）' {
+    # **実際のセッション状態に依存させない。** このファイルは CI（GitHub Actions の Windows
+    # runner）でも走るため、「いまロックされているか」を assert すると実行環境で結果が変わる。
+    # 純関数へ合成バイト列を渡し、解釈だけを固定する。
+    #
+    # ヘルパは BeforeAll に置く——Describe 直下の関数定義は discovery スコープに属し、
+    # It の実行時には見えない（Pester 5 以降のスコープ分離・実測で CommandNotFound）。
+    BeforeAll {
+        function New-WtsInfoExBuffer {
+            param([int]$Level = 1, [int]$SessionId = 7, [int]$SessionState = 0, [int]$SessionFlags = 1, [int]$Size = 40)
+            $b = New-Object byte[] $Size
+            [BitConverter]::GetBytes($Level).CopyTo($b, 0)
+            [BitConverter]::GetBytes($SessionId).CopyTo($b, 8)
+            [BitConverter]::GetBytes($SessionState).CopyTo($b, 12)
+            [BitConverter]::GetBytes($SessionFlags).CopyTo($b, 16)
+            $b
+        }
+    }
+
+    It 'SessionFlags=0（WTS_SESSIONSTATE_LOCK）をロックと読む' {
+        $r = ConvertFrom-SnotraWtsInfoEx -Buffer (New-WtsInfoExBuffer -SessionFlags 0) -ExpectedSessionId 7
+        $r.Locked | Should -BeTrue
+        $r.SessionId | Should -Be 7
+    }
+
+    It 'SessionFlags=1（WTS_SESSIONSTATE_UNLOCK）を非ロックと読む' {
+        (ConvertFrom-SnotraWtsInfoEx -Buffer (New-WtsInfoExBuffer -SessionFlags 1) -ExpectedSessionId 7).Locked | Should -BeFalse
+    }
+
+    It 'SessionId が呼び出し元と食い違えば「読めた」と言わない（オフセット仮定の検算）' {
+        # オフセットが 1 つずれると、無関係な 0 が「ロック中」に化ける。SessionId の一致が
+        # その沈黙経路に対する唯一の検知点である
+        { ConvertFrom-SnotraWtsInfoEx -Buffer (New-WtsInfoExBuffer -SessionId 3) -ExpectedSessionId 7 } |
+            Should -Throw '*SessionId が呼び出し元と一致しません*'
+    }
+
+    It 'Level が 1 でなければ SessionFlags の位置を仮定しない' {
+        { ConvertFrom-SnotraWtsInfoEx -Buffer (New-WtsInfoExBuffer -Level 2) -ExpectedSessionId 7 } |
+            Should -Throw '*Level が 1 ではありません*'
+    }
+
+    It 'LOCK/UNLOCK 以外の SessionFlags を非ロックへ倒さない（未知値は判定不能）' {
+        { ConvertFrom-SnotraWtsInfoEx -Buffer (New-WtsInfoExBuffer -SessionFlags -1) -ExpectedSessionId 7 } |
+            Should -Throw '*ロック状態を判定できません*'
+    }
+
+    It 'バッファが短ければ範囲外を読まない' {
+        { ConvertFrom-SnotraWtsInfoEx -Buffer (New-Object byte[] 12) -ExpectedSessionId 7 } |
+            Should -Throw '*短すぎます*'
+    }
+}
+
+Describe 'Assert-SnotraSessionUnlocked（#866 倒す向きの非対称）' {
+    It 'ロックと判定できたら止める' {
+        Mock -ModuleName SnotraSmoke Get-SnotraSessionLockState { [pscustomobject]@{ Locked = $true } }
+        { Assert-SnotraSessionUnlocked -Operation '窓のキャプチャ' } | Should -Throw '*画面がロックされている*'
+    }
+
+    It '非ロックなら素通りする' {
+        Mock -ModuleName SnotraSmoke Get-SnotraSessionLockState { [pscustomobject]@{ Locked = $false } }
+        { Assert-SnotraSessionUnlocked } | Should -Not -Throw
+    }
+
+    It '判定不能は警告のみで続行する（未知ホスト・CI runner で道具を失わないため）' {
+        Mock -ModuleName SnotraSmoke Get-SnotraSessionLockState { throw 'WTSQuerySessionInformationW に失敗しました（Win32 error 87）。' }
+        { Assert-SnotraSessionUnlocked -WarningAction SilentlyContinue } | Should -Not -Throw
+    }
+}
+
+Describe '実機配管' -Tag Integration -Skip:$sessionLocked {
     It '生成した seed を本体が parse して同じプロファイルへ書き込み、キャプチャ寸法が窓矩形と一致する' {
         $profile = Join-Path $TestDrive 'integration-profile'
         $stderr = Join-Path $TestDrive 'integration.err'

--- a/scripts/lib/SnotraSmoke.psm1
+++ b/scripts/lib/SnotraSmoke.psm1
@@ -26,8 +26,129 @@ public static extern bool SetProcessDpiAwarenessContext(IntPtr value);
 public static extern bool SetProcessDPIAware();
 [DllImport("dwmapi.dll")]
 public static extern int DwmGetWindowAttribute(IntPtr hWnd, int attr, out RECT value, int size);
+[DllImport("wtsapi32.dll", SetLastError = true)]
+public static extern bool WTSQuerySessionInformationW(IntPtr server, int sessionId, int infoClass, out IntPtr buffer, out int bytesReturned);
+[DllImport("wtsapi32.dll")]
+public static extern void WTSFreeMemory(IntPtr memory);
 public struct RECT { public int Left, Top, Right, Bottom; }
 '@
+    }
+}
+
+# WTSQuerySessionInformationW の引数（`WTSSessionInfoEx` = 25・`WTS_CURRENT_SESSION` = -1）と
+# `WTSINFOEX_LEVEL1_W.SessionFlags` の値。**Windows 7 では LOCK/UNLOCK の意味が逆**だが、
+# 本リポジトリの対象は Windows 10/11 ゆえ documented のまま扱う。
+$script:WtsSessionInfoEx = 25
+$script:WtsCurrentSession = -1
+$script:WtsSessionStateLock = 0
+$script:WtsSessionStateUnlock = 1
+
+<#
+.SYNOPSIS
+`WTSINFOEXW` のバイト列から SessionFlags を読む純関数。
+
+.DESCRIPTION
+**構造体のオフセットを自前で仮定するため、同じバッファから読める SessionId で検算する。**
+`WTSINFOEXW` は `Level`(DWORD) の後に union が続き、union の中身（`WTSINFOEX_LEVEL1_W`）は
+`LARGE_INTEGER` を含むので 8 バイト境界へ揃う。ゆえに SessionId は 8、SessionState は 12、
+SessionFlags は 16 に来る。**この仮定が外れれば SessionId が呼び出し元のセッションと合わなくなる**
+ので、合わなければ「読めた」と言わずに落とす（誤ったオフセットから読んだ 0 が
+「ロック中」に化けるのを防ぐ・fail-closed）。
+#>
+function ConvertFrom-SnotraWtsInfoEx {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [byte[]]$Buffer,
+        [Parameter(Mandatory)]
+        [int]$ExpectedSessionId
+    )
+
+    if ($Buffer.Length -lt 20) {
+        throw "WTSINFOEXW が短すぎます（$($Buffer.Length) バイト・20 バイト以上が要る）。"
+    }
+    $level = [BitConverter]::ToInt32($Buffer, 0)
+    if ($level -ne 1) {
+        throw "WTSINFOEXW.Level が 1 ではありません（$level）。SessionFlags の位置を仮定できません。"
+    }
+    $sessionId = [BitConverter]::ToInt32($Buffer, 8)
+    if ($sessionId -ne $ExpectedSessionId) {
+        throw "WTSINFOEXW の SessionId が呼び出し元と一致しません（構造体 $sessionId / 呼び出し元 $ExpectedSessionId）。オフセットの仮定が崩れています。"
+    }
+    $flags = [BitConverter]::ToInt32($Buffer, 16)
+    if ($flags -ne $script:WtsSessionStateLock -and $flags -ne $script:WtsSessionStateUnlock) {
+        throw "SessionFlags が LOCK(0)/UNLOCK(1) のいずれでもありません（$flags）。ロック状態を判定できません。"
+    }
+
+    [pscustomobject]@{
+        SessionId = $sessionId
+        SessionState = [BitConverter]::ToInt32($Buffer, 12)
+        SessionFlags = $flags
+        Locked = ($flags -eq $script:WtsSessionStateLock)
+    }
+}
+
+<#
+.SYNOPSIS
+現在のセッションがロックされているかを返す（判定不能なら throw）。
+
+.DESCRIPTION
+**デスクトップ名（`OpenInputDesktop` + `GetUserObjectInformation`）では判定できない。**
+近年の Windows はロック画面（LockApp）を `Default` デスクトップ上で動かすため、ロック中でも
+`Default` が返る（2026-08-01 実測の false negative・#866）。
+#>
+function Get-SnotraSessionLockState {
+    [CmdletBinding()]
+    param()
+
+    Initialize-SnotraNativeInterop
+    $buffer = [IntPtr]::Zero
+    $bytes = 0
+    if (-not [SnotraSmokeInterop.Native]::WTSQuerySessionInformationW(
+            [IntPtr]::Zero, $script:WtsCurrentSession, $script:WtsSessionInfoEx, [ref]$buffer, [ref]$bytes)) {
+        $code = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+        throw "WTSQuerySessionInformationW に失敗しました（Win32 error $code）。ロック状態を判定できません。"
+    }
+    try {
+        $bytesArray = New-Object byte[] $bytes
+        [System.Runtime.InteropServices.Marshal]::Copy($buffer, $bytesArray, 0, $bytes)
+    } finally {
+        [SnotraSmokeInterop.Native]::WTSFreeMemory($buffer)
+    }
+    ConvertFrom-SnotraWtsInfoEx -Buffer $bytesArray -ExpectedSessionId (Get-Process -Id $PID).SessionId
+}
+
+<#
+.SYNOPSIS
+画面がロックされていたら、何をすればよいかを名指しして止める。
+
+.DESCRIPTION
+**ロック中は窓が Win32 の視点では生きたままである**（`IsWindowVisible` は真・矩形も妥当・
+DPI も正しい）ため、既存のガードはすべて通り、`CopyFromScreen` は**ロック画面の中身を持つ
+有効な Bitmap** を返す。判定側が落ちたとしてもメッセージは色や描画経路を指すので、読んだ人は
+レンダリングを疑い始める（#866 実測）。ここで名指しして止める。
+
+**倒す向きを 2 つに分ける。** 「ロック中と判定できた」は throw、「**判定できなかった**」は警告のみで
+続行する。この関数の仕事は*誤った結果*を防ぐことであり、状態を読めないホストで実行そのものを
+拒めば、情報を足さずに道具を失う。加えて `Get-SnotraWindowCapture` は Pester の Integration
+テスト経由で **CI（GitHub Actions の Windows runner）でも走る**——判定不能を throw に倒すと、
+runner の WTS の振る舞いが未知のまま CI を壊しうる。**ロックという確定した事実にだけ強く倒す。**
+#>
+function Assert-SnotraSessionUnlocked {
+    [CmdletBinding()]
+    param(
+        [string]$Operation = 'この操作'
+    )
+
+    $state = $null
+    try {
+        $state = Get-SnotraSessionLockState
+    } catch {
+        Write-Warning "画面のロック状態を判定できませんでした（$($_.Exception.Message)）。ロック中であれば、以降の結果は画面の中身を反映しません（#866）。"
+        return
+    }
+    if ($state.Locked) {
+        throw "画面がロックされているため $Operation を実行できません。ロック中は窓が可視のままでも画面に合成されず、キャプチャはロック画面の中身を返します（#866）。画面のロックを解除してから実行してください。"
     }
 }
 
@@ -328,6 +449,11 @@ function Get-SnotraWindowCapture {
     Initialize-SnotraDpiAwareness
     Add-Type -AssemblyName System.Drawing
 
+    # **可視判定より先に見る。** ロック中は IsWindowVisible も矩形も真っ当な値を返し、
+    # ここから下は最後まで成功して**中身だけが違う Bitmap** を返す（#866）。
+    # 判定不能を throw へ倒さない理由は Assert-SnotraSessionUnlocked のコメント。
+    Assert-SnotraSessionUnlocked -Operation '窓のキャプチャ'
+
     if (-not [SnotraSmokeInterop.Native]::IsWindowVisible($Handle)) {
         throw 'キャプチャ対象の窓が可視ではありません。'
     }
@@ -381,4 +507,7 @@ Export-ModuleMember -Function @(
     'Wait-SnotraWindow'
     'Set-SnotraForegroundWindow'
     'Get-SnotraWindowCapture'
+    'ConvertFrom-SnotraWtsInfoEx'
+    'Get-SnotraSessionLockState'
+    'Assert-SnotraSessionUnlocked'
 )


### PR DESCRIPTION
Closes #866

## 何が問題だったか

画面がロックされていると、`Get-SnotraWindowCapture` の既存ガードはすべて通る——`IsWindowVisible` は真、DWM の矩形も妥当、DPI も正しい。窓は Win32 の視点では生きているからである。そして `CopyFromScreen` は**ロック画面の中身を持つ有効な Bitmap** を返す。

`visual-check-colors.ps1` の最頻色判定は落ちるが、**落ちるのは壁紙の偶然であって機構の保証ではない**（実測: ロック画面の最頻色は `#010102` が 21.4%）。しかも落ちたときに出る案内は

> 暗いままなら clear color が届いていない（runtime の `CLEAR_COLOR` が出ている）

なので、読んだ人はレンダリング経路を疑い始める。実際は画面がロックされていただけである。

## 何をしたか

`WTSQuerySessionInformationW`（`WTSSessionInfoEx`）で判定し、**可視判定より前**で止める。

**デスクトップ名による判定は使えない。** 近年の Windows はロック画面（LockApp）を `Default` デスクトップ上で動かすため、ロック中でも `OpenInputDesktop` + `GetUserObjectInformation` は `Default` を返す（実測の false negative）。この経路を最初に試して外したので、同じ道を辿らないようコメントに残した。

構造体のオフセット（`SessionId`=8 / `SessionState`=12 / `SessionFlags`=16）は自前の仮定なので、**同じバッファから読める `SessionId` が呼び出し元のセッションと一致するかで検算する**。位置が 1 つずれれば無関係な `0` が「ロック中」に化けるため、これがその沈黙経路に対する唯一の検知点である。

### 倒す向きを 2 つに分けた

| 状況 | 動き | 理由 |
|---|---|---|
| ロック中と**判定できた** | throw | 誤った結果を防ぐのがこの関数の仕事 |
| **判定できなかった** | 警告のみで続行 | 読めないホストで実行そのものを拒めば、情報を足さずに道具を失う。加えて `Get-SnotraWindowCapture` は Pester の Integration 経由で **CI の Windows runner でも走る**——判定不能を throw に倒すと runner の未知の振る舞いで CI を壊しうる |

### Integration は「赤」ではなく「未実施」へ

ロック中は 2 本目が `Set-SnotraForegroundWindow | Should -BeTrue` で**既に赤くなっていた**。環境の都合の赤と実装の欠陥が区別できないので、`BeforeDiscovery` で**確定してロック中のときだけ** Skip する（判定不能なら従来どおり実行＝fail-open。判定できないことを理由に検査を止めない）。

## 検証 — 両方向を実測した（受け入れ条件 3・5）

FI は**複製に変異を当てる**形（`.claude/rules/safety-nets.md`）。実物の判定も `docs/build-commands.md` も変異させていない——解釈は純関数へ合成バイト列を渡し、`Assert` は `Get-SnotraSessionLockState` を Mock している。

| 環境 | 観測値 | Pester |
|---|---|---|
| **ローカル・ロック中** | `SessionFlags=0` `SessionId=1` → `Locked=True` | 17 passed / 0 failed / **2 skipped**（Integration が skip された） |
| **ローカル・ロック解除時** | `SessionFlags=1` `SessionId=1` → `Locked=False` | 19 passed / 0 failed / **0 skipped**（Integration が実行され両方 pass） |
| **CI runner**（windows-latest） | `SessionFlags=1` `SessionId=2` → `Locked=False` | 19 passed / 0 failed / **0 skipped** |

3 環境とも `SessionId` が呼び出し元と一致＝**オフセットの検算が 3 回通った**。とくに runner は `SessionId=2` で、**ローカルと違う値に対して**検算が成立している（固定値に対してたまたま通っているのではない）。

**`skipped 0` が誤爆しないことの証跡である**——ガードのせいで検査が消えた経路が無いことまで同時に示している。ロック解除側は**リポジトリ所有者が自分の端末で実行**した（この検出器の性質上、エージェントの実行環境では測れない方向）。

ガードが出す文言:

```
画面がロックされているため 窓のキャプチャ を実行できません。ロック中は窓が可視のままでも
画面に合成されず、キャプチャはロック画面の中身を返します（#866）。画面のロックを解除してから
実行してください。
```

その他: `npm run governance:check` 全検査 passed（19 検査）/ `npm test` 563 passed。

## 判断の記録（受け入れ条件 4）— 打鍵注入側には置かない

- `smoke-egui.ps1` は **CI で走る**。誤爆すれば `Smoke` workflow を常に止めるが、その方向は実測できていない
- 打鍵側はロック中に前面を奪えず trace 待ちがタイムアウトするため、捕捉側と違って**大きく鳴る**——沈黙経路ではないので優先度も低い
- 述語（`Get-SnotraSessionLockState` / `Assert-SnotraSessionUnlocked`）は export したので、後から採用できる

## マージ前チェックリスト

- [x] CI が緑 — `governance-check` 7s / `node-check` 19s / `rust-check` 3m51s / `smoke-egui` 10m42s（[run 30701040076](https://github.com/finelagusaz/Snotra/actions/runs/30701040076)）
- [x] **CI runner での `SessionFlags` の値を確認した** — `[#866] セッションのロック状態: Locked=False SessionFlags=1 SessionId=2` / `Tests Passed: 19, Skipped: 0`。**runner でも Integration は skip されていない**（懸念していた「黙って skip され続ける」経路は成立していない）
