### PR TITLE
ci: smoke-egui のビルド時間を、空振りしていた rust-cache の修正とプロファイル緩和で短縮する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,19 @@ jobs:
       - name: cargo fmt
         run: cargo fmt --all -- --check
 
+      # `save-if` で main からしか保存しない。**この job 単体の都合ではなく、Actions キャッシュの
+      # 10GB 上限を共有しているからである**——保存を許すと PR ごとに 2573MB が
+      # `refs/pull/*/merge` へ積まれ（実測）、e2e.yml が main スコープへ置く smoke 用の
+      # エントリを LRU で押し出しうる。**押し出されても赤くならない**（restore-key で部分ヒットし、
+      # ビルドが静かに元の所要へ戻る）ため、検出ではなく圧力そのものを断つ。
+      #
+      # 受容する残余: Cargo.lock を変える PR では、その PR の 2 回目以降の run も main の
+      # エントリからしか復元できない。rust-check は debug ビルドで元々短く（実測 4m18s）、
+      # 依存を動かす PR は稀（`/deps-update`）なので、常時かかる 10GB 圧力と釣り合わない。
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: cargo check
         run: cargo check --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,13 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # **main ではキャンセルしない**。下の rust-check へ `save-if` を入れて main を唯一の保存経路に
+  # したため、main の run がキャンセルされると保存の Post ステップまで到達する保証が無くなる
+  # （到達しないと確かめたわけではない。保証が無い側へ倒すのが安全側である）。main へは直近
+  # 14 日で 184 コミット（1 日平均 13）入っており、連続マージが同じ `group` を奪い合う頻度に
+  # 達している。**e2e.yml が同じ理由で同じ形を採る**——保存経路を絞ったなら、その経路を
+  # キャンセルしない。PR 側は従来どおり最新だけを残す。
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   # 旧 frontend-check の縮退（#532 SU7 PR3・フロント撤去）。残る npm test は

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,10 +26,28 @@ on:
       - 'Cargo.lock'
       - 'package.json'
       - 'package-lock.json'
+  # **回帰検出のためではなく、rust-cache を main スコープへ書くための経路である**。
+  # GitHub Actions のキャッシュは、`pull_request` 実行の書き込みが PR 自身のスコープに閉じ、
+  # 他 PR からは読めない（実測: smoke-egui のエントリ 8 件がすべて `refs/pull/*/merge` だった）。
+  # base ブランチ（main）のスコープだけが全 PR から読めるため、main で 1 度作る経路が要る。
+  #
+  # **`paths` を意図的に持たない**。キャッシュキーは Cargo.lock だけでなく **rustc のバージョンでも
+  # 変わり**（`dtolnay/rust-toolchain@stable` は 6 週ごとに動く）、後者は paths で表現できない。
+  # 絞ると、rustc が更新された週から次に Cargo.lock が動くまで全 PR が完全 cold へ戻る。
+  # **「いつ warm すべきか」を条件で言い当てるより、毎マージで warm し直すほうが穴が無い**
+  # （回帰検出は副産物）。main への push は squash マージのみ（直 push は GitHub ruleset が拒否）で、
+  # PUBLIC リポジトリゆえ Actions の分数課金も無い。
+  push:
+    branches:
+      - main
 
 concurrency:
   group: e2e-${{ github.ref }}
-  cancel-in-progress: true
+  # **main ではキャンセルしない**。main の run は rust-cache を main スコープへ書くために在り、
+  # キャンセルされると保存を行う Post ステップまで到達しないので目的を果たさない。**これは
+  # 理屈上の心配ではない**——main へは直近 14 日で 184 コミット（1 日平均 13）入っており、
+  # 連続マージが同じ `group` を奪い合う頻度に達している。PR 側は従来どおり最新だけを残す。
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   # egui 経路の自動回帰 smoke（#532 SU7・e2e/ 撤去後の後継の最低線）。
@@ -52,15 +70,37 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # **`workspaces:` を指定しない**（既定の `.` ＝ルート）。このリポジトリは
+      # ルートが cargo workspace で `src-tauri` はそのメンバーゆえ、下の
+      # `cargo build -p snotra` が書くのは**ルートの `target/`** である。かつて
+      # `workspaces: src-tauri` を指定していた頃は存在しない `src-tauri/target` を
+      # キャッシュ対象にしており、`full match: true` と表示されながら復元していたのは
+      # `~/.cargo` のレジストリだけだった（132MB。ルート指定の rust-check は 2573MB）。
+      # **緑のログが空振りを隠す形の一種である**——毎 run で依存 357 crate を積み直し、
+      # ビルドの 8m39s のうち 5m23s をそこに費やしていた（run 31070343704 で実測）。
+      #
+      # `save-if` で main からしか保存しないのは、Actions キャッシュの 10GB 上限を
+      # 守るためである。PR ごとに release の target（GB 級）を書くと LRU で
+      # rust-check の 2.5GB が落ち、CI 全体が今より遅くなる。
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: src-tauri
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install dependencies
         run: npm ci
 
