### PR TITLE
chore(deps): egui / eframe / egui_kittest を 0.36.1 へ上げる

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,9 +1169,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecolor"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6758be723a3f298bbfda4db75748bc2ba0abafe096b6383c7c32da264764fbc3"
+checksum = "fc883f505d446814c0226bef4b64564b9adb9966fc00c88c57ce6d827dd152d6"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1179,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc8234e2f681b2afd2b2e8c332fa614de2fddbdcb28d0acf5c420449682ea90"
+checksum = "2afc0cbcdb6896b7bfb1dbbebaf7b9af9635ff38fd01e89bdd0174c1717b1857"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1204,7 +1204,6 @@ dependencies = [
  "raw-window-handle",
  "static_assertions",
  "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
  "web-time",
  "windows-sys 0.61.2",
@@ -1213,28 +1212,29 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796c98d50b79631281d516343a6f6e93c0666462ca36e2c93b39f25d7793325"
+checksum = "c977ac91dfaa651633fd9722e4ce9ccb32cda4c748b89a5cb57e504036e37c13"
 dependencies = [
  "accesskit",
  "ahash",
  "bitflags 2.13.1",
  "emath",
  "epaint",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "nohash-hasher",
  "profiling",
  "smallvec",
  "unicode-segmentation",
+ "web-sys",
 ]
 
 [[package]]
 name = "egui-winit"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea6bf3608db949588b95b8b341ee358d0c3f95cf4dc3f53d8d76717edee87db"
+checksum = "9327fc8edef2c57db9bcbcacc82c8a4b1e8cc64cd41a67db4419dcf643d88c83"
 dependencies = [
  "arboard",
  "bytemuck",
@@ -1247,29 +1247,27 @@ dependencies = [
  "raw-window-handle",
  "smithay-clipboard",
  "web-time",
- "webbrowser",
  "winit",
 ]
 
 [[package]]
 name = "egui_glow"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52274b9bfb8d8e252cd0f00c9f6214f360d75a0962baa77a2d62ddb002fe99d4"
+checksum = "69b65e45f8d8d7c6d848b3ec41f642b54ad828033f1511d4b4c9adc09040166a"
 dependencies = [
  "bytemuck",
  "egui",
  "glow",
  "log",
- "memoffset",
  "profiling",
 ]
 
 [[package]]
 name = "egui_kittest"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "002c31e1f41461ce206333ffbd2e07563b79e87eb71c27e026151d12ee7b78e0"
+checksum = "6a9ea43248738d0396342e7b537b3a79568b2a5d16e8c3fdfc0d8bcbd89dbf6d"
 dependencies = [
  "egui",
  "kittest",
@@ -1286,9 +1284,9 @@ checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "emath"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4ec073c9898516584d8c6cfdcee95b530b3d941cd5031ef4050aa36812308b"
+checksum = "dce03cf1604f74515830012c29991beb0b58f69e4e43f5afe22fa7afed65ccd5"
 dependencies = [
  "bytemuck",
 ]
@@ -1354,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e60a8888b51da911df23918fd7301359b1d43a406a0ff3b8863af093dd7fc6c"
+checksum = "11863a6b2b7823010c1090ddf4706947bdda46766742def0673195cbf7ff4a73"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1379,9 +1377,9 @@ dependencies = [
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ee4e1f553a3584c301f3a56ff1a775f1384781396cea301c8d952e9b93f560"
+checksum = "18dee69613aac468922cf28a32025eb7d7ed6985b61f73245848e58f37876c98"
 
 [[package]]
 name = "equivalent"
@@ -1522,9 +1520,9 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font-types"
-version = "0.11.3"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
+checksum = "0a7299a780854a6d391be2ae1c8521c9368471b559dbfd6a8dbd9f407eaff100"
 dependencies = [
  "bytemuck",
 ]
@@ -1926,9 +1924,9 @@ dependencies = [
 
 [[package]]
 name = "glifo"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d99fc21d493812643aae86d53b7bbd02f376434a90317e8a790bc209fdd6605e"
+checksum = "ed4a1bb24121291d27230c1b1b44e07d6a9b28cefdb32fe1581dfb84e14f940a"
 dependencies = [
  "bytemuck",
  "foldhash",
@@ -2096,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "harfrust"
-version = "0.7.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0431e8e389aa0f1e72bb9d1c2db8957a1a7a3580e8ed97db819c14837aac9b3e"
+checksum = "c03d949a14aa089bbb282f7dd76a498a7f684428e4257202efc119ec010376f9"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -2529,9 +2527,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -3968,12 +3966,13 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.39.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
+checksum = "046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709"
 dependencies = [
  "bytemuck",
  "font-types",
+ "once_cell",
 ]
 
 [[package]]
@@ -4623,9 +4622,9 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skrifa"
-version = "0.42.1"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
+checksum = "819ab7d62b1d3e72d9d9dea5650bac30424f9111364bb94928dbf5ecad1baa68"
 dependencies = [
  "bytemuck",
  "read-fonts",
@@ -5852,14 +5851,13 @@ dependencies = [
 
 [[package]]
 name = "vello_common"
-version = "0.0.9"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d672facaa2d697285a786cd9d44d614cd2ce54cdc022504bf339f8fff3b750"
+checksum = "b2e9aed918117e8152c9eddfd8362d73c465c23f26c44786aa331707b8a64fa2"
 dependencies = [
  "bytemuck",
  "fearless_simd",
  "guillotiere",
- "hashbrown 0.17.1",
  "log",
  "peniko",
  "smallvec",
@@ -5868,9 +5866,9 @@ dependencies = [
 
 [[package]]
 name = "vello_cpu"
-version = "0.0.9"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588691169aed86b5c8fb487266afee01323234e6fd0a3f2aaec0eaa8e4007f23"
+checksum = "ac7349e1f55f6b801c7c277958df4ea53e7f20f21e8014910ad888b2ecda93ea"
 dependencies = [
  "bytemuck",
  "glifo",
@@ -6175,22 +6173,6 @@ dependencies = [
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
-]
-
-[[package]]
-name = "webbrowser"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef62a3d5f7b2411119a11b6f62570dbff91d7105e011a20fb83fbf8f5761c40f"
-dependencies = [
- "jni 0.22.4",
- "log",
- "ndk-context",
- "objc2 0.6.4",
- "objc2-app-kit 0.3.2",
- "objc2-foundation 0.3.2",
- "url",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-egui = "=0.35.0"
+egui = "=0.36.1"
 tauri = { version = "=2.11.5", features = ["unstable"] }
 tauri-runtime = "=2.11.3"
 tauri-runtime-wry = "=2.11.4"

--- a/snotra-egui-runtime/src/input.rs
+++ b/snotra-egui-runtime/src/input.rs
@@ -20,6 +20,12 @@ pub(crate) struct InputState {
     /// Escape が永久に効かなくなる——fail-closed の側へ倒れるため、消去点を持つことが
     /// 抑止そのものと同じだけ重要である。
     held_since_focus_gain: HashSet<KeyCode>,
+    /// 現在の修飾キー状態。**egui 0.36 で `RawInput::modifiers` が消え、保持側がこちらへ移った**
+    /// （upstream の `Remove Modifiers from RawInput and make it a egui::Event`）。egui へは
+    /// `Event::ModifiersChanged` として流しつつ、`PointerButton` / `MouseWheel` / `Key` の
+    /// `modifiers` にはここの値を載せる——**両方要る**。イベントだけでは各イベントに載る値が
+    /// 埋まらず、保持だけでは egui 側の `InputState::modifiers` が更新されない。
+    modifiers: egui::Modifiers,
     /// `take()` を通った回数＝egui へフレームを渡した回数（診断のみ・#872/#936）。
     frame_count: u64,
     /// 直近で `take` 行を出した時刻。**心拍を間引くためだけに持つ**——runner では
@@ -114,6 +120,7 @@ impl InputState {
             pointer_pos: egui::Pos2::ZERO,
             started_at: Instant::now(),
             held_since_focus_gain: HashSet::new(),
+            modifiers: egui::Modifiers::default(),
             frame_count: 0,
             last_take_trace: None,
         }
@@ -222,7 +229,13 @@ impl InputState {
                 self.raw.events.push(egui::Event::WindowFocused(*focused));
             }
             WindowEvent::ModifiersChanged(modifiers) => {
-                self.raw.modifiers = modifiers_from_tao(*modifiers);
+                // **保持とイベント送出の両方を行う**（egui 0.36 で `RawInput::modifiers` が
+                // 消えた・`self.modifiers` の doc）。片方だけでは、各イベントに載る値か
+                // egui 側の `InputState::modifiers` のどちらかが更新されない。
+                self.modifiers = modifiers_from_tao(*modifiers);
+                self.raw
+                    .events
+                    .push(egui::Event::ModifiersChanged(self.modifiers));
             }
             WindowEvent::CursorMoved { position, .. } => {
                 self.pointer_pos =
@@ -240,7 +253,7 @@ impl InputState {
                         pos: self.pointer_pos,
                         button,
                         pressed: *state == ElementState::Pressed,
-                        modifiers: self.raw.modifiers,
+                        modifiers: self.modifiers,
                     });
                 }
             }
@@ -260,7 +273,7 @@ impl InputState {
                     unit,
                     delta,
                     phase: touch_phase(*phase),
-                    modifiers: self.raw.modifiers,
+                    modifiers: self.modifiers,
                 });
             }
             WindowEvent::KeyboardInput {
@@ -343,7 +356,7 @@ impl InputState {
         }
 
         if let Some(key) = active_key {
-            if pressed && self.raw.modifiers.command {
+            if pressed && self.modifiers.command {
                 match key {
                     egui::Key::C => {
                         self.raw.events.push(egui::Event::Copy);
@@ -373,7 +386,7 @@ impl InputState {
                 physical_key: key_from_key_code(event.physical_key),
                 pressed,
                 repeat: event.repeat,
-                modifiers: self.raw.modifiers,
+                modifiers: self.modifiers,
             });
         }
 

--- a/snotra-egui-runtime/src/renderer.rs
+++ b/snotra-egui-runtime/src/renderer.rs
@@ -64,7 +64,7 @@ impl EguiRenderer {
     pub(crate) fn paint(
         &mut self,
         context: &egui::Context,
-        output: egui::FullOutput,
+        mut output: egui::FullOutput,
         size: PhysicalSize<u32>,
         clear_color: Option<egui::Color32>,
     ) -> Result<PaintOutcome, RuntimeError> {
@@ -78,9 +78,23 @@ impl EguiRenderer {
         let ppp = output.pixels_per_point;
 
         // texture delta（set）を CPU store へ。free は present 成否に依らず後で確定。
-        for (id, delta) in &output.textures_delta.set {
-            raster::apply_texture_delta(&mut self.textures, *id, delta);
+        //
+        // **1 つの `TextureId` に複数の delta が来る**（egui 0.36 で値が `SmallVec` になった）。
+        // **到着順に全部適用すること**——部分更新は前の状態へ重ねる前提で作られており、
+        // 最後の 1 件だけを採ると間の更新が落ちる（フォントアトラスの追記が典型）。
+        //
+        // **参照で舐めずに `drain` で消費する。** egui 0.36 の `TexturesDelta` は `Drop` で
+        // 「未適用の delta が残っていないか」を `debug_assert!` する。参照で読むだけだと中身が
+        // 残ったまま drop され、**debug ビルドが panic する**（release は素通りするので、
+        // 気づかないまま出荷しうる側の差）。free も同じ理由でここで取り出しておく——
+        // **適用は present の後だが、所有権を先に移さないと、下の `?` で早期 return した経路が
+        // 未適用のまま drop する**。
+        for (id, deltas) in output.textures_delta.set.drain() {
+            for delta in deltas {
+                raster::apply_texture_delta(&mut self.textures, id, &delta);
+            }
         }
+        let to_free: Vec<egui::TextureId> = output.textures_delta.free.drain().collect();
         let clipped = context.tessellate(output.shapes, ppp);
         let t_tess = trace.then(std::time::Instant::now);
 
@@ -136,7 +150,7 @@ impl EguiRenderer {
         let present_result = buffer
             .present()
             .map_err(|e| RuntimeError::Present(e.to_string()));
-        for id in &output.textures_delta.free {
+        for id in &to_free {
             self.textures.remove(id);
         }
         present_result?;

--- a/snotra-settings/Cargo.toml
+++ b/snotra-settings/Cargo.toml
@@ -13,15 +13,15 @@ path = "src/main.rs"
 [dependencies]
 snotra-core = { path = "../snotra-core" }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
-eframe = { version = "0.35", default-features = false, features = ["default_fonts", "glow"] }
+eframe = { version = "0.36", default-features = false, features = ["default_fonts", "glow"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 open = "5"
 rfd = "0.17"
 
 [dev-dependencies]
 # ヘッドレス UI テスト（AccessKit 経由）。default-features = false で wgpu/snapshot/x11 を
-# 引き込まない（GPU 依存を CI に持ち込まないため。0.35 時点で default feature は無いが将来防御）。
-egui_kittest = { version = "0.35", default-features = false }
+# 引き込まない（GPU 依存を CI に持ち込まないため。0.36 時点で default feature は無いが将来防御）。
+egui_kittest = { version = "0.36", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62.2", features = [

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,6 +52,6 @@ windows = { version = "0.62.2", features = [
 # **kittest はテスト専用である**（#872）。`view.rs` の `search_input_ui` を実コードのまま
 # 走らせ、キャレット・focus・`TextEdit` 構築の**並び**を縛る。#938 が入れた単体検査は egui の
 # 意味論だけを固定し、`update()` の並びが後ろへ戻っても通る受容残余を持っていた。
-# 版は `egui = "=0.35.0"` に合わせる（`snotra-settings/Cargo.toml` と同じ指定）。
+# 版は `egui = "=0.36.1"` に合わせる（`snotra-settings/Cargo.toml` と同じ指定）。
 [dev-dependencies]
-egui_kittest = { version = "0.35", default-features = false }
+egui_kittest = { version = "0.36", default-features = false }

--- a/src-tauri/src/egui_shell/view.rs
+++ b/src-tauri/src/egui_shell/view.rs
@@ -1269,6 +1269,24 @@ mod tests {
         }
     }
 
+    /// テストで 1 pass 走らせ、**`textures_delta` を消費してから `FullOutput` を返す**。
+    ///
+    /// epaint 0.36 の `TexturesDelta` は未適用の delta を持ったまま drop されると `Drop` の
+    /// `debug_assert!` で落ちる。**製品の消費経路は `snotra-egui-runtime` の `renderer.rs`**
+    /// であり、テストはそこを通さない（`Context` だけを回して shapes や状態を見る）ので、
+    /// 捨てることをここで明示する。**`ctx.run_ui` を直に呼ばず必ずこれを通すこと**——
+    /// 直呼びは egui のフォントアトラスが更新されたフレームでだけ落ち、**入力に依存して
+    /// 落ちたり落ちなかったりする**。
+    fn run_pass(
+        ctx: &egui::Context,
+        input: egui::RawInput,
+        f: impl FnMut(&mut egui::Ui),
+    ) -> egui::FullOutput {
+        let mut out = ctx.run_ui(input, f);
+        out.textures_delta.clear();
+        out
+    }
+
     // `hex_color_parses_and_falls_back` は #673 で `visual.rs` の
     // `hex_parses_valid_and_falls_back_to_config_default` へ移した（hex→Color32 の変換が
     // view から純粋核へ移ったため）。**証明していた命題は 2 つとも移設先で保たれている**
@@ -1315,7 +1333,7 @@ mod tests {
             events: vec![egui::Event::Text("z".to_string())],
             ..Default::default()
         };
-        let _ = ctx.run_ui(input, |ui| {
+        run_pass(&ctx, input, |ui| {
             ui.add(egui::TextEdit::singleline(&mut text).id(id));
         });
 
@@ -1349,7 +1367,7 @@ mod tests {
         let before = egui::Context::default();
         let before_id = egui::Id::new("focus_before_widget");
         let mut before_text = String::new();
-        let _ = before.run_ui(typed(), |ui| {
+        run_pass(&before, typed(), |ui| {
             ui.ctx().memory_mut(|m| m.request_focus(before_id));
             ui.add(egui::TextEdit::singleline(&mut before_text).id(before_id));
         });
@@ -1362,7 +1380,7 @@ mod tests {
         let after = egui::Context::default();
         let after_id = egui::Id::new("focus_after_widget");
         let mut after_text = String::new();
-        let _ = after.run_ui(typed(), |ui| {
+        run_pass(&after, typed(), |ui| {
             let response = ui.add(egui::TextEdit::singleline(&mut after_text).id(after_id));
             response.request_focus();
         });
@@ -1534,7 +1552,7 @@ mod tests {
         let seen = std::cell::RefCell::new(None);
         // **測るのは最初の pass である。** 2 回目以降は global style 経由でも通ってしまうため、
         // 1 pass しか走らせないことがこのテストの要点である（症状の成立条件そのもの）。
-        let _ = ctx.run_ui(egui::RawInput::default(), |ui| {
+        run_pass(&ctx, egui::RawInput::default(), |ui| {
             let visuals = ui.visuals_mut();
             visuals.extreme_bg_color = input_bg;
             visuals.selection.bg_fill = selection;
@@ -1589,7 +1607,7 @@ mod tests {
         };
 
         let seen = std::cell::RefCell::new(None);
-        let _ = ctx.run_ui(egui::RawInput::default(), |ui| {
+        run_pass(&ctx, egui::RawInput::default(), |ui| {
             // 読む側は `TextEdit` と同じ解決 getter を使う（生フィールドを見ると実経路を
             // 素通りする——理由は上のテストの doc）。
             let _ = search_input_ui(ui, test_visuals(), &mut buf, &params, |child| {
@@ -1653,7 +1671,7 @@ mod tests {
                 events,
                 ..Default::default()
             };
-            let _ = ctx.run_ui(input, |ui| {
+            run_pass(&ctx, input, |ui| {
                 let bg = ui.interact(
                     ui.max_rect(),
                     egui::Id::new("main-window-drag"),
@@ -1737,7 +1755,7 @@ mod tests {
             system_theme: Some(egui::Theme::Light),
             ..Default::default()
         };
-        let _ = ctx.run_ui(input, |_| {});
+        run_pass(&ctx, input, |_| {});
         assert_eq!(
             ctx.global_style().interaction.interact_radius,
             0.0,
@@ -1781,7 +1799,7 @@ mod tests {
         let ctx = egui::Context::default();
         let mut buf = text.to_owned();
         let mut field = egui::Rect::NOTHING;
-        let out = ctx.run_ui(egui::RawInput::default(), |ui| {
+        let out = run_pass(&ctx, egui::RawInput::default(), |ui| {
             field = search_input_ui(ui, test_visuals(), &mut buf, &params, |_| {
                 "検索...".to_owned()
             })


### PR DESCRIPTION
egui / eframe / egui_kittest を **0.35.0 → 0.36.1** へ上げる。

> [!NOTE]
> 当初 #1046 の上に積んでいたが、**#1046 のマージ後に `git rebase --onto main 1ed786b` で main の上へ載せ替え済み**。差分は egui 更新分だけである（7 ファイル）。載せ替え後に fmt / clippy / `cargo test --workspace` を再実行して通過を確認した。

## 破壊的変更への追随

### `Modifiers` が `RawInput` から `Event` へ移った（upstream #8336）

修飾キーの現在値を `InputState` 自身が持ち、`ModifiersChanged` を受けたら**保持とイベント送出の両方**を行う。片方だけでは、各イベント（`PointerButton` / `MouseWheel` / `Key`）に載る値か、egui 側の `InputState::modifiers` のどちらかが更新されない。

### `TexturesDelta` が `Drop` で未適用の delta を検査するようになった

値も `SmallVec` 化し、1 つの `TextureId` に複数の delta が来る。`renderer.rs` は参照で舐めるだけだったため `debug_assert!` に掛かった（テスト 7 件が同じ理由で落ちた）。

**`release` では素通りするので、気づかないまま出荷しうる側の差である。** 取りこぼしが起きるとフォントアトラスの追記が落ち、「特定の文字だけ描画されない」という追いにくい症状になる。

- `drain` で消費する形へ変更
- `free` も**所有権を先に移して**から present 後に適用する（`?` で早期 return する経路が未適用のまま drop するのを塞ぐ）
- delta は**到着順に全部適用する**。部分更新は前の状態へ重ねる前提であり、最後の 1 件だけを採ると間の更新が落ちる

テスト側は `run_pass` ヘルパーへ集約した。`ctx.run_ui` の直呼びは**フォントアトラスが更新されたフレームでだけ落ちる**＝入力に依存して落ちたり落ちなかったりするため、通し方を 1 つに固定する。

## 挙動の確認

**hint の配置規則が変わった**（upstream #8332「Fix TextEdit hint text not following horizontal_align/vertical_align」）。#1045 に書いた申し送りの対象そのものだが、#1046 で `vertical_align(Center)` を明示済みのため hint は中央のままで、`input_text_sits_vertically_centered_for_both_body_and_hint` が本文・hint とも 6.00/6.00 で通過する。実機でも hint は左余白 4px・崩れなしを目視した。

**実機で 8 フォントのキャレット位置を測り、0.35.0 と完全に一致することを確認した。**

| フォント | 0.35.0 | 0.36.1 |
|---|---|---|
| Yu Gothic UI | 22行 3/2 | 22行 3/2 |
| Meiryo UI | 21行 3/3 | 21行 3/3 |
| Noto Sans JP | 20行 4/3 | 20行 4/3 |
| HackGen Console | 19行 4/4 | 19行 4/4 |
| Segoe UI | 22行 3/2 | 22行 3/2 |
| Arial | 19行 4/4 | 19行 4/4 |
| Consolas | 20行 4/3 | 20行 4/3 |
| Verdana | 21行 3/3 | 21行 3/3 |

CHANGELOG に tessellation / feathering / pixel rounding の変更が無いことと整合する（Refs #1045 の残余は不変）。

なお 0.36.1 には `Fix Sense::drag detecting drags when clicking widget above it`（upstream #8396）が入っている。#1043 が扱った当たり判定の領域だが、`bar_margin_belongs_to_the_window_drag_not_the_input_field` は通過している。

## 検証

`cargo test --workspace` / clippy（`-D warnings`）/ fmt / `npm run governance:check` / `npm run smoke:egui` すべて通過。

**IME 変換中の描画だけ自動確認できていない**（キー注入では IME の変換状態を作れない）。手動での確認が残る。
