### PR TITLE
refactor(core): per-entry の派生導出を 1 か所へ（順序の不変条件の二重出荷を解消）

### DIFF
--- a/snotra-core/src/indexer.rs
+++ b/snotra-core/src/indexer.rs
@@ -897,7 +897,7 @@ fn save_cache_sorted_in(
 ///
 /// **保存が返す `CachedMasks` をここでは捨てている（意図的・受容する残余）。** 下流の
 /// `PrebuiltIndex::from_tree` が木しか取らないため、この経路は今も Wave 1/2 を建て直す
-/// （issue #979・繋ぎ方は `PERFORMANCE.md`「次の反復の候補」の該当行）。
+/// （issue #984・繋ぎ方は `PERFORMANCE.md`「次の反復の候補」の該当行）。
 pub fn rebuild_and_save(scan: &[ScanPath], show_hidden_system: bool) -> IndexTree {
     // 権威的書き手: scan + sort + save を書き込みロック保持下で行い、
     // 背景再スキャン / 別の rebuild との index.bin 同時書き込みを防ぐ。

--- a/snotra-core/src/indexer.rs
+++ b/snotra-core/src/indexer.rs
@@ -810,35 +810,25 @@ impl DerivedColumns {
 pub(crate) fn derive_columns(entries: Vec<AppEntry>) -> DerivedColumns {
     // マスクを計算してキャッシュに含める。起動時に SearchEngine::new_with_cached_masks()
     // がマスク再計算をスキップできるようにする。
-    let lower_names: Vec<String> = entries.iter().map(|e| to_lower_folded(&e.name)).collect();
-    let lower_file_names: Vec<Option<String>> = entries
-        .iter()
-        .map(|e| lower_file_name(&e.target_path))
-        .collect();
-    // **マスクは潰す前の完全な文字列から導出する。** 潰した後に取ると
-    // `file_char_mask(None) == 0` になり、pre-filter が false negative を出す
-    // （`search/build.rs` の `compute_wave2` と同じ不変条件——あちらは「ビットマスクより後に
-    // 潰す」という順序で守っており、ここでは「潰す前に導出する」という順序で守る）。
-    let char_masks: Vec<u64> = lower_names.iter().map(|n| name_char_mask(n)).collect();
-    let file_name_char_masks: Vec<u64> = lower_file_names
-        .iter()
-        .map(|n| file_char_mask(n.as_deref()))
-        .collect();
-
-    // **共有を測って潰した形で書く**（v6 以降）。畳み込みは `collapse_lower_pair` が正本であり、
-    // 追記側（`extend_cached_masks`）と同じ関数を通ることだけが、ディスクとメモリで潰れ方が
-    // 一致する根拠である。ここを別実装で書き起こしてはならない。
     //
-    // **2 本を値ごと渡す。** マスクは上で導出済みで、以後この 2 本を読む箇所は無い
-    // ——参照で渡して `clone` すると、潰さずに済む分まで複製することになる。
-    let (collapsed_lower_names, collapsed_lower_file_names): (Vec<_>, Vec<_>) = entries
-        .iter()
-        .zip(lower_names)
-        .zip(lower_file_names)
-        .map(|((entry, lower_name), lower_file)| {
-            collapse_lower_pair(&entry.name, lower_name, lower_file)
-        })
-        .unzip();
+    // **per-entry の導出そのものは [`derive_entry_collapsed`] が持つ。** 追記側
+    // （`extend_cached_masks`）と同じ関数を通ることだけが、ディスクとメモリで潰れ方と
+    // マスクが一致する根拠である。ここに列ごとの別実装を書き起こしてはならない。
+    //
+    // 4 本を 1 周で埋める。列ごとの `collect` に分けると、潰す前の `Vec<String>` /
+    // `Vec<Option<String>>` の spine が潰した後の spine と重なって生きる区間ができる。
+    let len = entries.len();
+    let mut char_masks = Vec::with_capacity(len);
+    let mut file_name_char_masks = Vec::with_capacity(len);
+    let mut collapsed_lower_names = Vec::with_capacity(len);
+    let mut collapsed_lower_file_names = Vec::with_capacity(len);
+    for entry in &entries {
+        let (char_mask, file_mask, lower_name, lower_file) = derive_entry_collapsed(entry);
+        char_masks.push(char_mask);
+        file_name_char_masks.push(file_mask);
+        collapsed_lower_names.push(lower_name);
+        collapsed_lower_file_names.push(lower_file);
+    }
 
     // **木を建てるのは派生文字列を導出し終えた後である。** 建てる段が `target_path` を
     // 吸い上げるので、順序を入れ替えると `lower_file_name(&e.target_path)` の材料が消える。
@@ -1573,11 +1563,40 @@ pub fn scan_path_env(existing: &IndexTree, show_hidden_system: bool) -> Vec<AppE
     scan_path_dirs(&user_path, existing, show_hidden_system)
 }
 
+/// エントリ 1 件の派生（**潰す前**）。マスク 2 本と、潰す前の派生文字列 1 組を返す。
+///
+/// **マスクは潰す前の完全な文字列から導出する。** 潰した後に取ると
+/// `file_char_mask(None) == 0` になり、pre-filter が false negative を出す
+/// （`search/build.rs` の `compute_wave2` と同じ不変条件——あちらは「ビットマスクより後に
+/// 潰す」という順序で守っており、ここでは「潰す前に導出する」という順序で守る）。
+///
+/// 潰さない列（`CachedLower::Raw`）へ追記する経路と、マスクだけを要する経路（`lower` が
+/// `None`）がこれを直接呼ぶ。潰した形が要るなら [`derive_entry_collapsed`] を呼ぶ。
+fn derive_entry_lowers(entry: &AppEntry) -> (u64, u64, String, Option<String>) {
+    let lower_name = to_lower_folded(&entry.name);
+    let lower_file = lower_file_name(&entry.target_path);
+    let char_mask = name_char_mask(&lower_name);
+    let file_mask = file_char_mask(lower_file.as_deref());
+    (char_mask, file_mask, lower_name, lower_file)
+}
+
+/// エントリ 1 件の派生（**潰した形**）。マスク 2 本と、畳んだ派生文字列 1 組を返す。
+///
+/// **潰す前にマスクを取るという順序は、この 1 か所にしかない。**（`derive_entry_lowers` が
+/// 返した後でだけ `collapse_lower_pair` を当てる。）記録側（[`derive_columns`]）と追記側
+/// （`extend_cached_masks` の `Collapsed` 枝）が同じここを通ることが、ディスクとメモリで
+/// 潰れ方とマスクが一致する根拠である。検知器は `derived_masks_come_from_the_uncollapsed_strings`。
+fn derive_entry_collapsed(entry: &AppEntry) -> (u64, u64, Option<String>, LowerFileName) {
+    let (char_mask, file_mask, lower_name, lower_file) = derive_entry_lowers(entry);
+    let (lower_name, lower_file) = collapse_lower_pair(&entry.name, lower_name, lower_file);
+    (char_mask, file_mask, lower_name, lower_file)
+}
+
 /// 派生文字列 1 組を、`measure_derived_sharing` の判定に従って潰した形へ畳む。
 ///
-/// **`save_cache_sorted_in` と `extend_cached_masks` が共有する。** 別実装で書き起こすと、
-/// PATH エントリの分だけが索引の読み替えとずれる——`assemble` は `Collapsed` を測り直さない
-/// ので、ずれは**検索結果のスコアという形で静かに現れる**。
+/// **唯一の呼び出し元は [`derive_entry_collapsed`] である**（記録側・追記側はそこを通る）。
+/// 別実装で書き起こすと、その経路の分だけが索引の読み替えとずれる——`assemble` は
+/// `Collapsed` を測り直さないので、ずれは**検索結果のスコアという形で静かに現れる**。
 fn collapse_lower_pair(
     name: &str,
     lower_name: String,
@@ -1605,23 +1624,24 @@ fn collapse_lower_pair(
 /// entries から直接計算されるためここでは扱わない。
 pub fn extend_cached_masks(masks: &mut CachedMasks, new_entries: &[AppEntry]) {
     for entry in new_entries {
-        let lower = to_lower_folded(&entry.name);
-        let lower_file = lower_file_name(&entry.target_path);
-
-        // **マスクは潰す前の完全な文字列から導出する**（`file_char_mask(None) == 0` による
-        // pre-filter の false negative を避ける・`compute_wave2` の不変条件）。
-        masks.char_masks.push(name_char_mask(&lower));
-        masks
-            .file_name_char_masks
-            .push(file_char_mask(lower_file.as_deref()));
-
+        // per-entry の導出は記録側（`derive_columns`）と同じ [`derive_entry_lowers`] /
+        // [`derive_entry_collapsed`] を通す。ここに関数列を書き起こしてはならない。
         match masks.lower {
-            // v3 以下: 派生文字列を持たない（Wave 1 が全件を計算する）。
-            None => {}
+            // v3 以下: 派生文字列を持たない（Wave 1 が全件を計算する）。マスクだけ足す。
+            None => {
+                let (char_mask, file_mask, _, _) = derive_entry_lowers(entry);
+                masks.char_masks.push(char_mask);
+                masks.file_name_char_masks.push(file_mask);
+            }
+            // 潰さない列。**この枝は潰す段を持たないので順序の不変条件も持たない**
+            // （`assemble` が後で測る）。
             Some(CachedLower::Raw {
                 ref mut lower_names,
                 ref mut lower_file_names,
             }) => {
+                let (char_mask, file_mask, lower, lower_file) = derive_entry_lowers(entry);
+                masks.char_masks.push(char_mask);
+                masks.file_name_char_masks.push(file_mask);
                 lower_names.push(lower);
                 lower_file_names.push(lower_file);
             }
@@ -1630,7 +1650,9 @@ pub fn extend_cached_masks(masks: &mut CachedMasks, new_entries: &[AppEntry]) {
                 ref mut lower_names,
                 ref mut lower_file_names,
             }) => {
-                let (name, file) = collapse_lower_pair(&entry.name, lower, lower_file);
+                let (char_mask, file_mask, name, file) = derive_entry_collapsed(entry);
+                masks.char_masks.push(char_mask);
+                masks.file_name_char_masks.push(file_mask);
                 lower_names.push(name);
                 lower_file_names.push(file);
             }
@@ -3905,6 +3927,115 @@ mod tests {
             }
             other => panic!("variant は保たれなければならない（実際: {other:?}）"),
         }
+
+        // **マスクは潰す前の文字列から取る**（記録側の
+        // `derived_masks_come_from_the_uncollapsed_strings` と同じ不変条件を追記側でも見る）。
+        // 潰した後に取ると `SameAsLowerName` の 3 件目が `file_char_mask(None) == 0` になる。
+        assert_eq!(
+            masks.file_name_char_masks[1],
+            file_char_mask(Some("tool.exe"))
+        );
+        assert_eq!(
+            masks.file_name_char_masks[2],
+            file_char_mask(Some("docs")),
+            "`SameAsLowerName` へ潰れる件でも、マスクは潰す前の \"docs\" から取る"
+        );
+        assert_ne!(masks.file_name_char_masks[2], 0);
+        assert_eq!(masks.char_masks[1], name_char_mask("tool"));
+        assert_eq!(masks.char_masks[2], name_char_mask("docs"));
+    }
+
+    /// **マスクは潰す前の完全な文字列から導出する**（順序の不変条件・[`derive_entry_collapsed`]）。
+    ///
+    /// 潰した後に取ると、`lower_name` が `None` へ潰れた件は `name` から、file name が
+    /// `SameAsLowerName` / `Absent` へ潰れた件は `file_char_mask(None) == 0` から取ることに
+    /// なり、**pre-filter が false negative を出してその経路のエントリだけが検索でヒット
+    /// しなくなる**。結果は「それらしく」出るので挙動テストでは捕まらない——ここで潰れた件の
+    /// マスクを、潰す前の文字列から取ったマスクと直接突き合わせる。
+    ///
+    /// `derive_columns` は I/O を持たないので temp dir を要さない。
+    #[test]
+    fn derived_masks_come_from_the_uncollapsed_strings() {
+        let entries = vec![
+            // 両方潰れない: `name` に大文字、file name は拡張子ぶん `lower_name` と別。
+            AppEntry {
+                name: "Tool".to_string(),
+                target_path: "C:\\bin\\Tool.exe".to_string(),
+                is_folder: false,
+            },
+            // file name が `lower_name` と同一 → `SameAsLowerName` へ潰れる。
+            AppEntry {
+                name: "Docs".to_string(),
+                target_path: "C:\\Docs".to_string(),
+                is_folder: true,
+            },
+            // `name` が既に小文字 → `lower_names[2]` は `None` へ潰れる。
+            AppEntry {
+                name: "notes".to_string(),
+                target_path: "C:\\bin\\notes.txt".to_string(),
+                is_folder: false,
+            },
+            // file name 成分が無い → `Absent`（マスクは 0 が正しい唯一の件）。
+            AppEntry {
+                name: "Root".to_string(),
+                target_path: "C:\\".to_string(),
+                is_folder: true,
+            },
+        ];
+
+        let derived = derive_columns(entries);
+
+        // 前提: 潰れることを先に固定する（潰れなくなればこのテストは自明に通ってしまう）。
+        assert_eq!(
+            derived.lower_names,
+            vec![
+                Some("tool".to_string()),
+                Some("docs".to_string()),
+                None,
+                Some("root".to_string())
+            ]
+        );
+        assert_eq!(
+            derived.lower_file_names,
+            vec![
+                LowerFileName::Text("tool.exe".to_string()),
+                LowerFileName::SameAsLowerName,
+                LowerFileName::Text("notes.txt".to_string()),
+                LowerFileName::Absent,
+            ]
+        );
+
+        // 本題: マスクは潰す前の文字列に対応する。
+        assert_eq!(derived.char_masks[0], name_char_mask("tool"));
+        assert_eq!(derived.char_masks[1], name_char_mask("docs"));
+        assert_eq!(
+            derived.char_masks[2],
+            name_char_mask("notes"),
+            "`None` へ潰れた件も、マスクは潰す前の \"notes\" から取る"
+        );
+        assert_eq!(derived.char_masks[3], name_char_mask("root"));
+
+        assert_eq!(
+            derived.file_name_char_masks[0],
+            file_char_mask(Some("tool.exe"))
+        );
+        assert_eq!(
+            derived.file_name_char_masks[1],
+            file_char_mask(Some("docs")),
+            "`SameAsLowerName` へ潰れた件も、マスクは潰す前の \"docs\" から取る"
+        );
+        assert_ne!(
+            derived.file_name_char_masks[1], 0,
+            "潰した後に取ると `file_char_mask(None) == 0` になる"
+        );
+        assert_eq!(
+            derived.file_name_char_masks[2],
+            file_char_mask(Some("notes.txt"))
+        );
+        assert_eq!(
+            derived.file_name_char_masks[3], 0,
+            "file name 成分が無い件だけが 0 である"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 何をしたか

`CachedMasks` を作る per-entry の導出が記録側（`derive_columns`）と追記側
（`extend_cached_masks`）に別々の形で埋まっており、**「マスクは潰す前の文字列から取る」
という順序の不変条件が 2 か所に出荷されていた**。これを 1 か所へ括り出した。

```rust
/// エントリ 1 件の派生（**潰す前**）。マスク 2 本と、潰す前の派生文字列 1 組を返す。
fn derive_entry_lowers(entry: &AppEntry) -> (u64, u64, String, Option<String>)

/// エントリ 1 件の派生（**潰した形**）。
/// **潰す前にマスクを取るという順序は、この 1 か所にしかない。**
fn derive_entry_collapsed(entry: &AppEntry) -> (u64, u64, Option<String>, LowerFileName)
```

呼び出し側:

| 経路 | 呼ぶもの |
|---|---|
| 記録側 `derive_columns`（列ごとの 4 連 `collect` → 4 本を 1 周） | `derive_entry_collapsed` |
| 追記側 `extend_cached_masks` の `Collapsed` 枝 | `derive_entry_collapsed` |
| 追記側 `Raw` 枝（潰さない列） | `derive_entry_lowers` |
| 追記側 `None` 枝（v3 以下・マスクのみ） | `derive_entry_lowers` |

`Raw` 枝は**潰す段を持たないので順序の不変条件も持たない**（`assemble` が後で測る）。
故障注入がこの枝に届かないのは欠落ではなく、そこに守るべき順序が無いためである。

issue 本文の通り、`extend_cached_masks` を記録側から呼ぶ形は取らなかった（記録側は
serialize 用に `Cow::Borrowed` を取り出す必要があり、`CachedLower` の variant に対して
到達不能な match 腕が要る）。

副次的に、記録側だけが持っていた中間の `Vec<String>` / `Vec<Option<String>>` の spine が
潰した後の spine と重なって生きる区間が消えた（4 本を 1 周・`Vec::with_capacity` で
`collect` と同じちょうどの確保）。**メモリの実測はしていないので数字は書かない。**

## 故障注入（この PR の主要な証拠）

`derive_entry_collapsed` の中で順序を反転した（先に `collapse_lower_pair` してから、
潰した値からマスクを取る）:

```rust
let (lower_name, lower_file) = collapse_lower_pair(&entry.name, lower_name, lower_file);
let char_mask = name_char_mask(lower_name.as_deref().unwrap_or(&entry.name));
let file_mask = file_char_mask(match &lower_file {
    LowerFileName::Text(s) => Some(s.as_str()),
    _ => None,
});
```

`cargo test -p snotra-core` → **4 本が赤**（547 passed; 4 failed）。4 本とも
**潰れた件のマスクを潰す前の文字列のマスクと直接突き合わせる assertion** で落ちており、
別の理由（バイト差分・往復）で落ちたものは 1 本も無い:

```
---- indexer::tests::derived_masks_come_from_the_uncollapsed_strings stdout ----
assertion `left == right` failed: `SameAsLowerName` へ潰れた件も、マスクは潰す前の "docs" から取る
  left: 0
 right: 278540
---- indexer::tests::extend_cached_masks_collapses_before_appending_to_collapsed_vecs stdout ----
assertion `left == right` failed: `SameAsLowerName` へ潰れる件でも、マスクは潰す前の "docs" から取る
  left: 0
 right: 278540
---- search::tests::build::path_merge_after_cache_miss_agrees_with_deriving_over_the_extended_tree stdout ----
assertion `left == right` failed: path-merge/migemo=false: index 0 の file_name_char_mask がずれている
  left: 294913
 right: 0
---- search::tests::build::save_side_collapse_and_assemble_measurement_agree_at_entry_view stdout ----
assertion `left == right` failed: synthetic/migemo=false: index 1 の file_name_char_mask がずれている
  left: 294913
 right: 0
```

反転を元へ戻して全緑を再確認済み。

**検知器は 2 本足した**（既存 2 本だけでは記録側の列そのものを見る枠が無かった）:

- `indexer::tests::derived_masks_come_from_the_uncollapsed_strings`（新規）
  — `derive_columns` を直接呼び（I/O を持たないので temp dir を要さない）、
  `LowerFileName` の 3 状態（`Text` / `SameAsLowerName` / `Absent`）と
  `lower_names` の `None` を揃えた 4 件で、潰れた件のマスクを潰す前の文字列から取った
  マスクと照合する。**潰れること自体を先に assert してある**（潰れなくなればこのテストが
  自明に通ってしまうため）
- `extend_cached_masks_collapses_before_appending_to_collapsed_vecs`（既存へ追記）
  — 追記側 `Collapsed` 枝に同じ照合を足した

## 検証

- `cargo fmt --all -- --check` → exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` → exit 0
- `cargo test --workspace` → exit 0（snotra-core 551 passed / 全体で 0 failed）

テストは専用の temp root（`TMP`/`TEMP` 上書き）で実行した。上書きが効いていることは、
temp root の `LastWriteTime` を 2000-01-01 に戻してから `cargo test -p snotra-core --lib
indexer::` を走らせ、実行後に現在時刻へ更新されることで実測した（テストヘルパーが自分の
ディレクトリを作って消すため、実行後の中身は空になる）。

## ⚠️ 残す論点

- ~~**`rebuild_and_save` の doc が「issue #979」を指している。**~~
  **解決済み（2 番目のコミット）。** そこに書かれているのは *`PrebuiltIndex::from_tree` が
  木しか取らないので保存が返した `CachedMasks` を捨てている* という**別の作業項目**であり、
  この PR の題（per-entry 導出の重複解消）とは違った。受け皿として **#984** が切られたので、
  doc の参照先を `issue #979` → `issue #984` へ差し替えた（他の文言と、正準形の参照
  `PERFORMANCE.md`「次の反復の候補」はそのまま）。**`Closes #979` はこの PR が閉じる
  issue として正しいので残している。**
  `snotra-core/` 配下の `.rs` と リポジトリの `*.md` を grep したところ、`#979` を指す参照は
  この 1 行が全てだった（差し替え後は 0 件）。
- ⚠️ **返り値の型を 2 層のタプルにした。** issue の提案どおり
  `(u64, u64, Option<String>, LowerFileName)` を返す関数を置いたが、`Raw` 枝が潰す前の
  文字列を要するため、その下に `derive_entry_lowers` を敷いた。別案は
  (a) 潰した形から生へ戻す逆関数を書いて 1 関数に寄せる、
  (b) `fn derive<T>(entry, finish: impl FnOnce(&str, String, Option<String>) -> T)` の
  クロージャ版で順序を型で強制する、の 2 つ。(a) は畳み込みの意味論を反転した形で
  2 度目に書くことになり、`snotra-core/CLAUDE.md`「重複する派生文字列は索引に持たず、
  鎖で共有する」が記録している `Collapsed` / `Measured` 取り違えと同型の危険がある。
  (b) は順序の反転を型で不可能にする代わりに、**故障注入という受け入れ条件そのものを
  実行不能にする**。両方を退けて 2 層にしたが、争点として残す。
- ⚠️ 名前付きの struct ではなく 4 要素タプルのままにした（呼び出し側 4 か所とも
  すぐ分解する）。フィールド名が要るほど育ったら struct へ。

Closes #979