+      # **この job が建てるのは smoke 用のバイナリであり、配布バンドルではない**
+      # （`docs/build-commands.md`「検証コマンド ↔ GitHub Actions workflow の対応」の注）。
+      # `[profile.release]` の `lto = true` / `codegen-units = 1` は最終段の codegen と
+      # リンクだけで 3m15s を占め、しかも rust-cache は workspace crate を保存しないので
+      # キャッシュでは削れない。**この job に限って** env で緩める（`Cargo.toml` は触らない
+      # ——release.yml が建てる配布物の設定は変えない）。`panic = "abort"` と `opt-level` は
+      # そのままゆえ、検証対象である起動時の挙動は配布バンドルと同じ経路を通る。
       - name: Build release binary
+        env:
+          CARGO_PROFILE_RELEASE_LTO: "false"
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
         run: cargo build --release -p snotra
 
       # flip 済み（#532 SU7 PR2）: env なし＝「既定が egui であること」自体が検証対象（spec 決定 3）。

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,9 +5,11 @@ on:
   pull_request:
     branches:
       - main
-    # paths が唯一の自動ゲート。カテゴリ C 相当（ウィンドウ生成・ホットキー・スラッシュコマンド）を
-    # 含みうる変更、および依存 manifest/lockfile に触れた PR で自動起動する。
-    # 手動実行は workflow_dispatch。拾いすぎ（配下 *.md 等）は過剰実行で安全側ゆえ negation を足さない。
+    # **PR 側ではこの paths が唯一の自動ゲートである**（下の `push:` は paths を持たず、
+    # main への全マージで起動する——目的が違うため。理由はそちらのコメント）。カテゴリ C 相当
+    # （ウィンドウ生成・ホットキー・スラッシュコマンド）を含みうる変更、および依存 manifest/lockfile に
+    # 触れた PR で自動起動する。手動実行は workflow_dispatch。
+    # 拾いすぎ（配下 *.md 等）は過剰実行で安全側ゆえ negation を足さない。
     # WebView2 e2e（Playwright + tauri-driver）は #532 SU7 flip で撤去済み——後継は smoke-egui job
     # （egui 経路の自動回帰の最低線）+ 手動 GUI smoke 体制（docs/build-commands.md）。
     paths:
@@ -43,10 +45,11 @@ on:
 
 concurrency:
   group: e2e-${{ github.ref }}
