### PR TITLE
fix(test): indexer の temp_dir をプロセス一意にする

### DIFF
--- a/snotra-core/src/indexer.rs
+++ b/snotra-core/src/indexer.rs
@@ -2100,11 +2100,35 @@ mod tests {
     /// これらのテストは先頭でこのガードを取得する。
     static INDEX_LOCK_TEST_GUARD: Mutex<()> = Mutex::new(());
 
+    /// テスト用の作業ディレクトリを作り直して返す。
+    ///
+    /// 名前には `tag`（プロセス内の一意性）に加えて **`std::process::id()`** を含める。
+    /// `INDEX_WRITE_LOCK` はプロセス内の `static Mutex` ゆえ、テストバイナリが複数
+    /// プロセスに分かれる状況（`cargo test` と `cargo test --release` の重なり・
+    /// temp root を共有する 2 ジョブ・別 worktree での並行実行）では効かない。
+    /// pid を落とすと、片方の `remove_dir_all` がもう片方の `create_dir_all` や
+    /// `index.bin.tmp` の書き込みに割り込み、コード変更と無関係な panic になる（#978）。
     fn temp_dir(tag: &str) -> std::path::PathBuf {
-        let dir = std::env::temp_dir().join(format!("snotra_idx_test_{}", tag));
+        let dir =
+            std::env::temp_dir().join(format!("snotra_idx_test_{}-{}", tag, std::process::id()));
         let _ = fs::remove_dir_all(&dir);
         fs::create_dir_all(&dir).expect("create temp dir");
         dir
+    }
+
+    #[test]
+    fn temp_dir_name_is_unique_per_process() {
+        let dir = temp_dir("process_unique");
+        let name = dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("temp dir name");
+        assert_eq!(
+            name,
+            format!("snotra_idx_test_process_unique-{}", std::process::id()),
+            "作業ディレクトリ名に自プロセスの pid が入っていない（#978）"
+        );
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/snotra-core/src/indexer.rs
+++ b/snotra-core/src/indexer.rs
@@ -2117,7 +2117,7 @@ mod tests {
     }
 
     #[test]
-    fn temp_dir_name_is_unique_per_process() {
+    fn temp_dir_name_contains_process_id() {
         let dir = temp_dir("process_unique");
         let name = dir
             .file_name()


### PR DESCRIPTION
## 何を直したか

`snotra-core/src/indexer.rs` の `#[cfg(test)] mod tests` のヘルパー `temp_dir(tag)` が
作業ディレクトリ名を `tag` だけで決めており、**プロセス間で一意でなかった**。
テストバイナリが同時に 2 つ走ると同じ `%TEMP%\snotra_idx_test_<tag>` を食い合い、
片方の `remove_dir_all` がもう片方の `create_dir_all` / `index.bin.tmp` 書き込みへ
割り込んで、コード変更と無関係な panic（赤）になる。`INDEX_WRITE_LOCK` は
プロセス内の `static Mutex` ゆえここでは効かない。

名前に `std::process::id()` を含めた（`snotra_idx_test_<tag>-<pid>`）。

## 射程

- 変更は `temp_dir` の**関数本体と doc コメント**、および検知器 1 本のみ。
  シグネチャ `fn temp_dir(tag: &str) -> std::path::PathBuf` は不変なので、
  20 件超の呼び出し元は 1 行も変わっていない（差分は `indexer.rs` 1 ファイル・+25/-1）
- 製品コード（`#[cfg(test)]` の外）は 1 行も触っていない
- 形は既存の先例に合わせた: `config.rs` の `format!("snotra-dedup-{}", std::process::id())`、
  `tests/search_frame_cost.rs` の `snotra-search-frame-cost-{pid}-unused`

## 検証

| コマンド | exit code |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo test --workspace` | 0（全ターゲット 0 failed） |

**pid が実際に名前へ入ることの実測**: `temp_dir_name_is_unique_per_process` が
`snotra_idx_test_process_unique-{pid}` との完全一致を assert する。加えて一時的に
パスを print して実行し、`...\snotra_idx_test_process_unique-8328`（`pid=8328`）を
目視で確認した（print は commit に含めていない）。

## 後続候補（この差分では直さない・同一パターンの他の所在）

同じ「tag だけで temp ディレクトリ名を決める」ヘルパーが `snotra-core` 内に他にもある。
いずれも同じ理由でプロセス間衝突しうる:

- `snotra-core/src/history.rs:426` — `temp_dir`
- `snotra-core/src/binfmt.rs:190` — `temp_dir`
- `snotra-core/src/window_data.rs:104` — `temp_dir`
- `snotra-core/src/config.rs:3221` — `temp_dir`
- `snotra-core/src/folder.rs:242` — `temp_dir_with_contents`（変種）

Closes #978
