### PR TITLE
fix(lints): snotra-core の rustdoc 警告 10 件を crate 側の allow で解消する

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,13 @@ version = "0.1.0"
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "deny"
 invalid_html_tags = "deny"
+# `private_intra_doc_links` は「フラグ無しで建てた doc では private 項目が出ないので link が
+# 死ぬ」という警告だが、このリポジトリの doc 建ては `ci.yml` の
+# `cargo doc --workspace --no-deps --document-private-items` 固定であり、private への link は
+# 実際に解決する（crate は publish せず docs.rs 建ても無いので、フラグ無しで建てる消費者は居ない）。
+# **この allow はリンク切れの検査を弱めない**——存在しないシンボルへの link は
+# 上の `broken_intra_doc_links = "deny"` が引き続き deny で捕まえる（変異注入で実測）。
+private_intra_doc_links = "allow"
 
 # `src-tauri/clippy.toml` の禁止（#900）を、コマンドラインから独立させる（#950）。
 # `disallowed_methods` は **warn 既定**であり、この行が無いと赤くなるのは `ci.yml` と

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,16 +21,6 @@ version = "0.1.0"
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "deny"
 invalid_html_tags = "deny"
-# `private_intra_doc_links` は「フラグ無しで建てた doc では private 項目が出ないので link が
-# 死ぬ」という警告だが、このリポジトリの doc 建ては `ci.yml` の
-# `cargo doc --workspace --no-deps --document-private-items` 固定であり、private への link は
-# 実際に解決する（crate は publish せず docs.rs 建ても無いので、フラグ無しで建てる消費者は居ない）。
-# **この allow はリンク切れの検査を弱めない**——存在しないシンボルへの link は
-# 上の `broken_intra_doc_links = "deny"` が引き続き deny で捕まえる（変異注入で実測）。
-# **撤去条件: どれかの crate を publish する、または docs.rs へ doc を建てる方針が出たら、この行を外す。**
-# そのとき doc はフラグ無しでも建つので、上に書いた前提（`--document-private-items` 固定）が崩れる
-# ——private への link は本当に死に、この警告は正しい指摘へ変わる。
-private_intra_doc_links = "allow"
 
 # `src-tauri/clippy.toml` の禁止（#900）を、コマンドラインから独立させる（#950）。
 # `disallowed_methods` は **warn 既定**であり、この行が無いと赤くなるのは `ci.yml` と

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ invalid_html_tags = "deny"
 # 実際に解決する（crate は publish せず docs.rs 建ても無いので、フラグ無しで建てる消費者は居ない）。
 # **この allow はリンク切れの検査を弱めない**——存在しないシンボルへの link は
 # 上の `broken_intra_doc_links = "deny"` が引き続き deny で捕まえる（変異注入で実測）。
+# **撤去条件: どれかの crate を publish する、または docs.rs へ doc を建てる方針が出たら、この行を外す。**
+# そのとき doc はフラグ無しでも建つので、上に書いた前提（`--document-private-items` 固定）が崩れる
+# ——private への link は本当に死に、この警告は正しい指摘へ変わる。
 private_intra_doc_links = "allow"
 
 # `src-tauri/clippy.toml` の禁止（#900）を、コマンドラインから独立させる（#950）。

--- a/snotra-core/src/lib.rs
+++ b/snotra-core/src/lib.rs
@@ -1,3 +1,16 @@
+// `private_intra_doc_links` は「フラグ無しで建てた doc では private 項目が出ないので link が
+// 死ぬ」という警告だが、このリポジトリの doc 建ては `ci.yml` の
+// `cargo doc --workspace --no-deps --document-private-items` 固定であり、private への link は
+// 実際に解決する（crate は publish せず docs.rs 建ても無いので、フラグ無しで建てる消費者は居ない）。
+// **リンク切れの検査は弱まらない**——存在しないシンボルへの link は `broken_intra_doc_links = "deny"`
+// が引き続き捕まえる（変異注入で exit 101 を実測）。
+//
+// **ルート `[workspace.lints.rustdoc]` へ書いてはならない。** あの節は G-workspace-lints が
+// 「全エントリが deny/forbid」の ∀ で見張っており、allow を 1 行足すと deny の行を残したまま
+// 検査が赤くなる（#713 の設計。実測: governance:check / node-check / rust-check の 3 job が落ちた）。
+// 抑止の射程を「この crate のこの lint だけ」に閉じるのが、あの ∀ と両立する唯一の置き場である。
+#![allow(rustdoc::private_intra_doc_links)]
+
 pub mod binfmt;
 pub mod config;
 pub mod engine;


