### PR TITLE
chore(skills): merge-pr の手順を ASD-STE100 の構造規則へ揃える

### DIFF
--- a/.claude/skills/merge-pr/SKILL.md
+++ b/.claude/skills/merge-pr/SKILL.md
@@ -9,21 +9,103 @@ allowed-tools:
   - Write
 ---
 
-PR を squash マージする。マージで閉じる issue を決めるのは PR 本文であり、`gh pr merge` の `--subject` / `--body-file` では抑止できない（#488 実測）。auto-close は本文の**どこにあっても** `close`/`fix`/`resolve` 系 9 形（大文字小文字問わず・表やチェックリスト内も）でマージ時に走り、PR テンプレートが `Closes` を埋めるため**書いた覚えが無くても残る**。hook も見ていない（ルート `CLAUDE.md`「フック」の (A2)）。**だから下の手順が唯一の防御である**。なぜこの機構になるか（2 経路の可視性の非対称・マージ方式では逃げられない・squash 設定と復元レシピ)は `docs/adr/ADR-squash-merge-issue-autoclose.md`。
+PR を squash マージする。
 
 対象: $ARGUMENTS
 
-手順（squash マージでは常にこの順。`<PR>` は PR 番号、`<issue>` は issue 番号）:
+## この手順が唯一の防御である理由
 
-1. **マージ直前に** `gh pr view <PR> --json closingIssuesReferences` を**必ず**見る。これが GitHub の計算した「いま閉じる issue」である
-2. 一覧に閉じたくない issue があれば **PR 本文を編集して手順 1 を実行し直す**（`gh pr edit <PR> --body-file <tmp>`）。**一覧から消えるまで繰り返す。** どの行のどの語が効いたかを推測しない — 認識されるのは `close/closes/closed` `fix/fixes/fixed` `resolve/resolves/resolved` の 9 形で大文字小文字を問わず、表やチェックリストの中の行も、1 行に同居する複数の参照も効く。**編集を終えてよいと決めるのは一覧であって、自分のキーワード走査ではない**。マージ時の `--subject` / `--body-file` では止められない
-3. `--subject` / `--body-file` は squash commit のメッセージを整えるためだけに使う。**closing keyword を書いてはならない**（散文の "partially fixes #N" も効く）— 書くと手順 1 の一覧に現れないまま閉じる。省けば squash 本文は **PR 説明文そのもの**になる（表・チェックリスト込みで冗長）
-4. マージ後に**必ず**、次の 3 つを確認する。**`gh pr view <PR> --json closingIssuesReferences` を数えるだけでは足りない** — それは PR 本文からその瞬間に再計算される値であって、閉じた事実そのものではない:
-   - 取り直した `gh pr view <PR> --json closingIssuesReferences` の全件が意図どおり閉じたか
-   - **残すと決めた issue が今も `OPEN` か**（`gh issue view <issue> --json state`）。正しく動いていればそれらは上の一覧に現れない。**ゆえに一覧を数えるだけでは、守りたい当の issue を一度も見ないことになる**
-   - `gh issue list --state closed --search "closed:>=<mergedAt>"`（時刻は `gh pr view <PR> --json mergedAt --jq .mergedAt` で得る）。どちらの一覧にも属さない「知らないうちに閉じた issue」を拾う、唯一の接地した観測点。**この観測点は空を返す形で沈黙しうる**——`closed:>=` は ISO 8601 でなければ**エラーではなく 0 件**を返し、PowerShell の `ConvertFrom-Json` は `gh pr view <PR> --json mergedAt` の値を DateTime へ変換して `08/10/2026 10:26:23` の形へ崩す（2026-08-10 実測。`--jq` で生文字列を取れば起きない）。**ゆえに 0 件で終えてはならない**——上の 1 つ目で閉じたと確認した issue が**この一覧にも現れること**を突き合わせる。現れないなら、閉じなかったのではなく検索が効いていない。**1 つ目が空の PR ではこの突き合わせが原理的に使えない**（照合する相手がいない）——そのときは既知の閉じた issue を含む境界（`closed:>=<日付>` の形）で同じ検索を打ち、**形が効いていることを別に確かめてから** 0 件を受け取る（2026-08-10 実測: この経路で 0 件を受け取った）
-   誤って閉じていたら `gh issue reopen <issue>`（close イベントは履歴に残り、close を契機に動く下流は巻き戻らない。**reopen は回復であって、事前確認を省く免罪符ではない**）
+マージで閉じる issue を決めるのは **PR 本文**である。`gh pr merge` の `--subject` / `--body-file` では抑止できない（#488 実測）。
 
