### PR TITLE
docs(src-tauri): `cargo test -p snotra --lib` が常に失敗する事実を crate 冒頭へ記す

### DIFF
--- a/src-tauri/CLAUDE.md
+++ b/src-tauri/CLAUDE.md
@@ -1,6 +1,6 @@
 # src-tauri
 
-Tauri v2 バイナリ crate。検索 UI（`egui_shell/`・egui + softbuffer）と Win32 API 統合を担当（WebView2/フロントエンドは #532 SU7 で撤去）。
+Tauri v2 バイナリ crate。検索 UI（`egui_shell/`・egui + softbuffer）と Win32 API 統合を担当（WebView2/フロントエンドは #532 SU7 で撤去）。**`[lib]` を持たないため `cargo test -p snotra --lib` は常に失敗する**（`error: no library targets found`。2026-08-03 に 2 セッション連続で踏んだ）——テストは `--lib` なしの `cargo test -p snotra`、絞り込みはテスト名フィルタか `--bin snotra` で行う。
 
 各ルールは「**太字 = 守る指示**、後続 = 理由・経緯」の形式。迷ったら太字部分に従えば安全。
 


### PR DESCRIPTION
## 概要

`snotra` が `[lib]` を持たない bin 専用 crate であり `cargo test -p snotra --lib` が常に失敗する事実を、`src-tauri/CLAUDE.md` の crate 素性を述べる冒頭行へ 1 文で記録する。

## 背景

直近トランスクリプトの横断分析（2026-08-04）で、セッション境界を越えた同一ミスの再犯として観測された唯一の技術的事実。2026-08-03 のセッションで発見・修正されたが、保存先が計画文書（マージ時に削除される）しか無かったため、7 分後に開始した別セッションが同じコマンドで同じエラーを踏んだ。セッションを跨いで残る保存先として module CLAUDE.md へ置く。

## 検証

- `npm run governance:check` — 全検査 passed（検査 18 件 / 対象文書 35 件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