-  # **main ではキャンセルしない**。main の run は rust-cache を main スコープへ書くために在り、
-  # キャンセルされると保存を行う Post ステップまで到達しないので目的を果たさない。**これは
-  # 理屈上の心配ではない**——main へは直近 14 日で 184 コミット（1 日平均 13）入っており、
-  # 連続マージが同じ `group` を奪い合う頻度に達している。PR 側は従来どおり最新だけを残す。
+  # **main ではキャンセルしない**。main の run は rust-cache を main スコープへ書くために在るが、
+  # **キャンセルされた run で保存の Post ステップが走る保証は無い**（未実測ゆえ「走らない」とは
+  # 書かない。保証が無い側へ倒すのが安全側である）。**これは理屈上の心配ではない**——main へは
+  # 直近 14 日で 184 コミット（1 日平均 13）入っており、連続マージが同じ `group` を奪い合う頻度に
+  # 達している。PR 側は従来どおり最新だけを残す。
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/docs/adr/ADR-smoke-build-time.md
+++ b/docs/adr/ADR-smoke-build-time.md
@@ -1,0 +1,39 @@
+# ADR-smoke-build-time: smoke-egui のビルド短縮を、キャッシュの修正とプロファイル緩和の 2 点で行う
+
+`Smoke` workflow の所要 10 分のうち 84% がビルドだった。削り方には複数の候補があり、そのうち「速いが検証対象を変える」ものと「無駄が減るように見えて穴を作る」ものを却下した記録。
+
+## 文脈
+
+run 31070343704（2026-08-06）の実測:
+
+| 区間 | 所要 | 性質 |
+|---|---|---|
+| job 全体 | 10m18s | 直近 3 run は 10m21s / 11m39s / 10m21s |
+| Build release binary | 8m39s | 全体の 84% |
+| ├ 依存 357 crate のコンパイル | 5m23s | **キャッシュで消せる** |
+| └ 本体の codegen + fat LTO + リンク | 3m15s | **キャッシュでは消せない**（rust-cache は workspace crate を保存しない） |
+
+原因は `Swatinem/rust-cache` の `workspaces: src-tauri` である。このリポジトリはルートが cargo workspace で `src-tauri` はそのメンバーゆえ、`cargo build -p snotra` が書くのは**ルートの `target/`** だった。キャッシュ対象は存在しない `src-tauri/target` を指し、復元していたのは `~/.cargo` のレジストリだけ（132MB。ルート指定の rust-check は 2573MB）。ログには `full match: true` と出るため、**緑が空振りを隠していた**。
+
+制約が 2 つある。**(1) Actions キャッシュの合計が 9.88GB / 10GB** で、PR ごとに GB 級を書くと LRU で rust-check の 2573MB が落ち、CI 全体が今より遅くなる。**(2) `pull_request` 実行のキャッシュ書き込みは PR 自身のスコープに閉じる**——実測で smoke-egui のエントリ 8 件がすべて `refs/pull/*/merge` だった。全 PR が読めるのは base ブランチ（main）のスコープだけである。
+
+## 決定
+
+1. `workspaces:` を指定しない（既定の `.` ＝ルート）。
+2. `save-if: ${{ github.ref == 'refs/heads/main' }}`。PR からは保存せず、エントリを 1 個に抑える。
+3. `push: branches: [main]` を `paths` 無しで足し、main の run で warm する。`cancel-in-progress` は main だけ外す。
+4. "Build release binary" ステップ限定の env で `CARGO_PROFILE_RELEASE_LTO=false` / `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16`。
+
+## 検討した代替案と却下理由
+
+- **`--release` をやめて debug でビルドする**: 却下。startup の予算 25s には収まる公算が高いが、`panic = "abort"` → `unwind` の挙動差が**この job の検証対象（起動健全性）と同じ面に乗る**。速さのために検証対象そのものを変える方向であり、削るべきは検証ではなくビルドの無駄である。採った env 上書きは `lto` と `codegen-units` の 2 キーだけを動かし、`panic` / `opt-level` / `[profile.release.package.snotra]` を共有する。
+- **`push` の `paths` を `Cargo.lock` / `**/Cargo.toml` / `e2e.yml` に絞る**: 却下。「キャッシュを作り直すべき条件」を言い当てたつもりになるが、**キャッシュキーは Cargo.lock だけでなく rustc のバージョンでも変わり、それは paths で表現できない**（`dtolnay/rust-toolchain@stable` は 6 週ごとに動く）。絞ると rustc が更新された週から次に Cargo.lock が動くまで、全 PR が完全 cold へ戻る——数週間続きうる。
+  - **`schedule:` で週 1 warm して穴を埋める**: 却下。機構が 1 つ増えるうえ、rustc 更新直後の最大 1 週間は cold のままで穴が閉じ切らない。main への push は squash マージのみ（直 push は GitHub ruleset が拒否）で、PUBLIC リポジトリゆえ分数課金も無い。**条件で言い当てるより、毎マージで warm し直すほうが穴が無い。**
+- **`ci.yml` の rust-check とキャッシュを共有する**（rust-cache の `add-job-id-key` を落としてキーを揃える）: 却下。rust-check は debug、smoke は release でプロファイルが違う。キーを揃えると先に保存した側が後続を `Cache up-to-date` で止めるため、**release の target が一生入らない**。
+- **rust-check の job へ smoke を統合する / artifact でバイナリを受け渡す**: 却下。プロファイル不一致は上と同じで、加えて smoke が rust-check 全体（実測 4m）の後ろに直列化される。
+- **`Cargo.toml` の `[profile.release]` を直接緩める**: 却下。`release.yml` が建てる**配布物まで**最適化が落ちる。env をステップ限定に置けば、緩むのはこの job のバイナリだけになる。
+
+## 受容する残余
+
+- **rust-cache のキャッシュキーに `CARGO_PROFILE_*` は入らない**（ログの "Environment considered" は `CARGO_HOME` / `CARGO_INCREMENTAL` / `CARGO_TERM_COLOR` のみ・実測）。将来 env を変えてもキーは変わらないが、判定は cargo の fingerprint が行うので**誤ったバイナリは出ない**。現れるのは「キャッシュが効かない run が 1 回増える」だけである。
+- **`lto` を切ると依存側の fingerprint も変わる**（`-C lto` が消え `-C embed-bitcode=no` が付くことを最小 bin crate で実測）。ゆえに**この決定を入れた直後の 1 run は必ず cold** であり、その所要を効果の測定に使ってはならない。

