### PR TITLE
fix(scripts): trace 待ちの期限跨ぎ・沈黙する読み取り失敗を塞ぎ、smoke:startup のガードを直す

### DIFF
--- a/scripts/lib/SnotraSmoke.Tests.ps1
+++ b/scripts/lib/SnotraSmoke.Tests.ps1
@@ -138,6 +138,62 @@ Describe 'Read-SnotraTraceEvents' {
     }
 }
 
+Describe 'Wait-SnotraTraceCondition（#872 観測側の 2 つの穴）' {
+    BeforeAll {
+        function New-SnotraTestTraceFile {
+            param([string]$Path, [string[]]$Json)
+            $Json | ForEach-Object { "[trace] $_" } | Set-Content -LiteralPath $Path
+            $Path
+        }
+    }
+
+    It '予算が尽きていても条件を必ず 1 度は評価する（停止が期限を跨いでも取りこぼさない）' {
+        # 旧実装は `while (now -lt deadline)` ゆえ、期限切れ後は**一度も読まずに** $null を返した。
+        # 停止が最後の sleep を跨ぐと、既に成立していた条件を見ないまま諦める（#872 run 1306:
+        # 期待した事象は 39.354 に出ていて期限は 42.57 以降だったのに観測されなかった）。
+        $path = New-SnotraTestTraceFile -Path (Join-Path $TestDrive 'ready.log') `
+            -Json @('{"seq":1,"event":"target","data":{"ok":true}}')
+
+        $found = Wait-SnotraTraceCondition -Path $path -TimeoutMs 0 -Predicate { $_.event -eq 'target' }
+
+        $found | Should -Not -BeNullOrEmpty
+        $found.seq | Should -Be 1
+    }
+
+    It '読み取りに失敗した周回を「まだ出ていない」と同じ沈黙へ潰さない' {
+        # ディレクトリは Test-Path が真で Get-Content が落ちる（実測）。`-ErrorAction
+        # SilentlyContinue` は空を返すので、**読めなかったと未発生が同じ $null に化ける**。
+        $dir = Join-Path $TestDrive 'unreadable'
+        New-Item -ItemType Directory -Force -Path $dir | Out-Null
+
+        $found = Wait-SnotraTraceCondition -Path $dir -TimeoutMs 0 -Predicate { $true } `
+            -WarningVariable warnings -WarningAction SilentlyContinue
+
+        $found | Should -BeNullOrEmpty
+        ($warnings -join ' ') | Should -Match '読み取り'
+    }
+
+    It '本体が終了していれば予算を待たずに諦める（AbortIfExited）' {
+        # **通った実行では発火しないので、ここでしか観測されない。** 諦める条件を scriptblock で
+        # 受け取っていた版は、Pester の `It` の中で `.GetNewClosure()` が親スコープの変数を
+        # 捕まえられず、**発火しないまま予算いっぱい待つ**退化が黙って入っていた（実測: 予算
+        # 4000ms に対し 4031ms）。プロセスを型付きで受け取る形はその間違いを書けなくする。
+        $path = New-SnotraTestTraceFile -Path (Join-Path $TestDrive 'never.log') `
+            -Json @('{"seq":1,"event":"other","data":{}}')
+        $dead = Start-Process -FilePath 'cmd.exe' -ArgumentList '/c exit 0' -PassThru -WindowStyle Hidden
+        $dead.WaitForExit()
+
+        $sw = [Diagnostics.Stopwatch]::StartNew()
+        $found = Wait-SnotraTraceCondition -Path $path -TimeoutMs 4000 -PollMs 50 `
+            -Predicate { $_.event -eq 'target' } -AbortIfExited $dead -WarningAction SilentlyContinue
+        $sw.Stop()
+
+        $found | Should -BeNullOrEmpty
+        # 諦め損ねていれば予算 4000ms を使い切る。
+        $sw.Elapsed.TotalMilliseconds | Should -BeLessThan 2000
+    }
+}
+
 Describe 'Resolve-SnotraExistingProcess' {
     It 'Reject 方針では既存プロセスを終了せず例外にする' {
         Mock -ModuleName SnotraSmoke Get-Process { @([pscustomobject]@{ Id = 123 }) }
@@ -331,20 +387,20 @@ include_folders = true
                 [Nullable[int]]$BeforeChars = $null,
                 [int]$TimeoutMs = 5000
             )
-            $deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMs)
-            while ([DateTime]::UtcNow -lt $deadline) {
-                $matched = @(Read-SnotraTraceEvents -Path $stderr | Where-Object {
-                    $_.event -eq 'egui_input:changed' -and
-                    $_.data.scope -eq $Scope -and
-                    $_.data.after_chars -eq $AfterChars -and
-                    $_.data.appended_at_end -eq $AppendedAtEnd -and
-                    ($null -eq $BeforeChars -or $_.data.before_chars -eq $BeforeChars)
-                } | Select-Object -Last 1)
-                if ($matched.Count -gt 0) { return $matched[0] }
-                if ($null -ne $proc -and $proc.HasExited) { break }
-                Start-Sleep -Milliseconds 100
-            }
-            return $null
+            # 待ちループの形は `Wait-SnotraTraceCondition` が持つ（#872）。ここに写しを置くと、
+            # 期限跨ぎ・読み取り失敗の穴を塞ぐ変更が module 側にしか入らない。
+            $predicate = {
+                $_.event -eq 'egui_input:changed' -and
+                $_.data.scope -eq $Scope -and
+                $_.data.after_chars -eq $AfterChars -and
+                $_.data.appended_at_end -eq $AppendedAtEnd -and
+                ($null -eq $BeforeChars -or $_.data.before_chars -eq $BeforeChars)
+            }.GetNewClosure()
+            $describe = "egui_input:changed(scope=$Scope, after=$AfterChars, appended=$AppendedAtEnd" +
+                $(if ($null -eq $BeforeChars) { '' } else { ", before=$BeforeChars" }) + ')'
+            $abortArgs = if ($null -eq $proc) { @{} } else { @{ AbortIfExited = $proc } }
+            return Wait-SnotraTraceCondition -Path $stderr -Predicate $predicate -Description $describe `
+                -TimeoutMs $TimeoutMs -PollMs 100 @abortArgs
         }
 
         try {

--- a/scripts/lib/SnotraSmoke.psm1
+++ b/scripts/lib/SnotraSmoke.psm1
@@ -347,8 +347,13 @@ function Read-SnotraTraceEvents {
         [string]$Path
     )
 
-    if (-not (Test-Path -LiteralPath $Path)) { return }
-    ConvertFrom-SnotraTraceLine -Line (Get-Content -LiteralPath $Path -ErrorAction SilentlyContinue)
+    # **読み実装は `Read-SnotraTraceSnapshot` の 1 つだけにする。** 以前はここが独自に
+    # Get-Content していたため、読み取り失敗の扱いが 2 か所にあり、片方だけが沈黙していた。
+    $snapshot = Read-SnotraTraceSnapshot -Path $Path
+    if ($snapshot.ReadError) {
+        Write-Warning "trace の読み取りに失敗しました（$Path）: $($snapshot.ReadError)"
+    }
+    return $snapshot.Events
 }
 
 <#
@@ -401,12 +406,26 @@ function Read-SnotraTraceSnapshot {
     )
 
     if ([string]::IsNullOrEmpty($Path) -or -not (Test-Path -LiteralPath $Path)) {
-        return @{ Available = $false; Lines = @(); Events = @(); TraceLines = 0; Dropped = 0 }
+        return @{ Available = $false; Lines = @(); Events = @(); TraceLines = 0; Dropped = 0; ReadError = $null }
     }
     # **1 度だけ読む。** 行数と parse 成功数を別々の読み取りから取ると、稼働中のアプリが間に
     # 書き足した行で差が壊れる（code-review M1）。**生行も返す**のは同じ理由で——presence の
     # 表示と不変条件の判定が別時点のファイルを見ないようにするため。
-    $lines = @(Get-Content -LiteralPath $Path -ErrorAction SilentlyContinue)
+    #
+    # **読み取りの失敗を空と同じ値へ潰さない**（#872）。`-ErrorAction SilentlyContinue` は
+    # 落ちた読みに対しても空を返すため、Available=true / Events 0 件 / Dropped 0 という
+    # **正常な空ログと見分けられない値**になり、稼働中のアプリを観測する経路で
+    # 「読めなかった」が「まだ出ていない」に化ける。読めなければ Available を倒す
+    # （`manual-smoke.ps1` の `Get-TraceVerdict` はこれを見て判定そのものを見送る）。
+    # **不在（ReadError=$null）と失敗（ReadError あり）は別の状態である。**
+    try {
+        $lines = @(Get-Content -LiteralPath $Path -ErrorAction Stop)
+    } catch {
+        return @{
+            Available = $false; Lines = @(); Events = @()
+            TraceLines = 0; Dropped = 0; ReadError = $_.Exception.Message
+        }
+    }
     $traceLineCount = 0
     foreach ($text in $lines) { if ($text -match '^\[trace\]\s+') { $traceLineCount++ } }
     $events = @(ConvertFrom-SnotraTraceLine -Line $lines)
@@ -416,7 +435,99 @@ function Read-SnotraTraceSnapshot {
         Events     = $events
         TraceLines = $traceLineCount
         Dropped    = [Math]::Max(0, $traceLineCount - $events.Count)
+        ReadError  = $null
     }
+}
+
+<#
+.SYNOPSIS
+trace に述語を満たす事象が現れるまで待つ（待ちループの唯一の実装）。
+
+.DESCRIPTION
+**待ちループの形は `Set-SnotraForegroundWindow` に揃える**——「評価 → 期限判定 → sleep」の順で、
+`while (now -lt deadline)` にしない。前者は**期限を跨いだ停止のあとでも必ず 1 度は評価する**が、
+後者は最後の sleep 中に停止が起きると、**既に成立していた条件を一度も見ないまま諦める**
+（#872 run 1306: 期待した事象は 39.354 に出ており期限は 42.57 以降だったのに観測されなかった）。
+
+**trace ファイルは追記のみの過去の記録である。**ゆえに期限後の 1 度の評価が「待ち時間を
+こっそり延ばす」ことにはならない——事象が起きたか否かは時刻に依らず確定している。ただし
+**期限後に初めて見つかったことは停止の徴候である**ため、見つけても警告を出して記録に残す。
+
+**却下した案: 期限を跨いだら見つかっても失敗にする。**「予算内に応答したか」を測る検査なら
+正しいが、この検査が判定するのはキャレット位置であって応答時間ではない。予算は待つ辛抱の
+上限にすぎず、そこへ性能の意味を後付けすると、遅い runner で**実装が正しいまま赤になる**。
+
+読み取りの失敗（`ReadError`）は成立判定に影響させない——その周回が「まだ見えていない」のと
+同じ扱いになるのは避けられないが、**件数を数えて必ず報告する**。沈黙させると #872 の 3 つの
+機序（期限跨ぎ・未着・読み取り失敗）が事後に区別できない。
+
+**諦める条件を scriptblock で受け取らない。** この関数は module スコープで評価するため、
+呼び出し側の変数を読むには閉包が要る。ところが `.GetNewClosure()` は Pester の `It` の中では
+**親スコープの変数を捕まえない**（実測: 予算 4000ms に対し中断せず 4031ms 待った）。捕まえ
+損ねても**発火しないだけ**なので通った実行では観測されず、「本体が死んでも予算いっぱい待つ」
+という退化が黙って入る。プロセスを型付きで受け取れば、この間違いは書けなくなる。
+#>
+function Wait-SnotraTraceCondition {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [Parameter(Mandatory)]
+        [scriptblock]$Predicate,
+        [Parameter(Mandatory)]
+        [int]$TimeoutMs,
+        [int]$PollMs = 100,
+        # 与えると、このプロセスが終了した時点で期限を待たずに諦める（待っても変わらないため）。
+        [System.Diagnostics.Process]$AbortIfExited,
+        [string]$Description = 'trace の条件'
+    )
+
+    $deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMs)
+    $started = [DateTime]::UtcNow
+    $rounds = 0
+    $readErrors = 0
+    $lastReadError = $null
+    $lastSnapshot = $null
+    $aborted = $false
+
+    while ($true) {
+        $rounds++
+        $snapshot = Read-SnotraTraceSnapshot -Path $Path
+        $lastSnapshot = $snapshot
+        if ($snapshot.ReadError) {
+            $readErrors++
+            $lastReadError = $snapshot.ReadError
+        }
+        $matched = @($snapshot.Events | Where-Object -FilterScript $Predicate | Select-Object -Last 1)
+        if ($matched.Count -gt 0) {
+            $elapsed = [int]([DateTime]::UtcNow - $started).TotalMilliseconds
+            if ([DateTime]::UtcNow -ge $deadline) {
+                Write-Warning ("$Description は予算 ${TimeoutMs}ms を過ぎた評価で成立しました" +
+                    "（${elapsed}ms・$rounds 周）。停止の徴候として記録します。")
+            }
+            if ($readErrors -gt 0) {
+                Write-Warning "$Description の待ちで trace の読み取りに失敗した周回が $readErrors 回ありました: $lastReadError"
+            }
+            return $matched[0]
+        }
+        if ($null -ne $AbortIfExited -and $AbortIfExited.HasExited) { $aborted = $true; break }
+        if ([DateTime]::UtcNow -ge $deadline) { break }
+        Start-Sleep -Milliseconds $PollMs
+    }
+
+    # **不成立の理由を区別できる形で残す。** 何も出さないと、期限切れ・事象未着・読み取り失敗が
+    # 呼び出し側からは同じ $null にしか見えない（#872 で 7 件目まで機序を割れなかった原因）。
+    $elapsed = [int]([DateTime]::UtcNow - $started).TotalMilliseconds
+    $reason = if ($aborted) { "本体が終了（exit=$($AbortIfExited.ExitCode)）" } else { '予算切れ' }
+    $seen = if ($null -ne $lastSnapshot -and $lastSnapshot.Available) {
+        "trace 行 $($lastSnapshot.TraceLines) / 事象 $($lastSnapshot.Events.Count) / 捨てた行 $($lastSnapshot.Dropped)"
+    } else {
+        'trace を読めていない'
+    }
+    Write-Warning ("$Description が成立しませんでした（$reason・${elapsed}ms・$rounds 周・" +
+        "読み取り失敗 $readErrors 回・最後に見たもの: $seen）。" +
+        $(if ($lastReadError) { " 最後の読み取りエラー: $lastReadError" } else { '' }))
+    return $null
 }
 
 function Wait-SnotraTraceEvent {
@@ -431,13 +542,10 @@ function Wait-SnotraTraceEvent {
         [int]$PollMs = 200
     )
 
-    $deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMs)
-    while ([DateTime]::UtcNow -lt $deadline) {
-        $match = @(Read-SnotraTraceEvents -Path $Path | Where-Object { $_.event -eq $EventName } | Select-Object -Last 1)
-        if ($match.Count -gt 0) { return $match[0] }
-        Start-Sleep -Milliseconds $PollMs
-    }
-    return $null
+    # 待ちループの形（期限跨ぎ・読み取り失敗の扱い）は `Wait-SnotraTraceCondition` が単独で持つ。
+    # ここに写しを置くと、穴を塞ぐ変更が片方だけに入る（#872 では実際に 2 か所へ分かれていた）。
+    return Wait-SnotraTraceCondition -Path $Path -TimeoutMs $TimeoutMs -PollMs $PollMs `
+        -Description "trace の $EventName" -Predicate { $_.event -eq $EventName }.GetNewClosure()
 }
 
 function Send-SnotraKey {
@@ -482,8 +590,11 @@ function Wait-SnotraWindow {
     )
 
     Initialize-SnotraNativeInterop
+    # 形は `Set-SnotraForegroundWindow` / `Wait-SnotraTraceCondition` に揃える（#872）——
+    # 「評価 → 期限判定 → sleep」。`while (now -lt deadline)` だと、最後の sleep を跨ぐ停止で
+    # **窓が現れていても一度も見ないまま**「現れませんでした」と落ちる。
     $deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMs)
-    while ([DateTime]::UtcNow -lt $deadline) {
+    while ($true) {
         $handle = [SnotraSmokeInterop.Native]::FindWindowW([NullString]::Value, $Title)
         $ownerMatches = $true
         if ($handle -ne [IntPtr]::Zero -and $null -ne $Process) {
@@ -497,6 +608,7 @@ function Wait-SnotraWindow {
         if ($null -ne $Process -and $Process.HasExited) {
             throw "本体が終了しました（exit=$($Process.ExitCode)）。窓 '$Title' を観測できません。"
         }
+        if ([DateTime]::UtcNow -ge $deadline) { break }
         Start-Sleep -Milliseconds $PollMs
     }
     throw "窓 '$Title' が ${TimeoutMs}ms 以内に現れませんでした。"
@@ -629,6 +741,7 @@ Export-ModuleMember -Function @(
     'Resolve-SnotraExistingProcess'
     'Read-SnotraTraceEvents'
     'Read-SnotraTraceSnapshot'
+    'Wait-SnotraTraceCondition'
     'Wait-SnotraTraceEvent'
     'Send-SnotraKey'
     'Send-SnotraKeyChord'

--- a/scripts/lib/SnotraTraceInvariants.Tests.ps1
+++ b/scripts/lib/SnotraTraceInvariants.Tests.ps1
@@ -432,6 +432,24 @@ Describe 'Read-SnotraTraceSnapshot（捨てた行の数え方）' {
         $snapshot = Read-SnotraTraceSnapshot -Path (Join-Path $TestDrive 'missing.log')
         $snapshot.Available | Should -BeFalse
         $snapshot.Events.Count | Should -Be 0
+        # 不在は「読み取りの失敗」ではない。両者を同じ値にすると、下の検査が区別を失う。
+        $snapshot.ReadError | Should -BeNullOrEmpty
+    }
+
+    It '読み取りに失敗したら Available=false と ReadError を立て、「読めた」と言わない（#872）' {
+        # ディレクトリは Test-Path が真で Get-Content が落ちる（実測）。`-ErrorAction
+        # SilentlyContinue` のままだと Available=true・Events 0 件・Dropped 0 という
+        # **正常な空ログと区別できない値**を返し、稼働中のアプリを観測する経路で
+        # 「読めなかった」が「まだ出ていない」に化ける。
+        $dir = Join-Path $TestDrive 'unreadable-snapshot'
+        New-Item -ItemType Directory -Force -Path $dir | Out-Null
+
+        $snapshot = Read-SnotraTraceSnapshot -Path $dir
+
+        $snapshot.Available | Should -BeFalse
+        $snapshot.ReadError | Should -Not -BeNullOrEmpty
+        $snapshot.Events.Count | Should -Be 0
+        $snapshot.Dropped | Should -Be 0
     }
 }
 

