### PR TITLE
chore(claude): codex / superpowers プラグインをリポジトリで有効化する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,6 +26,8 @@
     ]
   },
   "enabledPlugins": {
-    "rust-analyzer-lsp@claude-plugins-official": true
+    "rust-analyzer-lsp@claude-plugins-official": true,
+    "codex@openai-codex": true,
+    "superpowers@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## 何をしたか

`.claude/settings.json` の `enabledPlugins` へ 2 件を足す。3 行の追加のみで、`hooks`（PreToolUse の `pre-bash.mjs` / PostToolUse の `post-edit.mjs`）は 1 文字も変えていない。

- `codex@openai-codex` — 別実装・別診断の委譲先（`codex:rescue`）
- `superpowers@claude-plugins-official` — skills 群

## なぜ確認が要るか

`.claude/settings.json` は追跡ファイルゆえ、この差分はマージした瞬間に**全員のセッションへ効く**。ルート `CLAUDE.md`「最重要ルール」2（エージェント設定の変更は合意してから）の対象そのものである。個人スコープで済ませるなら `.claude/settings.local.json`（gitignore 済み）という道もあり、そちらを選ぶなら本 PR は閉じてよい。

## `pr-review-toolkit` を含めなかった理由

同時に試したが、この差分には入れない。`.claude/agents/` の `code-reviewer` と**同名のエージェント**を持ち込むため、`/implement` の「4b. code-reviewer エージェント」がどちらを掴むかは実測しないと決まらない。書かれた期待と測定結果は別（`AGENTS.md`「検証の作法」）なので、測ってから別 PR で判断する。

## 検証

- `npm run governance:check` = 全検査 passed（検査 19 件 / 対象文書 34 件 / rules 7 件 / skills 12 件 / 恒久規範 常時ロード 13554/15500 字）
- スキル表（`CLAUDE.md`「利用できるスキル」）の更新は不要。あの表が索引するのは `disable-model-invocation: true` の user 起動専用スキルだけで、プラグインが持ち込む skills は母集団の外にある（射程は G-skill-table が双方向で固定）
- `.claude/settings.local.json` は staging に乗っていない（`git status --short` で確認）

## マージ前チェックリスト

- [x] この 2 プラグインをチーム共有として有効化することに合意する（合意できなければ close して local スコープへ）