-**手順 1 の一覧が「閉じる issue のすべて」になるのは、手順 3 を守り、かつ確認からマージまで PR 本文が変わらなかったときだけである。** 本文を凍結する機構は無く、`gh pr merge --auto` は確認とマージを引き離すため**使わない**。
+auto-close は本文の**どこにあっても**走る。対象は `close` / `fix` / `resolve` 系の 9 形で、大文字小文字を問わない。表やチェックリストの中の行も効く。
 
-**`--delete-branch` を付ける前に、そのブランチを base にする open PR が無いことを確認する**（`gh pr list --state open --base <branch> --json number`）。base ブランチを消された PR は GitHub が自動で `CLOSED` にし、**reopen できない**（`Cannot change the base branch of a closed pull request`・実測）。復旧には下流を main の上へ rebase して PR を取り直すことになる（#830 が #829 の取り直しである）。stacked PR では**下流を先にマージするか retarget してから**消す。
+PR テンプレートが `Closes` を埋めるため、**書いた覚えが無くても残る**。
+
+hook もこれを見ていない（ルート `CLAUDE.md`「フック」の (A2)）。
+
+**機構がここに無いので、下の手順が唯一の防御である。**
+
+なぜこの機構になるかは `docs/adr/ADR-squash-merge-issue-autoclose.md` が持つ。2 経路の可視性の非対称・マージ方式では逃げられないこと・squash 設定と復元レシピ。
+
+## 手順
+
+squash マージでは常にこの順で行う。`<PR>` は PR 番号、`<issue>` は issue 番号。
+
+### 1. 閉じる issue の一覧を見る
+
+打つ: `gh pr view <PR> --json closingIssuesReferences`
+
+**マージ直前に必ず打つ。** これが GitHub の計算した「いま閉じる issue」である。
+
+### 2. 閉じたくない issue が在れば、本文を編集する
+
+打つ: `gh pr edit <PR> --body-file <tmp>`
+
+編集したら手順 1 をやり直す。**一覧から消えるまで繰り返す。**
+
+⚠ どの行のどの語が効いたかを推測しない。認識されるのは 9 形（`close/closes/closed`・`fix/fixes/fixed`・`resolve/resolves/resolved`）で、大文字小文字を問わない。表やチェックリストの中の行も、1 行に同居する複数の参照も効く。
+
+**編集を終えてよいと決めるのは一覧であって、自分のキーワード走査ではない。**
+
+マージ時の `--subject` / `--body-file` では止められない。
+
+### 3. squash commit のメッセージを整える
+
+`--subject` / `--body-file` はこのためだけに使う。
+
+⚠ **closing keyword を書いてはならない。** 散文の "partially fixes #N" も効く。書くと手順 1 の一覧に現れないまま閉じる。
+
+省けば squash 本文は **PR 説明文そのもの**になる（表・チェックリスト込みで冗長）。
+
+### 4. マージ後に 3 点を確認する
+
+⚠ **`gh pr view <PR> --json closingIssuesReferences` を数えるだけでは足りない。** それは PR 本文からその瞬間に再計算される値であって、閉じた事実そのものではない。
+
+**(1) 取り直した一覧の全件が、意図どおり閉じたか**
+
+**(2) 残すと決めた issue が今も `OPEN` か**
+
+打つ: `gh issue view <issue> --json state`
+
+正しく動いていれば、それらは (1) の一覧に現れない。**ゆえに一覧を数えるだけでは、守りたい当の issue を一度も見ないことになる。**
+
+**(3) 知らないうちに閉じた issue が無いか**
+
+打つ: `gh issue list --state closed --search "closed:>=<mergedAt>"`
+
+時刻: `gh pr view <PR> --json mergedAt --jq .mergedAt`
+
+これは 2 つの一覧のどちらにも属さない issue を拾う、唯一の接地した観測点である。
+
+⚠ **0 件は「該当なし」を意味しない。** ISO 8601 でない時刻は、エラーを出さず 0 件を返す。
+
+0 件を受け取る前に、検索が効いていることを確かめる。
+
+- (1) に issue が在る → その issue が (3) の一覧にも現れることを見る。現れないなら、閉じなかったのではなく検索が効いていない
+- (1) が空 → 突き合わせる相手がいない。既知の閉じた issue を含む境界（`closed:>=<日付>` の形）で同じ検索を打ち、形が効いていることを確かめる
+
+実測 2026-08-10: PowerShell の `ConvertFrom-Json` は `gh pr view <PR> --json mergedAt` の値を DateTime へ変換する。`08/10/2026 10:26:23` の形へ崩れ、0 件で沈黙した。`--jq` で生文字列を取れば起きない。同日、(1) が空の PR でもこの検算で 0 件を受け取った。
+
+### 誤って閉じていたら
+
+打つ: `gh issue reopen <issue>`
+
+close イベントは履歴に残る。close を契機に動く下流は巻き戻らない。**reopen は回復であって、事前確認を省く免罪符ではない。**
+
+## 手順 1 の一覧が「閉じる issue のすべて」になる条件
+
+手順 3 を守り、かつ確認からマージまで PR 本文が変わらないこと。
+
+本文を凍結する機構は無い。`gh pr merge --auto` は確認とマージを引き離すため**使わない**。
+
+## `--delete-branch` を付ける前に
+
+打つ: `gh pr list --state open --base <branch> --json number`
+
+**そのブランチを base にする open PR が無いことを確認する。**
+
+⚠ base ブランチを消された PR は、GitHub が自動で `CLOSED` にする。**reopen できない**（`Cannot change the base branch of a closed pull request`・実測）。
+
+復旧には下流を main の上へ rebase し、PR を取り直すことになる（#830 が #829 の取り直しである）。
+
+stacked PR では、**下流を先にマージするか retarget してから**消す。


