### PR TITLE
fix(skills): merge-pr の 3 点検証が沈黙で合格に見える経路を塞ぐ

### DIFF
--- a/.claude/skills/merge-pr/SKILL.md
+++ b/.claude/skills/merge-pr/SKILL.md
@@ -21,7 +21,7 @@ PR を squash マージする。マージで閉じる issue を決めるのは P
 4. マージ後に**必ず**、次の 3 つを確認する。**`gh pr view <PR> --json closingIssuesReferences` を数えるだけでは足りない** — それは PR 本文からその瞬間に再計算される値であって、閉じた事実そのものではない:
    - 取り直した `gh pr view <PR> --json closingIssuesReferences` の全件が意図どおり閉じたか
    - **残すと決めた issue が今も `OPEN` か**（`gh issue view <issue> --json state`）。正しく動いていればそれらは上の一覧に現れない。**ゆえに一覧を数えるだけでは、守りたい当の issue を一度も見ないことになる**
-   - `gh issue list --state closed --search "closed:>=<mergedAt>"`（時刻は `gh pr view <PR> --json mergedAt` で得る）。どちらの一覧にも属さない「知らないうちに閉じた issue」を拾う、唯一の接地した観測点
+   - `gh issue list --state closed --search "closed:>=<mergedAt>"`（時刻は `gh pr view <PR> --json mergedAt --jq .mergedAt` で得る）。どちらの一覧にも属さない「知らないうちに閉じた issue」を拾う、唯一の接地した観測点。**この観測点は空を返す形で沈黙しうる**——`closed:>=` は ISO 8601 でなければ**エラーではなく 0 件**を返し、PowerShell の `ConvertFrom-Json` は `mergedAt` を DateTime へ変換して `08/10/2026 10:26:23` の形へ崩す（2026-08-10 実測。`--jq` で生文字列を取れば起きない）。**ゆえに 0 件で終えてはならない**——上の 1 つ目で閉じたと確認した issue が**この一覧にも現れること**を突き合わせる。現れないなら、閉じなかったのではなく検索が効いていない
    誤って閉じていたら `gh issue reopen <issue>`（close イベントは履歴に残り、close を契機に動く下流は巻き戻らない。**reopen は回復であって、事前確認を省く免罪符ではない**）
 
 **手順 1 の一覧が「閉じる issue のすべて」になるのは、手順 3 を守り、かつ確認からマージまで PR 本文が変わらなかったときだけである。** 本文を凍結する機構は無く、`gh pr merge --auto` は確認とマージを引き離すため**使わない**。

--- a/.claude/skills/merge-pr/SKILL.md
+++ b/.claude/skills/merge-pr/SKILL.md
@@ -21,7 +21,7 @@ PR を squash マージする。マージで閉じる issue を決めるのは P
 4. マージ後に**必ず**、次の 3 つを確認する。**`gh pr view <PR> --json closingIssuesReferences` を数えるだけでは足りない** — それは PR 本文からその瞬間に再計算される値であって、閉じた事実そのものではない:
    - 取り直した `gh pr view <PR> --json closingIssuesReferences` の全件が意図どおり閉じたか
    - **残すと決めた issue が今も `OPEN` か**（`gh issue view <issue> --json state`）。正しく動いていればそれらは上の一覧に現れない。**ゆえに一覧を数えるだけでは、守りたい当の issue を一度も見ないことになる**