--- a/docs/adr/ADR-smoke-build-time.md
+++ b/docs/adr/ADR-smoke-build-time.md
@@ -23,6 +23,7 @@ run 31070343704（2026-08-06）の実測:
 2. `save-if: ${{ github.ref == 'refs/heads/main' }}`。PR からは保存せず、エントリを 1 個に抑える。
 3. `push: branches: [main]` を `paths` 無しで足し、main の run で warm する。`cancel-in-progress` は main だけ外す。
 4. "Build release binary" ステップ限定の env で `CARGO_PROFILE_RELEASE_LTO=false` / `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16`。
+5. **`ci.yml` の rust-cache にも `save-if` を足す**（射程の拡張）。10GB 上限は 2 つの workflow が共有する 1 つの資源であり、rust-check が PR ごとに 2573MB を `refs/pull/*/merge` へ積み続ける限り、上の決定 2 が置く main エントリは LRU で押し出されうる。**押し出されても赤くはならない**——restore-key で部分ヒットし、ビルドが静かに元の所要へ戻る（今回直したのと同じ「緑のまま空振りする」形）。**圧力を作ったのはこの変更なので、検出器を足すのではなく圧力を断つ。**
 
 ## 検討した代替案と却下理由
 

--- a/docs/build-commands.md
+++ b/docs/build-commands.md
@@ -202,15 +202,16 @@ git config blame.ignoreRevsFile .git-blame-ignore-revs
 | `cargo check` / `cargo test -p snotra-core` / `cargo test -p snotra-egui-runtime` / `cargo test -p snotra` / `cargo test -p snotra-settings` / `cargo clippy` | `ci.yml`（rust-check） | PR 自動 |
 | `cargo doc --workspace --no-deps --document-private-items`（#562・intra-doc link 検査） | `ci.yml`（rust-check） | PR 自動 |
 | `npm run governance:check`（#587・ガバナンス文書検査） | `ci.yml`（governance-check） | PR 自動（**`skip-ci` 非対象** — if ガードを持たず常時実行） |
-| `npm run smoke:startup`（注） | `e2e.yml`（smoke-egui job） | 対象 paths を含む PR（自動）/ 手動 dispatch |
-| `npm run smoke:egui`（#532 SU7・egui 経路の自動回帰） | `e2e.yml`（smoke-egui job） | 対象 paths を含む PR（自動）/ 手動 dispatch |
+| `npm run smoke:startup`（注） | `e2e.yml`（smoke-egui job） | 対象 paths を含む PR（自動）/ main への push（依存 manifest 変更時）/ 手動 dispatch |
+| `npm run smoke:egui`（#532 SU7・egui 経路の自動回帰） | `e2e.yml`（smoke-egui job） | 対象 paths を含む PR（自動）/ main への push（依存 manifest 変更時）/ 手動 dispatch |
 