### PR DESCRIPTION
`/merge-pr` の手順を ASD-STE100（Simplified Technical English）の**構造規則**へ揃えた。指示・警告・条件・根拠が 1 文に同居していたものを 4 種類へ分けている。

## 測定（`。` と改行の両方で切った値）

| | 改稿前 | 改稿後 |
|---|---:|---:|
| 文数 / 平均長 | 40 文 / 67 字 | 80 文 / **33 字** |
| 50 字超 | 21 件 | **13 件** |
| 100 字超 | 9 件 | **1 件** |
| 最長 | 198 字 | **101 字** |
| 総文字数 | 2448 字 | **2457 字** |

**総文字数はほぼ不変（+9 字）である。** 短くなったのは*文*であって*情報*ではない——「簡潔に」の実体は削減ではなく**分離**だった。

## 採った規則と、採らなかった規則

**採った（構造規則）**:

- 1 文 1 指示・命令形
- 手順文と説明文を分ける（`打つ:` / `⚠` / `なぜ` / 実測 を別行へ）
- 警告は該当ステップの前に、独立したブロックで
- 条件は縦のリストで（空一覧の分岐が従属節だったものを 2 行の分岐へ）

**採らなかった（語彙と説明の最小化）**: この文書の読者は「既知の手順を実行する人」ではなく「**手順が尽きた場面に立つ agent**」である。#1020 と #1021 はどちらも手順が想定していなかった場合で、切り抜けられたのは*観測点が何のためにあるか*を理解していたからだった。根拠を削れば、その 2 件は捕まえられていない。

`CLAUDE.md`「チーム憲章」の「意図は明確に、指示は短くていい」は、実は同じことを言っている——短くするのは指示であって意図ではない。改稿前は両者が同じ文の中で絡んでいたために、**両方が長かった**。

## 逆向きの監査

`AGENTS.md`「サブエージェント委譲と worktree」の「差分が消した行の不変条件を名指しし、再確立地点を探す」に従い、改稿前の主張 42 件の着地を機械で突き合わせた。**未着地 0 件。**

**ただし 6 件はプローブを改稿後の言い回しで書いてしまった**（「改稿前にも無い」と印字された分）。それらは「改稿後に在る」ことしか示しておらず、元の主張が保存された証拠にはならない。6 件とも読み比べて同一と判断したが、これは機械ではなく人の判断である:

| 主張 | 改稿前 → 改稿後 |
|---|---|
| マージ直前に必ず | 「マージ直前に…を必ず見る」→「マージ直前に必ず打つ」 |
| 0 件で沈黙 | 「エラーではなく 0 件」→「エラーを出さず 0 件」 |
| 突き合わせ | 「この一覧にも現れることを突き合わせる」→「(3) の一覧にも現れることを見る」 |
| 空なら不可 | 「照合する相手がいない」→「突き合わせる相手がいない」 |
| 実測（空の場合） | 「（実測: この経路で 0 件を受け取った）」→「同日、(1) が空の PR でもこの検算で 0 件を受け取った」 |
| CLOSED | 「自動で `CLOSED` にし」→「自動で `CLOSED` にする」 |

## 外部からの参照を壊していないこと

正準形の見出し参照（`` `/merge-pr`「見出し」 ``）は 1 件も無い（実測）。外部から参照されている形は「**マージ後の 3 点検証**」という構成だけで（ルート `CLAUDE.md` の 2 箇所）、3 点の構成は保っている。`npm run governance:check` は緑。

## 残る 100 字超の 1 件

`認識されるのは 9 形（close/closes/closed・fix/fixes/fixed・resolve/resolves/resolved）で、大文字小文字を問わない` — 中身はほぼ列挙された 9 個の語で、STE の数え方では 1 語扱いの項目が並んでいる。これ以上は割らない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
