### PR TITLE
test: キャレット統合検査から runner のシェル依存を外す（#872 の観測時間）

### DIFF
--- a/scripts/lib/SnotraSmoke.Tests.ps1
+++ b/scripts/lib/SnotraSmoke.Tests.ps1
@@ -45,6 +45,16 @@ include_folders = false
         @(Get-ChildItem -Path $profile -Filter '*.bin').Count | Should -Be 0
         [IO.Path]::IsPathRooted($created.FullPath) | Should -BeTrue
     }
+
+    It 'ShowIcons を TOML の真偽値として書く（既定は true・$false で無効化できる）' {
+        # このノブが黙って効かなくなると、検査は緑のまま runner への要求だけが戻る（#872）。
+        # PowerShell の $true は "True" へ補間されるため、TOML として読めるかを直接見る。
+        $on = New-SnotraVerificationProfile -ProfileDir (Join-Path $TestDrive 'icons-on')
+        $off = New-SnotraVerificationProfile -ProfileDir (Join-Path $TestDrive 'icons-off') -ShowIcons $false
+
+        (Get-Content -Raw $on.ConfigPath) | Should -Match '(?m)^show_icons = true\r?$'
+        (Get-Content -Raw $off.ConfigPath) | Should -Match '(?m)^show_icons = false\r?$'
+    }
 }
 
 Describe 'Invoke-SnotraEnvironment' {
@@ -290,7 +300,10 @@ auto_hide_on_focus_lost = false
         New-Item -ItemType Directory -Force -Path $folder | Out-Null
         Set-Content -LiteralPath (Join-Path $folder 'aa-child.txt') -Value 'fixture'
         $scanRootToml = (Resolve-Path -LiteralPath $scanRoot).Path.Replace('\', '/')
-        $created = New-SnotraVerificationProfile -ProfileDir $profile `
+        # この検査はキャレット位置だけを見るので、アイコンは判定に一切入らない。
+        # runner ではシェルのアイコン問い合わせが恒久的に失敗し続け（#872）、その再要求が
+        # 打鍵から egui_input:changed までの観測時間を押し広げる。要求そのものを外す。
+        $created = New-SnotraVerificationProfile -ProfileDir $profile -ShowIcons $false `
             -AdditionalSections @'
 [general]
 show_on_startup = true

--- a/scripts/lib/SnotraSmoke.psm1
+++ b/scripts/lib/SnotraSmoke.psm1
@@ -177,13 +177,21 @@ function New-SnotraVerificationProfile {
         [string]$PathEntries = '',
         [string]$HotkeyModifier = 'Alt',
         [string]$HotkeyKey = 'Q',
-        [int]$WindowWidth = 600
+        [int]$WindowWidth = 600,
+        # $false で `results_view.rs` の `request_icons_for_results` が即 return し、
+        # icon worker も `SHGetFileInfoW` も走らなくなる。**runner では `SHGetFileInfoW` が
+        # `exists:true` のパスに対して `ShellQueryFailed(1008)` を返し**、失敗は
+        # `IconFailure::is_transient` が true ゆえ恒久 latch されず再要求され続ける
+        # ——アイコンを判定に使わない検査では、この空回りが観測時間を押し広げるだけになる（#872）。
+        [bool]$ShowIcons = $true
     )
 
     New-Item -ItemType Directory -Force -Path $ProfileDir | Out-Null
     Remove-Item -LiteralPath (Join-Path $ProfileDir 'config.toml.bak') -Force -ErrorAction SilentlyContinue
     Get-ChildItem -LiteralPath $ProfileDir -Filter '*.bin' -ErrorAction SilentlyContinue | Remove-Item -Force
 
+    # TOML の真偽値は小文字であり、PowerShell の $true は "True" へ補間される。
+    $showIconsToml = $ShowIcons.ToString().ToLowerInvariant()
     $parts = @(
         @"
 [hotkey]
@@ -192,6 +200,7 @@ key = "$HotkeyKey"
 
 [appearance]
 window_width = $WindowWidth
+show_icons = $showIconsToml
 "@.Trim()
     )
     if (-not [string]::IsNullOrWhiteSpace($AdditionalSections)) {


### PR DESCRIPTION
## 何をしたか

キャレット統合検査（`scripts/lib/SnotraSmoke.Tests.ps1` の「フォルダ復帰後の次打鍵を復元クエリの末尾へ追加する」）の seed へ `show_icons = false` を入れ、**runner のシェルに対する要求を検査から外す**。

- `New-SnotraVerificationProfile` に `-ShowIcons`（既定 `$true`）を追加。**既存の 3 つの呼び出し側（`smoke-egui.ps1` / `smoke-startup.ps1` / `visual-check-colors.ps1`）の挙動は変わらない**
- キャレット統合検査だけが `-ShowIcons $false` を渡す
- ノブが黙って効かなくなることを防ぐ単体テストを 1 件追加

## なぜ

#872 の 7 件目（run [1306](https://github.com/finelagusaz/Snotra/actions/runs/30785699313)）の trace に、検査の山場の約 4 秒間で 6 回これが出ていた:

```
{"exists":true, "path":"...\\alpha", "reason":"ShellQueryFailed(1008)", "transient":true}
```

`exists:true` と自分で記録しながら `SHGetFileInfoW` が 0 を返している。**runner のセッションでシェルのアイコン問い合わせが恒久的に失敗する**にもかかわらず、`IconFailure::is_transient`（`src-tauri/src/icon.rs:139`）が `true` を返すため恒久的な欠落として latch されず、可視である限り再要求され続ける。

この検査が判定に使うのはキャレット位置（`egui_input:changed` の `appended_at_end` / `before_chars` / `after_chars`）だけで、**アイコンは一切見ていない**。`show_icons = false` なら `results_view.rs:181` の `if !show_icons { return; }` で worker の spawn ごと止まるので、要求そのものが消える。

**判定の意味は変えない。** #872 の候補 (d)（再試行でくるむ）とも、前コメントの第 5 の候補（予算を実測へ合わせて広げる）とも性質が違い、観測時間を押し広げていた仕事を検査から取り除くだけである。

## 効果の測定（このブランチでしか測れない）

ローカルは元々 2.15s で予算 5,000ms の内側にあり、**差が出るのは runner の上だけ**である。#872 が書くとおり CI の実測は PR が在って初めて行えるので、ここで測る。

- [x] CI の `rust-check` が緑になる → run [30788532876](https://github.com/finelagusaz/Snotra/actions/runs/30788532876)・Pester 55 件全通過（単体 53 + 統合 2）
- [x] `Run PowerShell tests (Pester)` のログで、当該 It の所要が **6.75s（#872 記録の pass 時）より縮む** → **2.89s**
- [x] 同ログに `icon:extract_failed` が **1 件も出ない** → **0 件**
- [x] 上の 3 点を #872 へ記録する → https://github.com/finelagusaz/Snotra/issues/872#issuecomment-5162895902

### 実測

| 指標 | 従来（#872 記録） | この PR |
|---|---|---|
| runner での所要 | 6.75s（pass）/ 10.73s・12.76s（fail） | **2.89s** |
| `icon:extract_failed` | 6 件（山場の約 4 秒間） | **0 件** |
| ローカルでの所要 | 2.15s / 2.14s / 2.21s | 2.67s |

**予算 5,000ms の両側に散っていた runner の実測が、ローカルとほぼ同じ位置まで降りた。**#872 前コメントが測った分散のうち、シェルのアイコン問い合わせの空回りが占めていた分は大きい。

**ただし 1 回の緑は flake の解消を意味しない**（母数 12.5%）。この PR が示したのは観測時間が縮んだことまでであり、残った分散がどれだけかは以降の run が決める。

## 射程外（この PR では触らない）

#872 の 3 つの現れ方のうち、これが当たるのは観測時間の一部だけである。残りは未着手:

- **現れ方 1（前面化）** — run 1280 / 1299。#871 の後も再発しており、候補 (b)（前面非依存の注入経路）でしか消えない
- **run 1306 の観測漏れの機序** — 期待した事象は予算の内側（39.354 / 期限 ≧42.57）で発生していたのに `$null` が返った。3 通りの説明が割れたままで、切り分けには待ち側の計器（周回ごとの読み行数・parse 成功数・読み取り例外）が要る

## 検証

- `Invoke-Pester -ExcludeTagFilter Integration` — **53 件全通過**（新規 1 件を含む・ローカル実測）
- 統合検査 2 件 — ローカルで **2 件とも通過**（キャレット検査 2.67s）
- CI — **55 件全通過**（上の実測表）

ローカルの統合検査は、当初は前セッションの残留プロセス（`snotra-prebuild-jul30`）が `tauri_plugin_single_instance` を握って `exit=0` になり実行できなかった。**本ブランチの変更前後どちらでも同一症状**であることを stash して確認したうえで、残留プロセスを落として再実行した。

なお `Resolve-SnotraExistingProcess -Policy Reject` はこの残留プロセスを捕まえなかった（プロセス名 `snotra` の完全一致で探すため `snotra-prebuild-jul30` が視界の外）。**runner は綺麗なので CI の flake とは無関係**だが、ガードが黙って素通りする経路として記録しておく。

Refs #872

🤖 Generated with [Claude Code](https://claude.com/claude-code)