-（注）CI では smoke-egui job がビルドした release バイナリを共有するため、`npm run smoke:startup`（既定 ExePath = debug）ではなく `scripts/smoke-startup.ps1 -ExePath target/release/snotra.exe` を直接実行する。検証する起動経路は同じ（release バイナリが trace を出し、seed 済み検証用プロファイルで非 first-run 起動すること）。これは smoke 用ビルドの起動健全性検証であり、配布バンドル（`tauri build`）の検証ではない。
+（注）CI では smoke-egui job がビルドした release バイナリを共有するため、`npm run smoke:startup`（既定 ExePath = debug）ではなく `scripts/smoke-startup.ps1 -ExePath target/release/snotra.exe` を直接実行する。検証する起動経路は同じ（release バイナリが trace を出し、seed 済み検証用プロファイルで非 first-run 起動すること）。これは smoke 用ビルドの起動健全性検証であり、配布バンドル（`tauri build`）の検証ではない。**その帰結として、この job のバイナリだけは `[profile.release]` の `lto` / `codegen-units` を env で緩めて建てる**（`e2e.yml` の "Build release binary" ステップにコメントで根拠を置いた。`Cargo.toml` は変えないので `release.yml` が建てる配布物は fat LTO のまま）。`panic = "abort"` と `opt-level` は共有するため、検証対象である起動時の挙動は配布バンドルと同じ経路を通る。
 
 - `npm test` は ubuntu（node-check）と windows（rust-check）の両方で走る（#509）。`.githooks` / `.claude/hooks` の selftest は実運用が Windows でのみ起きるセーフティネットであり、hook 実行機構（Git-for-Windows の shebang 経由 sh 起動・パス/クォート境界）が本番と一致する OS で回帰検査する。ubuntu 側は実行ビット・POSIX sh 厳密性を相補的に担保する。CRLF 由来の fail-open は `.gitattributes` の `.githooks/** text eol=lf` で両 OS 回避済みで、かつ dash 側の故障モードなので windows 固有ではない。
 - **`skip-ci` ラベルはジョブ単位で効く** — node-check / rust-check の `if` が同一のため、貼ると cargo 系を含む**両方まるごと**スキップする（表の各行に個別注記はしない）。**`governance-check` job は `if` ガードを持たず、`skip-ci` を貼っても走る**（#587。skip-safe と定義された Markdown-only 変更こそが検査対象のため、意図的にガードしない）。CI は required status check ではない（ruleset `default` に `required_status_checks` 規則が無い・実測）ためマージは通り、main への push（マージ後）では `github.event_name == 'push'` により**ラベル無関係に必ず走る**。
 - **`skip-ci` を貼ってよいのは skip-safe な変更のみ** — node-check / rust-check がテスト対象に持たない `.claude/skills/**`・`.claude/rules/**`・`.claude/agents/**`・`docs/**`・`**/*.md` だけ（これらの決定的検査は skip されない governance-check が担う・#587）。**貼ってはならない**: `.claude/hooks/**`・`.githooks/**`・`scripts/**`・`.claude/settings.json` — これらは `npm test` が両 OS でセルフテストを回す（`vitest.config.ts` の `include`・上の #509）。「`.claude`-only だから安全」と一括りにしない（同じ表層形 `.claude/` が「Claude が読むだけの設定」と「CI が検査するセーフティネット」の二概念を担うため・#500）。
 - カテゴリ C（ウィンドウ生成・ホットキー・スラッシュコマンド）相当の変更や依存更新を含む PR は、対象 paths（`src-tauri/**`・`**/Cargo.toml`・`Cargo.lock`・`package.json`・`package-lock.json` 等）に該当するため `Smoke` workflow が自動起動する。paths 外の変更で手動実行するには `workflow_dispatch`。
+- **`Smoke` は main への push でも起動する。そちらは `paths` を持たず、全マージで走る**。**目的が回帰検出ではなく rust-cache の warm だからである** — Actions のキャッシュは `pull_request` 実行の書き込みが PR 自身のスコープに閉じ、base ブランチ（main）のスコープだけが全 PR から読める。**`paths` で絞らないのは、キャッシュキーが Cargo.lock だけでなく rustc のバージョンでも変わり、後者を paths で表現できないからである**（`dtolnay/rust-toolchain@stable` は 6 週ごとに動く。絞ると更新週から次の Cargo.lock 変更まで全 PR が完全 cold へ戻る）。PUBLIC リポジトリゆえ Actions の分数課金は無い。**main の run だけ `cancel-in-progress` を外してあるのも同じ目的による**（キャンセルされるとキャッシュを保存する Post ステップに到達しない。理由と実測は `e2e.yml` のコメント）。
 - この対応関係のドリフト（必須コマンドに対応 workflow が無い等）は `npm run governance:check`（G-ci-table）が検出する（#587。旧 `/health-check` Check 10）。
 
 ### その他


### PR DESCRIPTION
## 目的

`Smoke` workflow の smoke-egui job が 10 分かかっており、その 84% がビルドだった。

## 実測（run 31070343704・直近 3 run は 10m21s / 11m39s / 10m21s）