-   - `gh issue list --state closed --search "closed:>=<mergedAt>"`（時刻は `gh pr view <PR> --json mergedAt --jq .mergedAt` で得る）。どちらの一覧にも属さない「知らないうちに閉じた issue」を拾う、唯一の接地した観測点。**この観測点は空を返す形で沈黙しうる**——`closed:>=` は ISO 8601 でなければ**エラーではなく 0 件**を返し、PowerShell の `ConvertFrom-Json` は `mergedAt` を DateTime へ変換して `08/10/2026 10:26:23` の形へ崩す（2026-08-10 実測。`--jq` で生文字列を取れば起きない）。**ゆえに 0 件で終えてはならない**——上の 1 つ目で閉じたと確認した issue が**この一覧にも現れること**を突き合わせる。現れないなら、閉じなかったのではなく検索が効いていない
+   - `gh issue list --state closed --search "closed:>=<mergedAt>"`（時刻は `gh pr view <PR> --json mergedAt --jq .mergedAt` で得る）。どちらの一覧にも属さない「知らないうちに閉じた issue」を拾う、唯一の接地した観測点。**この観測点は空を返す形で沈黙しうる**——`closed:>=` は ISO 8601 でなければ**エラーではなく 0 件**を返し、PowerShell の `ConvertFrom-Json` は `gh pr view <PR> --json mergedAt` の値を DateTime へ変換して `08/10/2026 10:26:23` の形へ崩す（2026-08-10 実測。`--jq` で生文字列を取れば起きない）。**ゆえに 0 件で終えてはならない**——上の 1 つ目で閉じたと確認した issue が**この一覧にも現れること**を突き合わせる。現れないなら、閉じなかったのではなく検索が効いていない
    誤って閉じていたら `gh issue reopen <issue>`（close イベントは履歴に残り、close を契機に動く下流は巻き戻らない。**reopen は回復であって、事前確認を省く免罪符ではない**）
 
 **手順 1 の一覧が「閉じる issue のすべて」になるのは、手順 3 を守り、かつ確認からマージまで PR 本文が変わらなかったときだけである。** 本文を凍結する機構は無く、`gh pr merge --auto` は確認とマージを引き離すため**使わない**。


### PR DESCRIPTION
`/merge-pr` の手順 4 の 3 点目——「どちらの一覧にも属さない『知らないうちに閉じた issue』を拾う、唯一の接地した観測点」——が、**エラーではなく 0 件を返す形で沈黙しうる**ことを実測した。#1019 のマージ後検証で実際に踏んだ。

## 機序

`closed:>=` は ISO 8601 でなければ**エラーを出さず 0 件**を返す。そして PowerShell の `ConvertFrom-Json` は時刻フィールドを DateTime オブジェクトへ変換するため、値を展開すると形が崩れる。

実測（PR #1019 の時刻）:

| 取り方 | 得られる値 | 検索結果 |
|---|---|---|
| `gh pr view <PR> --json mergedAt --jq .mergedAt` | `2026-08-10T10:26:23Z` | #993 を拾う |
| `gh pr view <PR> --json mergedAt` → `ConvertFrom-Json` | `08/10/2026 10:26:23` | **エラーなく 0 件** |

崩れた形でも 0 件が返るので、**検証は「知らないうちに閉じた issue は無い」と読める**。実際 #1019 では #993 が閉じているのに 0 件だった。

## 変更

- 時刻の取り方を `--jq .mergedAt` へ直した（生文字列を得る）
- **そのうえで、0 件で終えてよいかの判定を突き合わせへ移した**——手順 4 の 1 つ目で閉じたと確認した issue が、この一覧にも現れることを確かめる。現れないなら「閉じなかった」のではなく「検索が効いていない」

取り方を 1 つ直すだけでは、次に別の経路で形が崩れたときに同じ沈黙が戻る。`.claude/rules/safety-nets.md`「これまで無意味だった状態に意味を与える変更は、その状態に到達する全経路を列挙する」——0 件に「合格」の意味を与えている以上、その状態へ至る別経路を検知できる形にしておく必要がある。

## 補足

2 つ目のコミットは、#1019 で入れたばかりの `G-stale-identifiers` が 1 つ目のコミットの散文を捕まえたものである（裸の `mergedAt` は GitHub API のフィールド名で現行語彙に無い）。記述の正確化でコマンド span へ畳んだ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
