### PR TITLE
fix(test): empty_history() を本当に空にする（開発機の状態でテスト結果が変わる問題）

### DIFF
--- a/snotra-core/CLAUDE.md
+++ b/snotra-core/CLAUDE.md
@@ -56,6 +56,7 @@
 
 - 新規ロジックは可能な限りこの crate に追加してテスト可能性を維持する
 - `#[cfg(test)]` でユニットテストを必ず書く
+- **ユニットテストの fixture に `HistoryStore::load()` を使わない**（#963）。実 `%APPDATA%\Snotra\history.bin` を読むため開発者のマシン状態で結果が変わり、しかも CI のランナーにはそのファイルが無いので**食い違いは CI では緑のまま開発機でだけ現れる**。空は `HistoryStore::empty()`、特定の内容は `HistoryStore::load_in` へ注入する。実運用の姿を測る計測ハーネス（`tests/` の `#[ignore]` ベンチ）だけは `load()` のままでよい
 - 検索スコア計算は `search.rs`、フォルダ列挙は `folder.rs` に集約（DRY）
 - **UI 表示文字列を持たない**: この crate は Win32 非依存の純ロジック層。エラーは `is_error: true` フラグで呼び出し側へ伝え、ユーザー向け文言の組み立て・表示は UI 層（`src-tauri/src/egui_shell/strings.rs`・`snotra-settings/src/i18n.rs`）の責務。ここに表示メッセージを埋め込まない
 - **`#[cfg(windows)]` で Win32 依存コードを追加する場合**: テストも `#[cfg(windows)]` で囲むか、OS リソースが存在しない環境でも安全にスキップできるよう `if let Some(...) =` パターンを使う。`assert!(value.is_some())` のような環境前提アサーションは環境依存テストになる

