### PR TITLE
docs(src-tauri): 監視スレッドの復元コメントを、実測で否定された hazard から実行スレッドの非対称へ差し替える

### DIFF
--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -147,11 +147,15 @@ pub(crate) fn launch_settings_process(app: &AppHandle, extra_args: &[&str]) -> R
         // Restore main window alwaysOnTop（egui は get_window・codex #3・SPEC §8.5）。
         // results 窓にも対称適用する（#646 PR2・上の解除と対）。
         //
-        // **既知の hazard（機序・重篤度・是正は #923 が正本）**: この復元はイベントループの
-        // 外——監視スレッド——から撃つため、hidden な main へ tao の差分適用が `SW_HIDE` を
-        // 漏らす（`src-tauri/CLAUDE.md`「Win32 / Tauri 注意事項」の窓ごとの層を参照）。
-        // **#746 で auto_hide 有効時に「設定終了時 main は hidden」が常態化したため、この
-        // 経路を毎回通るようになった**（従来も Escape 経由で到達可能ではあった）。
+        // **対称に書いてあるが、2 行の実行スレッドは違う**（#923 で実測）:
+        // `set_always_on_top` は tauri の `send_user_message` と tao の `execute_in_thread` で
+        // 二重に marshalling され、フラグの読みと `apply_diff` はイベントループ上で走る——
+        // ゆえに `show_egui_main` / `hide_egui_main` と逐次化される。**ここを cross-thread と
+        // 読んではならない**（在りもしない競合を見る。#923 はそれで起票され取り下げた）。
+        // このスレッドで即時に走るのは生 `SetWindowPos` の `set_topmost` だけである。
+        // hidden な main へ `apply_diff` が `SW_HIDE` を漏らすのは毎回起きるが、逐次化ゆえ
+        // 無害である。**無害なのは実測の範囲であって原理ではない**——どちらかを別経路へ
+        // 移すなら測り直すこと。
         if let Some(main) = handle_for_monitor.get_window("main") {
             let _ = main.set_always_on_top(true);
         }


### PR DESCRIPTION
## 何を変えたか

`src-tauri/src/commands/window.rs` の監視スレッド復元箇所のコメントを差し替えた（5 行 → 9 行）。#929 が入れた「既知の hazard（機序・重篤度・是正は #923 が正本）」は、その #923 が実測で否定され NOT_PLANNED でクローズされたため stale になっていた。

## なぜ

#923 は「復元がイベントループの外——監視スレッド——から撃たれるため、hidden な main へ tao の差分適用が `SW_HIDE` を漏らす」と記していた。しかし `tauri::Window::set_always_on_top` は監視スレッド上では実行されず、二重に marshalling される:

1. tauri-2.11.4 `window/mod.rs:2094` → dispatcher
2. tauri-runtime-wry-2.11.4 `lib.rs:2316` `WryWindowDispatcher::set_always_on_top` → `send_user_message`
3. 同 `lib.rs:239-254` `send_user_message`: 呼び出しスレッド ≠ `main_thread_id` なら `proxy.send_event`
4. 同 `lib.rs:4373-4382` イベントループの `Event::UserEvent` arm → `handle_user_message`
5. 同 `lib.rs:3521` → tao `Window::set_always_on_top`
6. tao `window.rs:852-861` → `thread_executor.execute_in_thread`（`event_loop.rs:522-548`）

ゆえにフラグの読み → `drop(lock)` → `apply_diff` はイベントループスレッド上の連続実行であり、`show_egui_main` が割り込める隙間は存在しない。

## 実測

計装した tao 0.35.3 を `[patch.crates-io]` で差し込み、使い捨てプロファイルの first-run で設定サイドカーを開閉した:

```
[trace] {"data":{"pid":8424,"status":-1},"event":"cmd:launch_settings_process:exited",...}
[TAO_PROBE] std=ThreadId(38) MONITOR THREAD: about to call set_always_on_top(true)
[TAO_PROBE] std=ThreadId(38) MONITOR THREAD: set_always_on_top(true) returned
[TAO_PROBE] tid=12000 std=ThreadId(1) execute_in_thread inline=true event_loop_tid=12000
[TAO_PROBE] tid=12000 std=ThreadId(1) set_window_flags hwnd=0x207a6 old_visible=false new_visible=false old_aot=false new_aot=true
[TAO_PROBE] tid=12000 std=ThreadId(1) apply_diff -> SW_HIDE hwnd=0x207a6 (side effect of flag diff)
```

監視スレッド `ThreadId(38)` の 2 行の間にフラグ操作が 1 つも無い。読み → `drop` → `apply_diff` はすべて `ThreadId(1)`（同じ行が自己申告する `event_loop_tid` と一致）で走る。陽性対照として、イベントループスレッド自身からの呼びが `inline=true` で `WS_EX_TOPMOST` を即反映することを同じ計装で確認している（tao 単体プローブ）。

計装は作業後に revert 済み（`Cargo.toml` / `Cargo.lock` / `window.rs`）。バイナリも再ビルドして計装文字列 0 件を確認した。

## 残した事実

- **(a)** 復元 2 行は対称に書かれているが実行スレッドが違う——このスレッドで即時に走るのは生 `SetWindowPos` の `set_topmost` だけである
- **(b)** hidden な main への `SW_HIDE` は毎回起きるが逐次化ゆえ無害。**実測の範囲であって原理ではない**

加えて「ここを cross-thread と読んではならない」という否定の知識を残した。#923 はまさにその誤読から起票されたため、事実だけ書き直すと同じ誤読が再発する。

## 検証

- PostToolUse hook（fmt / clippy / test）: 沈黙 = 合格
- `npm run governance:check`: 全 18 検査 passed（見出し参照 148 件を md 48 件 + .rs 91 件から照合）
- `cargo build -p snotra`: 成功

コメントのみの変更であり、挙動は変わらない。

Refs: #923

🤖 Generated with [Claude Code](https://claude.com/claude-code)
