### PR TITLE
chore(deps): snotra-egui-runtime の windows を 0.62.2 へ上げる

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4766,7 +4766,7 @@ dependencies = [
  "tauri-runtime",
  "tauri-runtime-wry",
  "thiserror 2.0.19",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]

--- a/snotra-egui-runtime/Cargo.toml
+++ b/snotra-egui-runtime/Cargo.toml
@@ -20,7 +20,7 @@ tauri-runtime-wry.workspace = true
 thiserror = "2"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "=0.61.3", features = [
+windows = { version = "0.62.2", features = [
     "Win32_Foundation",
     "Win32_Graphics_Gdi",
     "Win32_UI_Input_Ime",

--- a/snotra-egui-runtime/src/windows_ime.rs
+++ b/snotra-egui-runtime/src/windows_ime.rs
@@ -48,10 +48,19 @@ impl PlatformIme {
         let callback_state = Box::new(CallbackState { sender });
         let callback_ptr = (&*callback_state) as *const CallbackState as usize;
 
+        // tauri::Window::hwnd() は tauri が依存する windows 版の HWND を返す。当 crate は
+        // 別版を使うため、生ポインタを取り出して自版の型で組み直す（src-tauri と同じ形）。
+        // 両版の HWND は同一定義（pub struct HWND(pub *mut c_void)）ゆえ表現は等しい。
+        //
         // SAFETY: hwnd is owned by the attached Tauri Window. callback_ptr stays
         // valid until Drop removes this exact callback/id pair.
         let installed = unsafe {
-            SetWindowSubclass(hwnd, Some(ime_subclass_proc), IME_SUBCLASS_ID, callback_ptr)
+            SetWindowSubclass(
+                HWND(hwnd.0),
+                Some(ime_subclass_proc),
+                IME_SUBCLASS_ID,
+                callback_ptr,
+            )
         };
         if !installed.as_bool() {
             return Err(RuntimeError::ImeInitialization(


### PR DESCRIPTION
Dependabot の #868（`bump windows from 0.61.3 to 0.62.2`）は `rust-check` で落ちる。マニフェストだけを書き換えても `snotra-egui-runtime` のコードが型境界を跨げないためで、その 1 箇所を直したうえで版を上げる。#868 はこの PR で不要になる。

## 何が壊れていたか

```
error[E0308]: mismatched types
  --> snotra-egui-runtime/src/windows_ime.rs:54:31
   |
54 |  SetWindowSubclass(hwnd, Some(ime_subclass_proc), IME_SUBCLASS_ID, callback_ptr)
   |                    ^^^^ expected `HWND`, found `windows::Win32::Foundation::HWND`
   |
note: there are multiple different versions of crate `windows` in the dependency graph
```

`windows_ime.rs:46` の `window.hwnd()` が返すのは **tauri が依存する版**の `HWND` である。従来これをそのまま `SetWindowSubclass` へ渡せていたのは、`snotra-egui-runtime/Cargo.toml` が `windows = { version = "=0.61.3", ... }` と**厳密ピン**して tauri と同じ版を共有していたからで、その `=` が唯一の担保だった（理由を書いた注釈は無かった）。Dependabot はピンだけを上げたため、呼ぶ側が 0.62.2 へ移り `hwnd` は 0.61.3 のまま残った。

## 変更

1. `snotra-egui-runtime/Cargo.toml` — `windows` を `=0.61.3` → `0.62.2`。**厳密ピンを外す**（`=` は tauri と版を揃えるための拘束であり、下の 2. でその必要が消えるため。`src-tauri` の `"0.62.2"` と同形にすることで cargo が 1 つの 0.62.x へ寄せる）
2. `snotra-egui-runtime/src/windows_ime.rs` — 生ポインタを取り出して自版の型で組み直す形へ変更し、なぜそうするかの注釈を添えた

```rust
SetWindowSubclass(HWND(hwnd.0), Some(ime_subclass_proc), IME_SUBCLASS_ID, callback_ptr)
```

これは **`src-tauri` が同じ境界で既に採っている形**である（`egui_shell/` の `set_topmost` / `ShowWindow` 各所と `window_coordinator.rs` の `HWND(hwnd.0)`）。`windows_ime.rs` 自身も `PlatformIme::new` を出た後は同形で——`drain` と `Drop` が `hwnd_value: isize` から `HWND(self.hwnd_value as *mut c_void)` を組み直している——直接渡していたのは `new` の 1 箇所だけだった。両版の `HWND` は同一定義（`pub struct HWND(pub *mut core::ffi::c_void);`——上のエラー出力が両方について print している）なので、変換に表現上のリスクは無い。

## 「統一」の範囲（誇張しないための明記）

**依存グラフから `windows 0.61.3` が消えるわけではない。** `tao` / `tauri` / `tauri-runtime` / `tauri-runtime-wry` / `wry` / `webview2-com` / `webview2-com-sys` は 0.61.3 のまま残る（`cargo tree -i windows@0.61.3` で実測）。揃うのは**ワークスペースの 4 crate**である:

| | 変更前 | 変更後 |
|---|---|---|
| `snotra`（src-tauri） | 0.62.2 | 0.62.2 |
| `snotra-core` | 0.62.2 | 0.62.2 |
| `snotra-settings` | 0.62.2 | 0.62.2 |
| `snotra-egui-runtime` | **0.61.3** | **0.62.2** |

`src-tauri/CLAUDE.md`「Win32 / Tauri 注意事項」が既に「プロジェクトの `windows` クレート（v0.62）」と書いており、本 PR で全 4 crate がその記述と一致する。**規範文書の更新は不要**（0.61.3 の記載が残るのは日付付き設計書＝歴史記録のみで、これは書き換えない）。`Cargo.lock` の差分は 1 行。

## 検証

| カテゴリ | コマンド | 結果 |
|---|---|---|
| A | `cargo fmt --all -- --check` | ✅ |
| A | `cargo check --workspace` | ✅ |
| A | `cargo clippy --workspace --all-targets -- -D warnings` | ✅ |
| A | `cargo test` × 4 crate | ✅ |
| A | `cargo doc --workspace --no-deps --document-private-items` | ✅ |
| C | `npm test`（Vitest） | ✅ 563 件 |
| C | `npm run test:powershell`（Pester） | ✅ 22 件（実機配管が新バイナリで窓矩形＝キャプチャ寸法の一致まで確認） |

`cargo check` だけでは足りない点を意識して全カテゴリを回した——#868 の CI は `snotra-egui-runtime` で停止したため、依存側の `snotra` も clippy もテストも一度も走っていなかった。特に **feature union の移動**（当 crate が `Win32_UI_Input_Ime` 等を 0.61.3 バケツへ寄与しなくなる）が tao 側のコンパイルに響く可能性があったが、実測では影響なし。

`smoke:startup` / `smoke:egui` はローカルで実行していない（`smoke:egui` はデスクトップへキー注入するため作業中の実行を避けた）。`Cargo.toml` / `Cargo.lock` の変更は `e2e.yml` の paths に該当するので `Smoke` workflow が自動起動する。

## 目視について

IME preedit の経路は自動スモークの対象外だが、`SetWindowSubclass` の失敗は `installed.as_bool()` で捕まり `RuntimeError::ImeInitialization` になるため、**沈黙して二重描画へ落ちる経路は無い**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
