### PR TITLE
fix(scripts): debug ビルドのコンソール窓に前面を奪わせない（#872 現れ方 1 の原因）

### DIFF
--- a/scripts/lib/SnotraSmoke.Tests.ps1
+++ b/scripts/lib/SnotraSmoke.Tests.ps1
@@ -108,10 +108,8 @@ Describe 'Start-SnotraProcess' {
     }
 
     It 'コンソール窓を見せずに起動する（debug ビルドが前面を奪うのを防ぐ）' {
-        # #872 現れ方 1: debug は console サブシステムなので、stdio をリダイレクトすると
-        # `ConsoleWindowClass` の窓が実行ファイルのフルパスを題名にして作られる。それが前面を
-        # 奪うと打鍵の宛先が本体の窓に定まらない。**通った実行では発火しない**ため、
-        # ここでしか観測されない。
+        # 回帰テスト: #872 現れ方 1（機序は `Start-SnotraProcess` のコメントが正本）。
+        # **通った実行では発火しない**ため、この不変条件はここでしか観測されない。
         Mock -ModuleName SnotraSmoke Start-Process { }
 
         Start-SnotraProcess -ConfigDir 'p' -FilePath 'x.exe' -StandardErrorPath 'e.txt'
@@ -122,8 +120,7 @@ Describe 'Start-SnotraProcess' {
     }
 
     It 'NoNewWindow のときは WindowStyle を渡さない（Start-Process の排他な引数）' {
-        # 両方渡すと Start-Process がパラメータセットの衝突で落ちる。`-NoNewWindow` は
-        # 呼び出し元のコンソールを共有する＝新しい窓を作らないので、目的は同じく満たす。
+        # 回帰テスト: #872（排他の理由は `Start-SnotraProcess` のコメントが正本）。
         Mock -ModuleName SnotraSmoke Start-Process { }
 
         Start-SnotraProcess -ConfigDir 'p' -FilePath 'x.exe' -NoNewWindow

--- a/scripts/lib/SnotraSmoke.Tests.ps1
+++ b/scripts/lib/SnotraSmoke.Tests.ps1
@@ -106,6 +106,32 @@ Describe 'Start-SnotraProcess' {
             if ($savedTraceExists) { $env:SNOTRA_TRACE = $savedTrace } else { Remove-Item Env:SNOTRA_TRACE -ErrorAction SilentlyContinue }
         }
     }
+
+    It 'コンソール窓を見せずに起動する（debug ビルドが前面を奪うのを防ぐ）' {
+        # #872 現れ方 1: debug は console サブシステムなので、stdio をリダイレクトすると
+        # `ConsoleWindowClass` の窓が実行ファイルのフルパスを題名にして作られる。それが前面を
+        # 奪うと打鍵の宛先が本体の窓に定まらない。**通った実行では発火しない**ため、
+        # ここでしか観測されない。
+        Mock -ModuleName SnotraSmoke Start-Process { }
+
+        Start-SnotraProcess -ConfigDir 'p' -FilePath 'x.exe' -StandardErrorPath 'e.txt'
+
+        Should -Invoke -ModuleName SnotraSmoke Start-Process -Times 1 -ParameterFilter {
+            $WindowStyle -eq 'Hidden'
+        }
+    }
+
+    It 'NoNewWindow のときは WindowStyle を渡さない（Start-Process の排他な引数）' {
+        # 両方渡すと Start-Process がパラメータセットの衝突で落ちる。`-NoNewWindow` は
+        # 呼び出し元のコンソールを共有する＝新しい窓を作らないので、目的は同じく満たす。
+        Mock -ModuleName SnotraSmoke Start-Process { }
+
+        Start-SnotraProcess -ConfigDir 'p' -FilePath 'x.exe' -NoNewWindow
+
+        Should -Invoke -ModuleName SnotraSmoke Start-Process -Times 1 -ParameterFilter {
+            $NoNewWindow -eq $true -and $null -eq $WindowStyle
+        }
+    }
 }
 
 Describe 'Resolve-SnotraCargoExecutable' {

--- a/scripts/lib/SnotraSmoke.psm1
+++ b/scripts/lib/SnotraSmoke.psm1
@@ -291,17 +291,18 @@ function Start-SnotraProcess {
     # `ConsoleWindowClass` の窓が**実行ファイルのフルパスを題名にして**作られる。この窓が
     # 前面を奪うと、`Set-SnotraForegroundWindow` は本体の窓を前面にできず、注入した打鍵の
     # 宛先が定まらない——CI で実測した前面窓は
-    # `title='D:\a\Snotra\Snotra\target\debug\snotra.exe'` だった（run #1280 / #1299）。
+    # `title='D:\a\Snotra\Snotra\target\debug\snotra.exe'` だった（run 1280 / 1299）。
     # **release を使う `smoke-egui` が同じキー注入をしながら一度も踏んでいない**のは、
     # release にこの窓が無いためである。
     #
+    # **`Hidden` は隠すだけで、窓は在る**（実測: `ConsoleWindowClass` が visible=False で残る）。
+    # 前面は奪わなくなるが、窓を列挙する種類の検査を足すときは母集団に混じる。作らせない形は
+    # `ProcessStartInfo.CreateNoWindow`（実測: 窓 0 個）だが、`Start-Process` が露出しておらず
+    # `PassThru` 相当・引数のクォート規則・リダイレクトの再導出が要る。この 1 件には見合わない。
+    #
     # `-WindowStyle` と `-NoNewWindow` は排他なので分ける。`-NoNewWindow` は子が呼び出し元の
     # コンソールを使う＝新しい窓を作らないため、こちらも競合相手を増やさない。
-    if ($NoNewWindow) {
-        $startParameters.NoNewWindow = $true
-    } else {
-        $startParameters.WindowStyle = 'Hidden'
-    }
+    if ($NoNewWindow) { $startParameters.NoNewWindow = $true } else { $startParameters.WindowStyle = 'Hidden' }
 
     Invoke-SnotraEnvironment -Variables $variables -ScriptBlock {
         Start-Process @startParameters
@@ -652,8 +653,7 @@ function Get-SnotraForegroundWindowLabel {
     $title = New-Object System.Text.StringBuilder 256
     [void][SnotraSmokeInterop.Native]::GetWindowTextW($handle, $title, $title.Capacity)
     # **クラス名も出す**（#872）。題名だけでは、前面を握っていたのが本体の窓なのか
-    # debug ビルドが連れてくるコンソール窓（`ConsoleWindowClass`）なのかを
-    # 事後に確定できない——現れ方 1 の機序を突き止めるのに 2 回の発生を要した。
+    # debug ビルドが連れてくるコンソール窓（`ConsoleWindowClass`）なのかを事後に確定できない。
     $class = New-Object System.Text.StringBuilder 256
     [void][SnotraSmokeInterop.Native]::GetClassNameW($handle, $class, $class.Capacity)
     [uint32]$ownerPid = 0

--- a/scripts/lib/SnotraSmoke.psm1
+++ b/scripts/lib/SnotraSmoke.psm1
@@ -24,6 +24,8 @@ public static extern bool SetForegroundWindow(IntPtr hWnd);
 public static extern IntPtr GetForegroundWindow();
 [DllImport("user32.dll", CharSet = CharSet.Unicode)]
 public static extern int GetWindowTextW(IntPtr hWnd, System.Text.StringBuilder text, int count);
+[DllImport("user32.dll", CharSet = CharSet.Unicode)]
+public static extern int GetClassNameW(IntPtr hWnd, System.Text.StringBuilder text, int count);
 [DllImport("user32.dll")]
 public static extern bool SetProcessDpiAwarenessContext(IntPtr value);
 [DllImport("user32.dll")]
@@ -283,7 +285,23 @@ function Start-SnotraProcess {
     if ($PSBoundParameters.ContainsKey('ArgumentList')) { $startParameters.ArgumentList = $ArgumentList }
     if ($PSBoundParameters.ContainsKey('StandardErrorPath')) { $startParameters.RedirectStandardError = $StandardErrorPath }
     if ($PSBoundParameters.ContainsKey('StandardOutputPath')) { $startParameters.RedirectStandardOutput = $StandardOutputPath }
-    if ($NoNewWindow) { $startParameters.NoNewWindow = $true }
+    # **debug ビルドはコンソール窓を連れてくる。それを見せない**（#872 の現れ方 1）。
+    # `main.rs` の `#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]` により
+    # debug はコンソールサブシステムであり、stdio をリダイレクトして起動すると
+    # `ConsoleWindowClass` の窓が**実行ファイルのフルパスを題名にして**作られる。この窓が
+    # 前面を奪うと、`Set-SnotraForegroundWindow` は本体の窓を前面にできず、注入した打鍵の
+    # 宛先が定まらない——CI で実測した前面窓は
+    # `title='D:\a\Snotra\Snotra\target\debug\snotra.exe'` だった（run #1280 / #1299）。
+    # **release を使う `smoke-egui` が同じキー注入をしながら一度も踏んでいない**のは、
+    # release にこの窓が無いためである。
+    #
+    # `-WindowStyle` と `-NoNewWindow` は排他なので分ける。`-NoNewWindow` は子が呼び出し元の
+    # コンソールを使う＝新しい窓を作らないため、こちらも競合相手を増やさない。
+    if ($NoNewWindow) {
+        $startParameters.NoNewWindow = $true
+    } else {
+        $startParameters.WindowStyle = 'Hidden'
+    }
 
     Invoke-SnotraEnvironment -Variables $variables -ScriptBlock {
         Start-Process @startParameters
@@ -633,9 +651,14 @@ function Get-SnotraForegroundWindowLabel {
 
     $title = New-Object System.Text.StringBuilder 256
     [void][SnotraSmokeInterop.Native]::GetWindowTextW($handle, $title, $title.Capacity)
+    # **クラス名も出す**（#872）。題名だけでは、前面を握っていたのが本体の窓なのか
+    # debug ビルドが連れてくるコンソール窓（`ConsoleWindowClass`）なのかを
+    # 事後に確定できない——現れ方 1 の機序を突き止めるのに 2 回の発生を要した。
+    $class = New-Object System.Text.StringBuilder 256
+    [void][SnotraSmokeInterop.Native]::GetClassNameW($handle, $class, $class.Capacity)
     [uint32]$ownerPid = 0
     [void][SnotraSmokeInterop.Native]::GetWindowThreadProcessId($handle, [ref]$ownerPid)
-    return "0x$($handle.ToString('X')) pid=$ownerPid title='$($title.ToString())'"
+    return "0x$($handle.ToString('X')) pid=$ownerPid class='$($class.ToString())' title='$($title.ToString())'"
 }
 
 <#


### PR DESCRIPTION
## 何をしたか

#872 の**現れ方 1（前面化）の原因を特定して取り除く**。`Start-SnotraProcess` が `-WindowStyle Hidden` で起動するようにし、debug ビルドが連れてくるコンソール窓を見せない。

## 原因は runner ではなく、本体自身のコンソール窓だった

本 issue は現れ方 1 を「打鍵の宛先が前面窓でしか決まらず、前面を奪えるかが runner 側の都合で揺れる」と機序づけ、候補 (b)（`PostMessageW` への切り替え）でしか消えないとしていた。**それは誤りである。**

CI が記録していた前面窓を読み直したところ、こうだった（run [1299](https://github.com/finelagusaz/Snotra/actions/runs/30726104252)）:

```
WARNING: 窓 0x30186 を 3000ms 以内に前面化できません
（前面: 0x7006E pid=2200 title='D:\a\Snotra\Snotra\target\debug\snotra.exe'）
```

**題名が実行ファイルのフルパス**である。これはコンソール窓の名乗り方であり、本体の窓（題名 `Snotra`）ではない。

`src-tauri/src/main.rs:8` の `#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]` により **debug はコンソールサブシステム**であり、stdio をリダイレクトして起動すると `ConsoleWindowClass` の窓が作られる。それが前面を奪えば、打鍵は本体ではなくそちらへ行く。

### ローカルでの実測

| 起動の仕方 | コンソール窓 | 本体の窓 | `Set-SnotraForegroundWindow` |
|---|---|---|---|
| 既定 | `PseudoConsoleWindow`（この機体は ConPTY ゆえ競合しない） | visible=True | — |
| `-WindowStyle Hidden` | `class='ConsoleWindowClass'` `title='C:\workspace\Snotra\target\debug\snotra.exe'` が **visible=False** | **visible=True** | **True** |

**runner の警告に出ていた窓と、クラスも題名の形も一致する。**

### 裏づけになる非対称

**release を使う `smoke-egui` は、同じ `keybd_event` によるキー注入をしながら現れ方 1 を一度も踏んでいない。** release には `windows_subsystem = "windows"` が効いてこの窓が無い。原因が実行環境ではなく**ビルドプロファイル**にあることの、独立した傍証である。

## 候補 (b) は要らない

本 issue の候補 (b) は「`keybd_event`（グローバル）→ 対象 hwnd への `PostMessageW` に替えれば要素 1 が消える」というもので、**egui 側の modifier 状態や IME 経路が同じに再現されるかは未検証**と明記されていた。競合していた窓を消せば前面の奪取は成立するので、その未検証の置き換えに踏み込む理由が無くなる。

## 実装

- `-WindowStyle` と `-NoNewWindow` は `Start-Process` の排他な引数なので分岐する。`-NoNewWindow`（`visual-check-colors.ps1` のみ）は子が呼び出し元のコンソールを共有する＝**新しい窓を作らない**ため、こちらも競合相手を増やさない。同じ形の経路として列挙したが、欠陥は持たないので変更していない
- `Get-SnotraForegroundWindowLabel` にクラス名を足す。題名だけでは、前面を握っていたのが本体の窓かコンソール窓かを事後に確定できない——**この機序を突き止めるのに 2 回の発生を要した**

## 検証

| カテゴリ | 判定 | 根拠 |
|---|---|---|
| A（Rust） | 該当なし | `*.rs` を変更していない |
| B（TypeScript） | 該当なし | `*.ts` を変更していない |
| C（ウィンドウ生成・ホットキー経路） | **実行** | 下記。窓の生成条件そのものを変えるため該当 |
| D（UI スタイル・レイアウト） | 該当なし | 製品側の描画・レイアウト・文言を変更していない |
| E（git hook） | 該当なし | `.githooks/**` を変更していない |
| F（ガバナンス文書） | 該当なし | `*.md`・`.claude/rules/`・`.claude/skills/`・workflow のいずれも変更していない |

```
npm test                  568 passed (7 files)
npm run test:powershell   69 passed / 0 failed（+2）
npm run smoke:startup     5 runs passed（debug ビルド）
npm run smoke:egui        passed（release ビルド——窓が SW_HIDE を拾って隠れないことの検査）
```

**`smoke:egui` が本 PR の主たるリスクの検査である。** `-WindowStyle Hidden` は `STARTUPINFO.wShowWindow` に `SW_HIDE` を載せるため、本体の窓までそれを尊重すると窓が出なくなる。release で show/hide が観測できているので、そうなっていない。

### 追加したテストと、それが固定する不変条件

| テスト | 不変条件 |
|---|---|
| コンソール窓を見せずに起動する | 通った実行では発火しないため、ここでしか観測されない |
| NoNewWindow のときは WindowStyle を渡さない | `Start-Process` の排他な引数の衝突を防ぐ |

### 副次的な観測

`smoke:startup` の `first_trace_ms` が 351〜478ms から **234〜269ms** へ下がった。コンソール窓の生成が起動を遅らせていたと見られる。**本 PR の判定には使っていない**（5 run の観測であり、原因を分離していない）。

## レビュー

- `/symmetric-check` — **実施**。発見 0 件。生成/破棄の対称ペアは増減しておらず、変えたのは起動時の窓の見せ方 1 点。`-NoNewWindow` との排他はテストで固定した
- `/dry-check` — **実施**。発見 0 件。`Start-Process` の呼び出しは `Start-SnotraProcess` の 1 箇所に集約済みで、手書きの複製は無い（`rg Start-Process scripts/` で確認）
- 該当なし — `/race-check`・`/cache-check`・`/persistence-check`・`/state-check`
- `code-reviewer` エージェント — **未実施**。作業したセッションの制約による。**独立レビューは成立していない**

## #872 について

本 PR は現れ方 1 の原因を取り除くが、**#872 は閉じない**。同 issue が決めたいのは「この検査を CI ゲートに置き続けるか、置くならどの形にするか」であり、それは 3 つの現れ方すべてに手が入った状態で改めて判断するものである。

Refs #872

🤖 Generated with [Claude Code](https://claude.com/claude-code)