--- a/snotra-core/src/engine.rs
+++ b/snotra-core/src/engine.rs
@@ -285,7 +285,20 @@ mod tests {
     }
 
     fn empty_history() -> HistoryStore {
-        HistoryStore::load()
+        HistoryStore::empty()
+    }
+
+    /// `empty_history()` は名前どおり空でなければならない（#963）。
+    ///
+    /// **この検査は CI では常に緑で、開発機でだけ落ちる。** ランナーには
+    /// `%APPDATA%\Snotra` が無いので `HistoryStore::load()` も空を返すためで、
+    /// だからこそ食い違いを CI が構造的に検出できない。ここで固定する。
+    #[test]
+    fn empty_history_fixture_is_actually_empty() {
+        assert!(
+            empty_history().recent_launches(usize::MAX).is_empty(),
+            "empty_history() が空でない — 実 history.bin を読んでいる"
+        );
     }
 
     fn default_config() -> Config {

--- a/snotra-core/src/folder.rs
+++ b/snotra-core/src/folder.rs
@@ -247,7 +247,17 @@ mod tests {
     }
 
     fn empty_history() -> HistoryStore {
-        HistoryStore::load()
+        HistoryStore::empty()
+    }
+
+    /// `empty_history()` は名前どおり空でなければならない（#963）。
+    /// **CI では常に緑で開発機でだけ落ちる**性質は `engine.rs` の同名テストの doc を参照。
+    #[test]
+    fn empty_history_fixture_is_actually_empty() {
+        assert!(
+            empty_history().recent_launches(usize::MAX).is_empty(),
+            "empty_history() が空でない — 実 history.bin を読んでいる"
+        );
     }
 
     #[test]
@@ -645,7 +655,7 @@ mod tests {
     fn folder_cmp_is_total_order_by_path() {
         // "Café" と "Cafe" は to_lower_folded で同キー化する（アクセント畳込み）。
         // path tie-breaker が無いと select_nth_unstable の境界順が read_dir 順へ漏れる。
-        // empty_history() は既存 folder テストのヘルパー（HistoryStore::load()）。
+        // empty_history() は既存 folder テストのヘルパー（`HistoryStore::empty()`）。
         let hist = empty_history();
         let entries = vec![
             DirEntryData {

--- a/snotra-core/src/history.rs
+++ b/snotra-core/src/history.rs
@@ -82,11 +82,30 @@ impl HistoryStore {
     /// 履歴をディスクから読み込む。`top_n`（剪定容量）は焼き込まず、`save`/`prune` 呼び出し時に
     /// 引数で受け取る（live-read 化、issue #348）。これにより `result_limit` の設定変更が
     /// 再起動なしで反映され、`HistoryStore.top_n` の焼き込みによるドリフトが構造的に発生しない。
+    ///
+    /// **ユニットテストの fixture にこれを使わないこと**——実 `%APPDATA%\Snotra\history.bin` を
+    /// 読むため開発者のマシン状態でテスト結果が変わる。空が欲しいなら [`Self::empty`]、
+    /// 特定の内容が欲しいなら [`Self::load_in`] に注入する（理由の全文は `empty` の doc・#963）。
     pub fn load() -> Self {
         match Config::config_dir() {
             Some(dir) => Self::load_in(&dir),
             None => Self::from_loaded(HistoryData::default(), HISTORY_VERSION),
         }
+    }
+
+    /// 空の履歴を作る（**テスト fixture 専用**・ファイル I/O を伴わない）。
+    ///
+    /// **テストで `load()` を fixture に使ってはならない**（#963）。`load()` は
+    /// `Config::config_dir()`（= 実 `%APPDATA%\Snotra`）を読むため開発機の実履歴が混入し、
+    /// 順序や件数を見る検査の結果が開発者のマシン状態で変わる。しかも CI のランナーには
+    /// そのファイルが無く `load()` も空を返すので、**食い違いは CI では緑のまま、
+    /// 開発機でだけ現れる**——検出器が構造的に届かない形になる。
+    ///
+    /// 実履歴を意図して読みたいのは計測ハーネス（`tests/` 配下の `#[ignore]` ベンチ）だけで、
+    /// あちらは実運用の姿を測るのが目的ゆえ `load()` のままでよい。
+    #[cfg(test)]
+    pub(crate) fn empty() -> Self {
+        Self::from_loaded(HistoryData::default(), HISTORY_VERSION)
     }
 
     /// `load()` と同じ読み込みを `dir` 注入で行う（統合テスト用、issue #429）。

--- a/snotra-core/src/history.rs
+++ b/snotra-core/src/history.rs
@@ -84,8 +84,11 @@ impl HistoryStore {
     /// 再起動なしで反映され、`HistoryStore.top_n` の焼き込みによるドリフトが構造的に発生しない。
     ///
     /// **ユニットテストの fixture にこれを使わないこと**——実 `%APPDATA%\Snotra\history.bin` を
-    /// 読むため開発者のマシン状態でテスト結果が変わる。空が欲しいなら [`Self::empty`]、
+    /// 読むため開発者のマシン状態でテスト結果が変わる。空が欲しいなら `Self::empty`、
     /// 特定の内容が欲しいなら [`Self::load_in`] に注入する（理由の全文は `empty` の doc・#963）。
+    ///
+    /// （`Self::empty` を intra-doc link にしないのは `#[cfg(test)]` ゆえ非 test ビルドの
+    /// rustdoc から見えず、`broken_intra_doc_links = "deny"` で CI が落ちるため）
     pub fn load() -> Self {
         match Config::config_dir() {
             Some(dir) => Self::load_in(&dir),

--- a/snotra-core/src/search/tests/basic.rs
+++ b/snotra-core/src/search/tests/basic.rs
@@ -240,6 +240,20 @@ fn search_double_ext_full() {
     assert_eq!(results[0].name, "hoge");
 }
 
+/// `empty_history()` は名前どおり空でなければならない（#963）。
+/// **CI では常に緑で開発機でだけ落ちる**性質は `engine.rs` の同名テストの doc を参照。
+///
+/// 直下の `recent_history_empty_when_no_launches` はこの前提に乗っている——fixture が
+/// 実履歴を持つと「起動していないから空」ではなく「実履歴のパスが合成 entry と
+/// たまたま一致しないから空」を測ることになり、意味が入れ替わる。
+#[test]
+fn empty_history_fixture_is_actually_empty() {
+    assert!(
+        empty_history().recent_launches(usize::MAX).is_empty(),
+        "empty_history() が空でない — 実 history.bin を読んでいる"
+    );
+}
+
 #[test]
 fn recent_history_empty_when_no_launches() {
     let entries = make_entries(&["Firefox", "Chrome"]);
@@ -255,9 +269,9 @@ fn recent_history_empty_when_no_launches() {
 /// `last_launched` が並び、順序はパス昇順のタイブレークで決まる。期待値を固定文字列で
 /// 書くと、計測の秒境界をまたいだ回だけ落ちる不安定なテストになる。
 ///
-/// **`empty_history()` は空ではない**——実体は `HistoryStore::load()` で、開発機の実
-/// `history.bin` を読む。ゆえに期待値は本テストが記録したパス（`c:\fake\`）へ絞る。
-/// 絞らないと開発機の実起動履歴が期待値に混入する（実際に踏んだ）。
+/// 期待値は本テストが記録したパス（`c:\fake\`）へ絞ってある。**#963 で `empty_history()` が
+/// 真に空になった今この絞り込みは不要だが、期待値を「自分が記録したもの」に限る形は
+/// fixture の実装に依存しないぶん強い**ので残す。
 #[test]
 fn recent_history_follows_recent_launches_order_and_drops_unmatched() {
     let entries = make_entries(&["alpha", "beta", "gamma"]);

--- a/snotra-core/src/search/tests/common.rs
+++ b/snotra-core/src/search/tests/common.rs
@@ -15,5 +15,5 @@ pub(super) fn make_entries(names: &[&str]) -> Vec<AppEntry> {
 }
 
 pub(super) fn empty_history() -> HistoryStore {
-    HistoryStore::load()
+    HistoryStore::empty()
 }

--- a/snotra-core/src/search/tests/path.rs
+++ b/snotra-core/src/search/tests/path.rs
@@ -71,7 +71,7 @@ fn path_match_receives_history_boost() {
         make_entry("app1", "C:\\tool\\editor\\app1.exe"),
         make_entry("app2", "C:\\tool\\editor\\app2.exe"),
     ];
-    let mut history = HistoryStore::load();
+    let mut history = HistoryStore::empty();
     for _ in 0..5 {
         history.record_launch("C:\\tool\\editor\\app1.exe", "");
     }
@@ -189,7 +189,7 @@ fn path_match_history_key_unified_across_separators() {
         make_entry("app1", "C:\\tool\\editor\\app1.exe"),
         make_entry("app2", "C:\\tool\\editor\\app2.exe"),
     ];
-    let mut history = HistoryStore::load();
+    let mut history = HistoryStore::empty();
     // tool/editor（スラッシュ）で起動記録
     history.record_launch("C:\\tool\\editor\\app1.exe", "tool/editor");
 

--- a/snotra-core/tests/path_query_cost.rs
+++ b/snotra-core/tests/path_query_cost.rs
@@ -176,6 +176,9 @@ fn measure_recent_history_cost() {
         ),
         None => SearchEngine::new_with_migemo(result.entries, config.search.migemo_enabled),
     };
+    // **ここは実 `history.bin` を読むのが正しい**（#963 でユニットテスト側の fixture は
+    // 空へ移したが、計測ハーネスは実運用の姿を測るのが目的である）。統合テストは
+    // 別クレートゆえ `HistoryStore::empty()`（`#[cfg(test)]`）に手も届かない。
     let history = HistoryStore::load();
     let limit = config.search.recent_limit.unwrap_or(8);
 


### PR DESCRIPTION
Closes #963

## 何をしたか

ユニットテストの fixture `empty_history()` は**名前に反して空ではなく**、`HistoryStore::load()` で実 `%APPDATA%\Snotra\history.bin` を読んでいた。開発者のマシン状態でテスト結果が変わり、しかも CI のランナーにはそのファイルが無く `load()` も空を返すため、**食い違いは CI では緑のまま開発機でだけ現れる**——検出器が構造的に届かない形だった。

`HistoryStore::empty()`（`#[cfg(test)]`・ファイル I/O なし）を置き、3 つの fixture をそこへ委譲させた。

## 母集団を fixture ではなく呼び出しに取った

fixture を経由しない直接呼びが **2 件**あった（`search/tests/path.rs`）。検出器の母集団を「fixture」に取ると外は原理的に見えないため、`HistoryStore::load()` の**呼び出しそのもの**を grep して数え直した。

| 場所 | 判断 |
|---|---|
| `snotra-core/src/` の fixture 3 件 | → `HistoryStore::empty()` |
| `snotra-core/src/search/tests/path.rs` の直接呼び 2 件 | → `HistoryStore::empty()` |
| `src-tauri/` の 3 件 | 製品経路。そのまま |
| `snotra-core/tests/path_query_cost.rs` | **計測ハーネス。実運用の姿を測るのが目的ゆえ意図的にそのまま**（統合テストは別クレートで `#[cfg(test)]` の `empty()` に手も届かない） |

## 潜在ではなく、条件付きで顕在化する欠陥だった

issue には「現に壊れているわけではない」と書いたが**正しくない**。合成 fixture と衝突するパスを持つ `history.bin` を用意して当てると、修正前は **6 件**が落ちる:

| 落ちるテスト | 種別 |
|---|---|
| `empty_history_fixture_is_actually_empty` × 3 | 本 PR の検出器 |
| `recent_history_empty_when_no_launches` × 2 | **既存テスト** |
| `recent_history_follows_recent_launches_order_and_drops_unmatched` | #962 で追加 |

衝突するパスが実履歴に入った瞬間に壊れる、という性質だった。

## 検出器と、その検出力の実測

各 fixture へ `empty_history_fixture_is_actually_empty` を置いた。**この検査は CI では常に緑で、開発機でだけ落ちる**——まさに問題が現れる場所でだけ発火する。実際、修正前のこの機で 3 件とも Red だった（TDD で Red → Green を確認済み）。

故障注入は**実 `history.bin` に一切触れず**、汚染プロファイルを別に作って `SNOTRA_CONFIG_DIR` で向けた:

| 条件 | 結果 |
|---|---|
| 修正後・通常実行 | 519 passed / 0 failed |
| **修正後・汚染プロファイル** | **519 passed / 0 failed**（同一） |
| **修正前・汚染プロファイル** | **513 passed / 6 failed** |

**同一結果に意味を持たせるため、注入に検出力があることを先に測った。** 3 行目が無ければ「何も測れない注入で緑を確認した」ことになる。生成に使った足場は撤去済み。

## 規範として残したもの

- `HistoryStore::load()` の doc に「ユニットテストの fixture に使わない」を置いた（**誘惑が生じるまさにその場所**）
- `snotra-core/CLAUDE.md`「開発ルール」へ 1 行

## 残余（機械的ガードは置いていない）

新しいテストが `HistoryStore::load()` を直接呼ぶ経路は、3 つの検出器では捕まらない（fixture を通らないため）。`snotra-core/src` が `HistoryStore::load()` を呼ばないことは crisp な不変条件なので `governance-check` へ載せる余地はあるが、コメント中の言及と区別する必要があり、費用に見合うか判断がつかなかったため**意図的に置いていない**。必要なら別途。

## 検証

- `cargo fmt --all -- --check` / `cargo clippy --workspace --all-targets -- -D warnings`: 通過
- `cargo test -p snotra-core`: **519 passed / 0 failed**（+3）
- `npm run governance:check`: 全 19 検査 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
