### PR TITLE
chore: SPEC 節参照を正準形へ揃え、コメントの写しと変更履歴を畳む

### DIFF
--- a/src-tauri/src/egui_shell/launcher_controller.rs
+++ b/src-tauri/src/egui_shell/launcher_controller.rs
@@ -1227,10 +1227,8 @@ impl LauncherController {
             self.run_search(); // folder は同期フィルタ（debounce 不要・I/O 無し）
         } else {
             self.state.set_query(buf);
-            // SPEC §4.9「入力と選択」の実体。folder 側の対（`set_folder_filter` 内の
-            // selected=0）と合わせて 1 つの as-built を成す。**打鍵からここへの配線を固定する
-            // テストは無い**（`AppHandle` を要するため）ので、腐りの手がかりはこの参照だけ
-            // である（#921）。
+            // `SPEC.md`「4.9 入力と選択」の実体（folder 側の対は `set_folder_filter` 内の
+            // `selected = 0`）。
             self.state.reset_selection(); // SolidJS parity: 毎打鍵 selected=0（M1 gap 是正）
             // prefix はこの changed エッジで 1 回だけ取得し run_search_with へ渡す
             //（interp と合わせ engine lock の毎打鍵多重取得を避ける・finding 9）。

--- a/src-tauri/src/egui_shell/search_state.rs
+++ b/src-tauri/src/egui_shell/search_state.rs
@@ -881,7 +881,7 @@ mod tests {
         assert!(s.results().is_empty(), "選択が 0 でも、それが指す行は無い");
     }
 
-    // ---- フォルダ内の絞り込みと選択（#838 / #921・SPEC §4.9 の as-built）----
+    // ---- フォルダ内の絞り込みと選択（`SPEC.md`「4.9 入力と選択」の as-built・#838 / #921）----
     //
     // **上の #743 ブロック（左右カーソルキーによる階層移動）の外に置く**——主題が違ううえ、
     // あちらの冒頭は本数を名指ししており、内側へ足すとその記述が stale になる。
@@ -890,16 +890,16 @@ mod tests {
     // `changed()` エッジと `launcher_controller.rs` の `on_input_changed`）は射程外で、
     // その呼び出しを消してもこのテストは緑のままである（#743 ブロックの冒頭と同じ性質の限界）。
 
-    /// フォルダ内の絞り込みの打鍵は選択を 1 行目へ戻す（SPEC §4.9「入力と選択」——通常検索も
-    /// 含めた正本はそちらで、#921 で §6.3 から一本化した）。
+    /// フォルダ内の絞り込みの打鍵は選択を 1 行目へ戻す。正本は `SPEC.md`「4.9 入力と選択」で、
+    /// 通常検索側も含めてそこが 1 か所で持つ（ここが測るのは folder 側の半分だけである）。
     /// **非ゼロから始める**——0 から始めると `enter_folder` の初期値と区別が付かない。
     /// **`enter_folder` を先に通す**——`set_folder_filter` は `folder` が `None` でも黙って
     /// `selected = 0` を撃つため、突入を忘れると folder 中の挙動を何も実証しない。
     ///
-    /// **§6.3 の as-built（列挙失敗のエラー行が絞り込みの対象外であること）は、
-    /// ここでは測れない**——判定は driver 側（`launcher_controller.rs` の `run_search_with` が
-    /// `folder_error` を filter 非適用で差し替える）にあり `AppHandle` を要する。腐り検知は
-    /// その行のコメントだけが担う（#838 で受容した残余）。
+    /// **`SPEC.md`「6.3 フォルダ展開中の検索」の as-built（列挙失敗のエラー行が絞り込みの
+    /// 対象外であること）は、ここでは測れない**——判定は `LauncherController::folder_error`
+    /// を読む driver 側にあり `AppHandle` を要する（機構はそのフィールドの doc が持つ・
+    /// #838 で受容した残余）。
     #[test]
     fn folder_filter_typing_resets_selection_to_first_row() {
         let mut s = SearchState::new();


### PR DESCRIPTION
#838（PR #920）／#921（PR #922）で足したコメントを `/simplify` の 4 レンズ（reuse / simplification / efficiency / altitude）で見直した結果の品質修正。**実行コードの差分は 0 行**（非コメント差分 0 行を実測）。

## 変更内容

### 1. SPEC 節参照を正準形へ揃える（altitude レンズ）

`scripts/governance-check.mjs` の `HEADING_REF` は

```js
/`([^`\n]+)`\s*(?:§\s*[\d.]*\s*)?「([^「」\n]+)」/g
```

で、**バッククォートで囲んだファイル名が必須**である。#921 で置いた `SPEC §4.9「入力と選択」` は**マッチしない**（実測）。

| 形 | 判定 |
|---|---|
| `` `SPEC.md`「4.9 入力と選択」`` | **MATCH** → `SPEC.md:209` の `### 4.9 入力と選択` へ着地 |
| `SPEC §4.9「入力と選択」` | **NO MATCH** |

同ファイル内に既にある `` `SPEC.md`「6.7 フォルダ展開中の現在地表示」`` の形へ揃え、直した 3 本すべてがマッチすることを実測した。

**検出器の母集団に `.rs` はまだ含まれない**（`governanceDocs()` は `.md` だけを対象とする）ので今日は挙動が変わらないが、#921 の PR 本文でこの参照を「テストを持てない事実の唯一の腐り検知の錨」と位置づけた以上、機械が読める形であるべきである。

### 2. 変更履歴の再現を削除（simplification レンズ）

「#921 で §6.3 から一本化した」は `docs/comment-guidelines.md:22` が名指しで禁じる形（「**変更履歴の再現**（git log / PR が持つ。コメントは『現在の形の理由』だけを書く）」）。現在の形の理由だけを残した。

### 3. `folder_error` の機構説明の 4 つ目の写しを畳む（reuse レンズ）

「列挙失敗行は filter 非適用」の機構は差分より前から 3 か所にある — `LauncherController::folder_error` のフィールド doc ／ `FolderMsg::Failed` の doc ／ `run_search_with` の行末。テスト doc からは再説明を落とし、**シンボル名で錨を指す**形にした（位置をファイル名・行で断定しない・#588）。

旧文の「腐り検知は**その行**のコメントだけが担う」は、3 候補のどれにも解決できない指し方だった。

### 4. 自己言及コメントを削除（reuse / simplification 両レンズ）

「打鍵からここへの配線を固定するテストは無い…腐りの手がかりはこの参照だけである」はコメントが自分の存在意義を語る文で、読者の行動を変えない（同じ内容は `9baff57` のコミット本文が持つ）。錨である §4.9 参照は残し、自己言及だけを落とした。

## 採らなかった指摘（理由つき）

- **テスト doc の方法論散文**（「非ゼロから始める」「`enter_folder` を先に通す」）が #743 ブロックと重なる — 正本が 100 行離れており、畳むと「空虚に真」なテストを書く罠を**現地で**防げなくなる。指摘した 2 レンズとも ⚠️ を付けていた
- **ブロック冒頭「なぜ隣のブロックの外に置いたか」** — この記述自体が、後から「整頓」で #743 ブロックの内側へ移されること（＝あちらの「この 5 本」を stale にすること）を防いでいる
- **assert の位置変更**（前提の検査を結果の位置から移す）— 測る対象が変わる（提案者自身が ⚠️）
- **efficiency レンズは指摘なし** — プローブ crate で `cargo doc` が `#[cfg(test)]` から HTML を 1 バイトも生まないこと、`SPEC.md` を `include_str!` する箇所が 0 件であることまで実測した「該当なし」

## 検証

- **カテゴリ A**: `cargo fmt --check` / `clippy --workspace --all-targets -D warnings` / `cargo test -p snotra` **197 passed / 0 failed** / `cargo doc` — 全緑
- **カテゴリ F**: `npm run governance:check` 全検査 passed（検査 18 件）
- **カテゴリ B / C / D / E**: 該当なし（実行コードの差分が 0 行で、trace イベント名・hotkey・表示経路・視覚経路のいずれにも届かない）
- **挙動不変の証拠**: `git diff $(git merge-base main HEAD) -- src-tauri/` の**非コメント差分 0 行**。収支は 9 insertions / 11 deletions

## 申し送り（この PR では触らない）

altitude レンズが実測つきで 2 件の follow-up 候補を挙げた。どちらも本差分の外なので起票していない。

1. **`governance-check` の母集団へ `.rs` を足す** — `.rs` 90 本を母集団に入れて既存検査を走らせると、**本 PR と無関係な既存の腐りが 2 件**出る（`snotra-settings/src/tabs/visual.rs:395` が `safety-nets.md` の改題に未追随、`src-tauri/src/monitor.rs:80` が SPEC に無い見出しを指す）。検出器の変更は `.claude/rules/safety-nets.md` がフォールトインジェクションを要求するため、別タスクが妥当
2. **打鍵 → `reset_selection()` の配線を trace で測る** — `egui_input:changed` は分岐の 10 行上に既にあり、`scripts/lib/SnotraSmoke.Tests.ps1` が実キー注入で `scope='folder'` を断言している。分岐**後**の観測点を足せば通常検索側も測れる

Refs #838, #921