### PR DESCRIPTION
`cargo doc` が出していた `snotra-core (lib doc) generated 10 warnings` を解消する。

## 何が起きていたか

10 件はすべて `rustdoc::private_intra_doc_links`（`index_tree.rs` 7 件 / `indexer.rs` 1 件 / `search/build.rs` 1 件 / `search.rs` 1 件）。この lint は「フラグ無しで建てた doc では private 項目が出ないので link が死ぬ」と言うものだが、本リポジトリの doc 建ては `ci.yml` の `cargo doc --workspace --no-deps --document-private-items` 固定であり、private への link は実際に解決する。crate は publish せず docs.rs 建ても無いので、フラグ無しで建てる消費者は居ない。

#562 の検出器である `broken_intra_doc_links = "deny"` とは**別の lint** であり、リンク切れの検査には触れていない。

## 変更

`snotra-core/src/lib.rs` の crate root へ `#![allow(rustdoc::private_intra_doc_links)]` を、理由と**置き場の制約**つきで置いた。`Cargo.toml` は触っていない。

置き場の制約をコメントに明記した理由は下記の経緯による。

## 経緯: ルート `Cargo.toml` へ置いた前案は検出器が落とした

当初は `[workspace.lints.rustdoc]` へ `private_intra_doc_links = "allow"` を置いたが、**G-workspace-lints（#713）が 3 job すべてを落とした**（governance-check / node-check / rust-check が同一原因）。

```
Cargo.toml:1  [workspace.lints.rustdoc] に broken_intra_doc_links / invalid_html_tags が
              deny/forbid で揃っていない（全 member が opt-in していても intra-doc link の
              検出が黙って無効になる・#713）
```

`rustdocLintsAreDenied` は「節内の**全エントリ**が deny/forbid」という ∀ で判定する。これは「deny の行を残したまま隣に allow を足して検出を殺す」形を塞ぐ意図的な設計であり、実装コメントも「次の人の最も安い直し方が『検査を緩める』にならないよう」と明記している。**検出器を緩める方向は取らず**、抑止の射程を「この crate のこの lint だけ」へ閉じることで ∀ と両立させた。

この経緯は再発防止のため `lib.rs` のコメントに残してある（「ルート `[workspace.lints.rustdoc]` へ書いてはならない」とその理由）。

## 検証

- `cargo doc --workspace --no-deps --document-private-items`: 警告 10 → 0（exit 0）
- **`deny` の生存をフォールトインジェクションで実測**: crate 側 allow を置いた状態で `index_tree.rs:22` の link を存在しないシンボルへ壊すと `error: unresolved link` ＋ `= note: requested on the command line with -D rustdoc::broken-intra-doc-links` で **exit 101**。この形でもリンク切れは捕まる。実測後に復元し `git diff -- '*.rs'` が空であることを確認済み
- `npm run governance:check`: 全検査 passed（検査 19 件）
- `npx vitest run scripts/governance-check.test.mjs`: 244 passed（CI で落ちた `:413` / `:1739` の assertion を含むファイル）
- `cargo fmt --all -- --check`: green

## 既知の flake（本 PR とは無関係・実測で切り分け済み）

`indexer::tests::load_or_scan_with_stats_reports_upgrade_save_ms_in_cache_save_ms` がフルスイート実行で稀に落ちる（単体では 6/6 green）。**`Cargo.toml` を base `ae3335d` へ一時 revert してフルスイートを走らせても同じテストが落ちる**ため、本変更との因果は無い。

実体は `snotra-core/src/indexer.rs:3404` の `assert!(result.stats.cache_save_ms > 0, ...)` で、1 エントリの昇格 save がミリ秒計で 0 に丸まると落ちる形をしている。CI の速いランナーでも起きうるので、時間ではなく呼び出しの有無で配線を固定する形への置き換えを別途検討する価値がある（本 PR の範囲外）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