--- a/scripts/lib/SnotraTraceInvariants.Tests.ps1
+++ b/scripts/lib/SnotraTraceInvariants.Tests.ps1
@@ -453,6 +453,71 @@ Describe 'Read-SnotraTraceSnapshot（捨てた行の数え方）' {
     }
 }
 
+Describe 'Get-SnotraTraceFailureCount（赤とみなす状態の定義）' {
+    BeforeAll {
+        function New-Verdict {
+            param([hashtable]$Overall = @{}, [bool]$JudgeFailed = $false)
+            $all = @{}
+            foreach ($n in (Get-SnotraTraceInvariantNames)) {
+                $all[$n] = if ($Overall.ContainsKey($n)) { $Overall[$n] } else { 'SKIP' }
+            }
+            return @{ Overall = $all; JudgeFailed = $JudgeFailed }
+        }
+    }
+
+    It 'trace を読めなかったら赤にする（観測不能を成功として終えない）' {
+        # #872: `Read-SnotraTraceSnapshot` が読み取り失敗を Available=false へ倒すので、
+        # 判定は走らず Verdict は $null になる。**ここで 0 を返すと、権限・共有違反で
+        # 読みが落ちた実行が exit 0 で終わる**——この PR が塞いでいる false green そのもの。
+        Get-SnotraTraceFailureCount -Verdict $null -ReadError 'Unable to get content' | Should -Be 1
+    }
+
+    It 'trace の不在は赤にしない（-NoLaunch や 1 行も出ていない実行）' {
+        # 読み取り失敗と同じ扱いにすると、trace を出さない正当な使い方が常に失敗する。
+        Get-SnotraTraceFailureCount -Verdict $null -ReadError $null | Should -Be 0
+        Get-SnotraTraceFailureCount -Verdict $null -ReadError '' | Should -Be 0
+    }
+
+    It '不変条件の FAIL を数える' {
+        $names = @(Get-SnotraTraceInvariantNames)
+        $verdict = New-Verdict -Overall @{ $names[0] = 'FAIL'; $names[1] = 'FAIL' }
+        Get-SnotraTraceFailureCount -Verdict $verdict -ReadError $null | Should -Be 2
+    }
+
+    It '判定器の例外も赤にする（例外は欠陥であって無事ではない）' {
+        Get-SnotraTraceFailureCount -Verdict (New-Verdict -JudgeFailed $true) -ReadError $null | Should -Be 1
+    }
+
+    It '全 SKIP は赤にしない（調べられなかったことを違反として数えない）' {
+        Get-SnotraTraceFailureCount -Verdict (New-Verdict) -ReadError $null | Should -Be 0
+    }
+
+    It '赤は積み上がる（FAIL と例外と読み取り失敗が互いを隠さない）' {
+        $names = @(Get-SnotraTraceInvariantNames)
+        $verdict = New-Verdict -Overall @{ $names[0] = 'FAIL' } -JudgeFailed $true
+        Get-SnotraTraceFailureCount -Verdict $verdict -ReadError 'boom' | Should -Be 3
+    }
+}
+
+Describe 'Get-SnotraTraceFailedInvariants' {
+    It '母集団を Get-SnotraTraceInvariantNames から引く（呼び出し側が名前を写さない）' {
+        # 不変条件を 1 つ足したとき、呼び出し側の写しが黙って取りこぼすのを防ぐ。
+        $names = @(Get-SnotraTraceInvariantNames)
+        $row = @{}
+        foreach ($n in $names) { $row[$n] = 'PASS' }
+        $row[$names[-1]] = 'FAIL'
+
+        $failed = @(Get-SnotraTraceFailedInvariants -Verdicts $row)
+
+        $failed.Count | Should -Be 1
+        $failed[0] | Should -Be $names[-1]
+    }
+
+    It '判定表が無ければ空を返す（呼び出し側に null 分岐を書かせない）' {
+        @(Get-SnotraTraceFailedInvariants -Verdicts $null).Count | Should -Be 0
+    }
+}
+
 Describe 'Format-SnotraTraceVerdictTable' {
     It '区間ごとの判定を markdown の表として返す' {
         $events = @(

--- a/scripts/lib/SnotraTraceInvariants.psm1
+++ b/scripts/lib/SnotraTraceInvariants.psm1
@@ -511,6 +511,70 @@ function Get-SnotraTraceSectionVerdict {
 
 <#
 .SYNOPSIS
+判定表（`Overall` または区間の行）のうち FAIL の不変条件名を返す。
+
+.DESCRIPTION
+**「FAIL という値で赤を見分ける」規則を呼び出し側へ写さないための口である。**
+素の `Where-Object { $row[$_] -eq 'FAIL' }` を各所に書くと、判定値の集合を変えたとき
+（例: FAIL を細分する）に一部だけが追随する。名前の母集団も
+`Get-SnotraTraceInvariantNames` から引くので、不変条件を 1 つ足したときに
+呼び出し側の写しが黙って取りこぼすことがない。
+#>
+function Get-SnotraTraceFailedInvariants {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [hashtable]$Verdicts
+    )
+
+    if ($null -eq $Verdicts) { return @() }
+    return @(Get-SnotraTraceInvariantNames | Where-Object { $Verdicts[$_] -eq 'FAIL' })
+}
+
+<#
+.SYNOPSIS
+trace 側の「赤」の件数を返す。0 なら trace は合否を下げない。
+
+.DESCRIPTION
+**赤とみなす状態の定義を 1 か所に置く。** 呼び出し側（`manual-smoke.ps1` の exit code、
+記録、端末表示）がそれぞれ数え直すと、状態を 1 つ足したときに一部だけが追随し、
+**新しい赤が exit code から黙って落ちる**。
+
+赤は 3 つある。いずれも「問題が無かった」ではない:
+
+- 不変条件の **FAIL**（違反そのもの）
+- **判定器の例外**（`JudgeFailed`）——例外は欠陥であって無事ではない（code-review C2）
+- **trace を読めなかった**（`ReadError`）——観測できなかったことを成功として終えると、
+  権限・共有違反で読みが落ちた実行が緑になる（#872。`Read-SnotraTraceSnapshot` が
+  読み取り失敗と不在を区別しているのは、この判断のためである）
+
+**trace の不在（`-NoLaunch` で起動した・まだ 1 行も出ていない）は赤ではない。**
+`ReadError` が無いまま `Verdict` が `$null` の場合がそれで、0 を返す——ここを赤に
+倒すと、trace を出さない正当な使い方が常に失敗する。
+#>
+function Get-SnotraTraceFailureCount {
+    [CmdletBinding()]
+    param(
+        # `Test-SnotraTraceInvariants` の結果。判定していなければ $null。
+        [AllowNull()]
+        [hashtable]$Verdict,
+        # `Read-SnotraTraceSnapshot` の ReadError。読めていれば $null。
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$ReadError
+    )
+
+    $count = 0
+    if (-not [string]::IsNullOrEmpty($ReadError)) { $count++ }
+    if ($null -ne $Verdict) {
+        $count += @(Get-SnotraTraceFailedInvariants -Verdicts $Verdict.Overall).Count
+        if ($Verdict.JudgeFailed) { $count++ }
+    }
+    return $count
+}
+
+<#
+.SYNOPSIS
 不変条件ごとの件数を 1 行へ畳む。`-Compact` は端末向けの短い形。
 
 .DESCRIPTION
@@ -600,6 +664,8 @@ Export-ModuleMember -Function @(
     'Get-SnotraTraceMarker'
     'Test-SnotraTraceInvariants'
     'Get-SnotraTraceSectionVerdict'
+    'Get-SnotraTraceFailedInvariants'
+    'Get-SnotraTraceFailureCount'
     'Format-SnotraTraceCountSummary'
     'Format-SnotraTraceVerdictTable'
 )

--- a/scripts/manual-smoke.ps1
+++ b/scripts/manual-smoke.ps1
@@ -249,7 +249,14 @@ function Show-Trace([string[]]$patterns, [array]$sectionList) {
   # アプリが間に書き足した行で「並べた presence」と「判定した列」が食い違う。
   $snapshot = Get-TraceSnapshot
   if (-not $snapshot.Available) {
-    Write-Host "  （trace なし: -NoLaunch で起動したか、まだ 1 行も出ていません）" -ForegroundColor DarkGray
+    # **不在と読み取り失敗を同じ文言にしない**（#872）。`Available=false` へ至る経路が
+    # 2 本になったので、片方の説明だけを出すと**読めなかった実行を「まだ出ていません」と
+    # 誤って説明する**——目視の判断材料が嘘になる。
+    if ($snapshot.ReadError) {
+      Write-Host "  （trace を読めませんでした: $($snapshot.ReadError)）" -ForegroundColor Red
+    } else {
+      Write-Host "  （trace なし: -NoLaunch で起動したか、まだ 1 行も出ていません）" -ForegroundColor DarkGray
+    }
     return
   }
   if ($patterns.Count -eq 0) {

--- a/scripts/manual-smoke.ps1
+++ b/scripts/manual-smoke.ps1
@@ -339,7 +339,7 @@ foreach ($r in $results) {
   if ($null -eq $traceVerdict) { continue }
   $row = Get-SnotraTraceSectionVerdict -Result $traceVerdict -SectionId $r.id
   if ($null -eq $row) { continue }
-  $traceFailed = @($script:InvariantNames | Where-Object { $row[$_] -eq 'FAIL' })
+  $traceFailed = @(Get-SnotraTraceFailedInvariants -Verdicts $row)
   if ($traceFailed.Count -gt 0 -and $r.verdict -eq 'PASS') {
     $mismatches += "項目 $($r.id)「$($r.title)」— **目視 PASS だが trace は $($traceFailed -join ', ') が FAIL**。目視で見落とした回帰の可能性がある"
   } elseif ($traceFailed.Count -eq 0 -and $r.verdict -eq 'FAIL') {
@@ -353,11 +353,10 @@ $pass = @($done | Where-Object { $_.verdict -eq "PASS" }).Count
 $fail = @($done | Where-Object { $_.verdict -eq "FAIL" }).Count
 $skip = @($done | Where-Object { $_.verdict -eq "SKIP" }).Count
 $notRun = @($items | Where-Object { $id = $_.id; -not ($done | Where-Object { $_.id -eq $id }) })
-# **判定器の例外も赤にする**（code-review C2）——例外は欠陥であって「問題が無かった」ではない。
-$traceFail = if ($null -ne $traceVerdict) {
-  @($script:InvariantNames | Where-Object { $traceVerdict.Overall[$_] -eq 'FAIL' }).Count +
-  $(if ($traceVerdict.JudgeFailed) { 1 } else { 0 })
-} else { 0 }
+# **赤とみなす状態の定義は `Get-SnotraTraceFailureCount` が単独で持つ**——違反・判定器の例外
+# （code-review C2）・trace を読めなかったこと（#872）の 3 つ。ここで数え直すと、赤を 1 つ
+# 足したときに exit code だけが追随しない。
+$traceFail = Get-SnotraTraceFailureCount -Verdict $traceVerdict -ReadError $finalSnapshot.ReadError
 
 $lines = @()
 $lines += "## カテゴリ D 目視スモークの記録"
@@ -381,6 +380,11 @@ if ($null -ne $traceVerdict) {
     $lines += "| 注意 | **判定器は ``egui_results:show`` を 1 件も見ていない**（イベント名のドリフトの可能性——H4 / H5 は事実上検査されていない） |"
   }
   $lines += "| trace 行 | $($finalSnapshot.TraceLines) 行中 $($finalSnapshot.Events.Count) 行を parse / **捨てた行 $($finalSnapshot.Dropped)** |"
+} elseif ($finalSnapshot.ReadError) {
+  # **不在と読み取り失敗を同じ行にしない**（#872）。読めなかった実行を「1 行も出ていない」と
+  # 記録へ書き残すと、後から読む人は trace が出ていないほうを疑い、**観測が落ちた事実が
+  # 記録から消える**。exit code 側は `Get-SnotraTraceFailureCount` が赤にしている。
+  $lines += "| trace 不変条件 | **読めなかった**（$($finalSnapshot.ReadError)）——判定していない。観測不能であって「問題なし」ではない |"
 } else {
   $lines += "| trace 不変条件 | **判定していない**（trace なし: ``-NoLaunch`` で起動したか 1 行も出ていない） |"
 }
@@ -432,6 +436,9 @@ if ($null -ne $traceVerdict) {
   if ($finalSnapshot.Dropped -gt 0) {
     Write-Host "  parse できなかった行が $($finalSnapshot.Dropped) 件あるため PASS を SKIP へ落としました。" -ForegroundColor Yellow
   }
+} elseif ($finalSnapshot.ReadError) {
+  Write-Host "=== trace 不変条件: 読めなかった（判定していない） ===" -ForegroundColor Red
+  Write-Host "  $($finalSnapshot.ReadError)" -ForegroundColor Red
 } else {
   Write-Host "=== trace 不変条件: 判定していない（trace なし） ===" -ForegroundColor Yellow
 }

--- a/scripts/smoke-startup.ps1
+++ b/scripts/smoke-startup.ps1
@@ -73,16 +73,18 @@ for ($run = 1; $run -le $Iterations; $run++) {
   # 固定待機を一律に伸ばすと 5 起動 × 予算が常時かかる。最初の 1 行を待つ形なら、
   # 速い起動は速いまま・遅い起動だけ待つ。$WaitMs は**最初の trace 以降**の観測窓として
   # 残す——ここを縮めると後続の first-run イベントを取りこぼし、検査が痩せる。
-  $firstTraceMs = $null
+  # **待つのは「最初の行」ではなく「最初の `[trace]` 行」である**（#786）。行の存在だけを
+  # 見ると、アプリが最初に stderr へ出す `[index-load] ...`（非 trace の診断行）で抜けてしまい、
+  # 観測窓が**まだ 1 件も trace が出ていない時点**で開く——#690 が塞いだはずの穴が同じ
+  # 関数の中で開いたままだった。**キャッシュが温まっているほど `[index-load]` が早く出るので、
+  # 開発機ほど早く失敗する**（CI と手元で挙動が分かれる）。
+  #
+  # 判定の形は `Wait-SnotraTraceCondition` が単独で持つ（#872）——期限跨ぎの取りこぼしと
+  # 読み取り失敗の沈黙もそこで塞がっている。ここに写しを置かない。
   $swFirst = [System.Diagnostics.Stopwatch]::StartNew()
-  while ($swFirst.Elapsed.TotalMilliseconds -lt $FirstTraceTimeoutMs) {
-    if ((Test-Path $errPath) -and @(Get-Content $errPath -ErrorAction SilentlyContinue).Count -gt 0) {
-      $firstTraceMs = [int]$swFirst.Elapsed.TotalMilliseconds
-      break
-    }
-    if ($proc.HasExited) { break }
-    Start-Sleep -Milliseconds 100
-  }
+  $firstEvent = Wait-SnotraTraceCondition -Path $errPath -Predicate { $true } `
+    -TimeoutMs $FirstTraceTimeoutMs -PollMs 100 -AbortIfExited $proc -Description '最初の trace'
+  $firstTraceMs = if ($null -eq $firstEvent) { $null } else { [int]$swFirst.Elapsed.TotalMilliseconds }
 
   Start-Sleep -Milliseconds $WaitMs
   if (-not $proc.HasExited) {


### PR DESCRIPTION
## 何をしたか

trace を待つ観測側に開いていた穴を塞ぎ、待ちループと trace の読みを 1 つの実装へ寄せた。ついでに、同じ穴を持っていた `smoke:startup` のガード（#786）を同じ道具で直す。

コミットは 2 本:

1. `c796819` — 期限跨ぎと沈黙する読み取り失敗を塞ぐ（#872 の観測側）
2. `3fe7984` — `smoke:startup` が「最初の `[trace]` 行」を待つようにする（#786）

## なぜ

### #872 — run 1306 の機序が 3 通りに割れたまま決着しなかった

期待した事象は**予算の内側**（39.354 / 期限 ≧42.57）で発生していたのに観測されなかった。説明は 3 つあり、手元の証拠ではどれとも決められなかった。**そのうち 2 つを機構で消し、残る 1 つを事後に区別できるようにする。**

**(1) 期限跨ぎ — 消した。** 待ちループが `while (now -lt deadline) { 評価; sleep }` の形だと、最後の sleep を跨ぐ停止で**既に成立していた条件を一度も見ないまま**諦める。`Set-SnotraForegroundWindow` が #871 で既に採っていた `while ($true) { 評価; 期限判定; sleep }` へ揃えた。

trace は**追記のみの過去の記録**なので、期限後の 1 度の評価は待ち時間を延ばす意味を持たない——事象が起きたか否かは時刻に依らず確定している。ただし期限後に初めて成立したことは停止の徴候ゆえ警告に残す。

> **却下した案: 期限を跨いだら見つかっても失敗にする。** 「予算内に応答したか」を測る検査なら正しいが、この検査が判定するのはキャレット位置であって応答時間ではない。予算に性能の意味を後付けすると、遅い runner で**実装が正しいまま赤になる**。

同じ穴は `Wait-SnotraWindow` にも在った（`AGENTS.md`「同一パターン全コードパス検索」）。

**(2) 沈黙する読み取り失敗 — 消した。** `Get-Content -ErrorAction SilentlyContinue` は落ちた読みにも空を返すため、`Read-SnotraTraceSnapshot` が `Available=true` / 事象 0 件 / 捨てた行 0 という**正常な空ログと見分けられない値**を返していた。読めなければ `Available` を倒し、`ReadError` で不在と区別する。

実測: ディレクトリを渡すと `Test-Path` は真で `Get-Content` が落ちる。これを決定的な fixture に使っている。

**(3) 行がまだ可視でなかった — 消せない。** 機構で扱えないので、**事後に区別できるようにする**: 待ちが不成立で終わるとき、周回数・経過・読み取り失敗の回数・最後に見た trace 行数/事象数/捨てた行数を必ず出す。次に落ちたときは 3 通りを切り分けられる。

### #786 — #690 が塞いだはずの穴が同じ関数の中で開いていた

`smoke:startup` のガードは「最初の trace が出るまで待つ」意図だったが、**行の存在しか見ていなかった**。アプリが stderr へ最初に出す `[index-load] ...` は `[trace]` 行ではないので、ガードはここで抜け、観測窓が**まだ 1 件も trace が出ていない時点**で開いていた。

**キャッシュが温まっているほど `[index-load]` が早く出るため、開発機ほど早く失敗する。**

判定は `Wait-SnotraTraceCondition` へ委ねた。手書きのループを残すと、上で塞いだ 2 つの穴がこの経路にだけ残る。

## 構造

待ちループと trace の読みが、それぞれ**2 箇所へ写されていた**（`Wait-SnotraTraceEvent` と実機配管の `waitForInputChange` / `Read-SnotraTraceEvents` と `Read-SnotraTraceSnapshot`）。#872 では実際に「穴を塞ぐ変更が片方だけに入る」形になりうる配置だったので、1 つへ寄せた。

**諦める条件は scriptblock ではなくプロセスを型で受け取る。** この関数は module スコープで評価するため呼び出し側の変数を読むには閉包が要るが、`.GetNewClosure()` は **Pester の `It` の中で親スコープの変数を捕まえない**（実測: 予算 4000ms に対し中断せず 4031ms 待った）。捕まえ損ねても**発火しないだけ**なので、通った実行では永久に観測されず、「本体が死んでも予算いっぱい待つ」という退化が黙って入る。型付きで受け取ればこの間違いは書けない。

## 検証

| カテゴリ | 判定 | 根拠 |
|---|---|---|
| A（Rust） | 該当なし | `*.rs` を変更していない |
| B（TypeScript） | 該当なし | `*.ts` を変更していない |
| C（ウィンドウ生成・ホットキー経路） | **実行** | 下記。製品コードではないが、その経路を検証する配管そのものを変えたため意味で該当と判定 |
| D（UI スタイル・レイアウト） | 該当なし | 製品側の描画・レイアウト・文言を変更していない |
| E（git hook） | 該当なし | `.githooks/**` を変更していない |
| F（ガバナンス文書） | 該当なし | `*.md`・`.claude/rules/`・`.claude/skills/`・workflow のいずれも変更していない |

```
npm test                  568 passed (7 files)
npm run test:powershell   59 passed / 0 failed（単体 57 + 統合 2）
npm run smoke:startup     5 runs passed（#786 修正後）
npm run smoke:egui        passed（show/hide + results show/hide・webview delta 0）
```

**#786 修正の実測**: `first_trace_ms` が **234〜348ms → 351〜478ms** へ上がった。差は `[index-load]` から最初の `[trace]` 行までの時間であり、ガードが見るものが変わったことの直接の証拠である。

**フォールトインジェクション**（`.claude/rules/safety-nets.md`）: Red の時点で旧実装が `TimeoutMs=0` で `$null` を返し、読めないパスに `Available=$true` と答えることを確認した。稼働中のガードは弱めず、テスト側の fixture に変異を当てている。

### 追加したテストと、それが固定する不変条件

| テスト | 不変条件 |
|---|---|
| 予算が尽きていても条件を必ず 1 度は評価する | 期限跨ぎの停止で、成立済みの条件を取りこぼさない |
| 読み取りに失敗した周回を沈黙へ潰さない | 待ち側で「読めなかった」が「まだ出ていない」に化けない |
| 本体が終了していれば予算を待たずに諦める | 閉包の退化（発火しないまま予算を使い切る）の検知点 |
| 読み取りに失敗したら `Available=false` と `ReadError` を立てる | snapshot が正常な空ログと読み取り失敗を区別する |
| 不在では `ReadError` を立てない | 不在と失敗が別の状態であり続ける |
| `-ShowIcons` を TOML の真偽値として書く | （#887 で追加済み） |

## レビュー

- `/dry-check` — **実施**。候補 3 件、うち 1 件（`smoke-startup.ps1`）を本 PR で置換、2 件は [維持]（`index.bin` の出現待ちは観測対象がファイル存在で穴が無い / `smoke-egui.ps1` の事後観測は合否判定ではなく証拠採取）
- `/symmetric-check` — **実施**。発見 **1 件・修正済み**: `Available=false` への経路が 2 本になったのに `manual-smoke.ps1` の説明が「まだ 1 行も出ていません」のままで、読めなかった実行を誤って説明していた
- 該当なし — `/race-check`・`/cache-check`・`/persistence-check`・`/state-check`
- `code-reviewer` エージェント — **未実施**。理由: 作業したセッションの制約でエージェントを起動していない。**独立レビューは成立していない**

## 射程外

#872 の 3 つの現れ方のうち、**前面化（現れ方 1）はそのまま残る**。run 1280 / 1299 で発生しており、#871 の後も再発している。候補 (b)（前面非依存の注入経路）でしか消えず、そちらは #872 が「未検証」と明記している規模である。

Closes #786
Refs #872

🤖 Generated with [Claude Code](https://claude.com/claude-code)