| 区間 | 所要 |
|---|---|
| job 全体 | 10m18s |
| Build release binary | **8m39s** |
| ├ 依存 357 crate のコンパイル | 5m23s（キャッシュで消せる） |
| └ 本体の codegen + fat LTO + リンク | 3m15s（キャッシュでは消えない） |

原因は `Swatinem/rust-cache` の `workspaces: src-tauri`。このリポジトリはルートが cargo workspace で `src-tauri` はそのメンバーゆえ、`cargo build -p snotra` が書くのは**ルートの `target/`** だった。キャッシュ対象は存在しない `src-tauri/target` を指し、`full match: true` と表示しながら復元していたのは `~/.cargo` のレジストリだけ（132MB。ルート指定の rust-check は 2573MB）。**緑のログが空振りを隠していた形**（#686 と同族）。

## 変更

1. **`workspaces:` を外す**（既定の `.` ＝ルート）
2. **`save-if: main`** — Actions キャッシュの 10GB 上限（変更前 9.88GB）を守り、PR ごとに GB 級を積まない
3. **`push: branches: [main]`（paths なし）** — `pull_request` 実行の書き込みは PR 自身のスコープに閉じる（実測: エントリ 8 件がすべて `refs/pull/*/merge`）。全 PR が読めるのは main スコープだけなので warm する経路が要る。`paths` で絞らないのは、キャッシュキーが **rustc のバージョンでも変わり**それを paths で表現できないため
4. **main では `cancel-in-progress` を外す** — キャンセルされた run で保存の Post ステップが走る保証が無い。main へは直近 14 日で 184 コミット（1 日平均 13）入っており、連続マージが同じ group を奪い合う頻度に達している
5. **ステップ限定の env で `lto=false` / `codegen-units=16`** — `Cargo.toml` は触らないので `release.yml` の配布物は fat LTO のまま。`panic = "abort"` と `opt-level` は共有する
6. **`ci.yml` の rust-cache にも `save-if`**（射程の拡張）— 10GB 上限は 2 workflow が共有する 1 資源で、rust-check が PR ごとに 2573MB を積む限り新設の main エントリが LRU で押し出されうる。押し出されても restore-key で部分ヒットし**静かに元の所要へ戻るだけで赤くならない**ので、検出器ではなく圧力を断つ

7. **`ci.yml` でも main の `cancel-in-progress` を外す** — 6 で main を唯一の保存経路にした以上、その経路をキャンセルしうる設定を残せない（4 と同型）。同一パターンを全 workflow で走査済み: `release.yml` も rust-cache を使うが concurrency を持たず `save-if` も無いため該当しない

却下した代替案（debug ビルド / push paths の絞り込み / schedule での週 1 warm / rust-check とのキャッシュ共有 / `Cargo.toml` 直接変更）は `docs/adr/ADR-smoke-build-time.md` に記録した。

## ローカルで実測済み

- `CARGO_PROFILE_RELEASE_*` が rustc へ届くこと — 最小 bin crate で baseline `-C lto` + `codegen-units=1` → override 後 `-C embed-bitcode=no` + `codegen-units=16`
- **緩めたバイナリで smoke が通ること** — `smoke:egui` passed（show/hide + results show/hide、webview delta 0）/ `smoke:startup` passed（5 run、first_trace 120–226ms）
- `npm run governance:check` passed（ADR 33 本 / 引用 177 件）、`npm test` 580 passed
- 前提としてキャッシュを 7.3GB 分掃除済み（孤児 12 件。撤去済み workflow の repro ×2・closed PR のエントリ・旧ハッシュ）

## マージ後に確認する（キャッシュの効果はローカルで測れない）

- [ ] **この PR 自身の smoke run は cold なので効果測定に使わない** — `save-if` で main エントリがまだ無く、かつ LTO 変更で依存の fingerprint が飛ぶ
- [ ] マージ後の main run で `refs/heads/main` に smoke-egui のエントリが GB 級で保存されたこと（`gh api repos/{owner}/{repo}/actions/caches` の `ref` と `size_in_bytes` を貼る）
- [ ] **次の** PR の "Build release binary" **ステップ単位**の所要が短縮したこと（job 総時間ではなく。`full match: true` は根拠にしない——今回の原因そのものがそれだった）。**測る PR は `Cargo.lock` にも toolchain にも触れていないものを選ぶ**——どちらかが動くとキーがミスして cold になり、「効かなかった」と誤読する
- [ ] 新エントリ追加後もキャッシュ合計が 10GB 未満であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
