### PR TITLE
chore(scripts): 入力欄の縦の幾何をフォント別に実測する道具を置く

### DIFF
--- a/docs/build-commands.md
+++ b/docs/build-commands.md
@@ -88,6 +88,21 @@ npm run check:colors -- -Interactive      # 判定せず起動し、目視項目
 - **`SNOTRA_CONFIG_DIR` が効いたことは肯定的に確かめる。** 実行後にプロファイル配下へ `*.bin` が生成されていることを見る。効いていなければ本体は実 config を読むため、ピクセルが赤いときに「色が届いていない」と「env が効いていない」を切り分けられない
 - 判定が赤のとき（`-KeepShot` なら緑でも）`target/visual-check/` へスクリーンショットを残す。観測点が背景でない場所を指していないかは、この画像で確認する
 
+#### 入力欄の縦位置が気になる変更では、フォント別に実ピクセルを測る
+
+```powershell
+npm run check:input-metrics                                  # 既定の 8 フォント（日本語 4 + 英語 4）
+pwsh -File scripts/visual-input-metrics.ps1 -Fonts 'Segoe UI;Arial'   # `;` 区切りで絞る
+pwsh -File scripts/visual-input-metrics.ps1 -KeepShots        # 撮った窓を target/ へ残す
+```
+
+- **合否を出さない。道具であって検査ではない。** 出るのは「欄の内側 / キャレットの高さ / 上下余白 / Skew」の表で、読むのは人間である。**毎作業では走らせない**——使う契機は egui / epaint を上げたとき・入力欄の描画や行高やフォント登録に触ったとき・「見え方が変わった気がする」と報告を受けたときである
+- **判定を持たせない理由**: フォント依存で 1px の非対称が構造的に残る（#1045）ため、閾値を置けば「常に緑」か「常に赤」のどちらかへ倒れる。**永久に赤いゲートはゲートが無いのと機能的に同じである**（`check:colors` が #953 で旧述語を捨てたのと同型）
+- **Rust 側の検査では届かない領域を見る。** `view.rs` の `input_text_sits_vertically_centered_for_both_body_and_hint` は egui の**論理座標**で galley を縛るが、実機のフォント解決・softbuffer のラスタライズ・DPI を通らない。2026-08-11 の実測では、論理座標では 8 フォントすべて対称だったのに**実機では 4 種で 1px ずれていた**（Windows 既定の Yu Gothic UI と Segoe UI が両方ずれる側）
+- **前後で撮って突き合わせる使い方を想定している。** egui 0.36.1 への更新では、8 フォントの値が 0.35.0 と一寸違わないことをこの形で確かめた
+- 判定ロジックは `scripts/lib/SnotraInputMetrics.psm1`（純関数・Pester が測る）、起動とキャプチャは `scripts/visual-input-metrics.ps1` が持つ。**値の意味と読み方はモジュールの doc が正本**
+- `check:colors` と同じく **CI では走らない**・**ユーザーの実 config には触れない**（`SNOTRA_CONFIG_DIR` で `target/visual-input-metrics/` を指す）・**画面ロック中は実行できない**
+
 #### エージェントが目視項目を自分で実施するとき
 
 `smoke:manual` が実行できないのは合否の記録に `Read-Host` を使うからで、**目視項目の実体（アプリを操作して表示を観測する）は実施できる**（#836 で 11 項目・#870 で日英 2 本の実績）。実施するなら次の 4 点に従う。

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "smoke:egui": "pwsh -NoProfile -File scripts/smoke-egui.ps1",
     "smoke:manual": "pwsh -NoProfile -File scripts/manual-smoke.ps1",
     "check:colors": "pwsh -NoProfile -File scripts/visual-check-colors.ps1",
+    "check:input-metrics": "pwsh -NoProfile -File scripts/visual-input-metrics.ps1",
     "bench:startup": "pwsh -NoProfile -File scripts/bench-startup.ps1",
     "measure:memory": "pwsh -NoProfile -File scripts/measure-memory.ps1",
     "measure:memory:stages": "pwsh -NoProfile -File scripts/measure-memory-stages.ps1",

--- a/scripts/lib/SnotraInputMetrics.Tests.ps1
+++ b/scripts/lib/SnotraInputMetrics.Tests.ps1
@@ -1,0 +1,101 @@
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot 'SnotraInputMetrics.psm1') -Force
+
+    # 2026-08-11 の実測を形にした行ヒット列（欄の内側 27 行・幅 600px）。
+    # 塗りは内側の全行に在り、**文字やキャレットが乗る行では画素数が減る**（覆われる分）。
+    function FillHits {
+        param([int]$InnerTop, [int]$InnerBottom, [int]$Length)
+        $hits = @(0) * $Length
+        for ($i = $InnerTop; $i -le $InnerBottom; $i++) { $hits[$i] = 580 }
+        # 文字とキャレットが乗る帯は、その分だけ塗りが削られる。
+        for ($i = $InnerTop + 3; $i -le $InnerBottom - 2; $i++) { $hits[$i] = 500 }
+        $hits
+    }
+}
+
+Describe 'Find-SnotraFieldBounds' {
+    It '塗りが並ぶ行の範囲を欄の内側とする' {
+        $bounds = Find-SnotraFieldBounds -FillHits (FillHits -InnerTop 481 -InnerBottom 507 -Length 600) -MinHits 100
+
+        $bounds.InnerTop | Should -Be 481
+        $bounds.InnerBottom | Should -Be 507
+    }
+
+    It '中身で覆われた行が閾値を割っても、範囲は縮まない（最初と最後で決まる）' {
+        # 文字とキャレットが乗る行は塗りが 500 まで減る。**間が抜けても外側 2 行が残る限り
+        # 範囲は同じ**——これは仕様であって妥協ではない。行ごとに連続性を要求すると、
+        # 文字が端から端まで伸びた 1 行で欄が 2 つに割れて見える。
+        $loose = Find-SnotraFieldBounds -FillHits (FillHits -InnerTop 481 -InnerBottom 507 -Length 600) -MinHits 100
+        $tight = Find-SnotraFieldBounds -FillHits (FillHits -InnerTop 481 -InnerBottom 507 -Length 600) -MinHits 550
+
+        ($loose.InnerBottom - $loose.InnerTop + 1) | Should -Be 27
+        ($tight.InnerBottom - $tight.InnerTop + 1) | Should -Be 27
+    }
+
+    It '閾値が塗りの実数を超えると、欄そのものを見失う' {
+        # 上下端の行すら 580 しかない。601 を要求すれば 1 行も残らない——**「見失った」は
+        # `$null` として現れ、余白 0 とは区別される**（呼び出し側が撮り直す契機になる）。
+        Find-SnotraFieldBounds -FillHits (FillHits -InnerTop 481 -InnerBottom 507 -Length 600) -MinHits 601 |
+            Should -BeNullOrEmpty
+    }
+
+    It '塗りが 1 行も無ければ null を返す（窓が出ていない・色の指定が食い違う）' {
+        Find-SnotraFieldBounds -FillHits (@(0) * 100) -MinHits 100 | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Find-SnotraSpan' {
+    It '最初と最後を採る（途中の隙間で範囲を縮めない）' {
+        # 文字列の galley は字間で途切れる。塊で採ると範囲が縮む。
+        $hits = @($false, $true, $true, $false, $false, $true, $false)
+
+        $span = Find-SnotraSpan -Hits $hits
+        $span.Top | Should -Be 1
+        $span.Bottom | Should -Be 5
+    }
+
+    It 'Offset を画像座標へ足す' {
+        $span = Find-SnotraSpan -Hits @($false, $true, $true) -Offset 481
+
+        $span.Top | Should -Be 482
+        $span.Bottom | Should -Be 483
+    }
+
+    It '1 つも真が無ければ null を返す（キャレットの消灯を余白 0 と混同させない）' {
+        Find-SnotraSpan -Hits @($false, $false) | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Get-SnotraVerticalMargins' {
+    BeforeAll {
+        # 実測（Segoe UI・欄の内側 27 行・キャレット 22 行）: 上 3 / 下 2。
+        $script:field = [pscustomobject]@{ InnerTop = 466; InnerBottom = 492 }
+    }
+
+    It '上下余白と高さを求める' {
+        $m = Get-SnotraVerticalMargins -Field $script:field -Span ([pscustomobject]@{ Top = 469; Bottom = 490 })
+
+        $m.Top | Should -Be 3
+        $m.Bottom | Should -Be 2
+        $m.Height | Should -Be 22
+        $m.InnerHeight | Should -Be 27
+    }
+
+    It 'Skew は符号を保つ（上に寄ったか下に寄ったかを潰さない）' {
+        # 修正前の実測（上に貼り付き）と修正後（わずかに下寄り）は、同じ 1px でも向きが逆である。
+        $down = Get-SnotraVerticalMargins -Field $script:field -Span ([pscustomobject]@{ Top = 469; Bottom = 490 })
+        $up = Get-SnotraVerticalMargins -Field $script:field -Span ([pscustomobject]@{ Top = 468; Bottom = 489 })
+
+        $down.Skew | Should -Be 1
+        $up.Skew | Should -Be -1
+    }
+
+    It '偶奇が揃えば Skew は 0 になる（HackGen Console の実測 4/4）' {
+        $m = Get-SnotraVerticalMargins -Field $script:field -Span ([pscustomobject]@{ Top = 470; Bottom = 488 })
+
+        $m.Top | Should -Be 4
+        $m.Bottom | Should -Be 4
+        $m.Skew | Should -Be 0
+        $m.Height | Should -Be 19
+    }
+}

--- a/scripts/lib/SnotraInputMetrics.psm1
+++ b/scripts/lib/SnotraInputMetrics.psm1
@@ -1,0 +1,138 @@
+#Requires -Version 7
+<#
+.SYNOPSIS
+  main 窓の入力欄の**縦の幾何**を、スクリーンショットの実ピクセルから導く純関数群。
+
+.DESCRIPTION
+  Rust 側の検査（`view.rs` の `input_text_sits_vertically_centered_for_both_body_and_hint`）は
+  egui の**論理座標**で galley の位置を縛る。そこを通らないものが 3 つある: 実機のフォント解決・
+  softbuffer のラスタライズ（`raster.rs` はカバレッジ AA を持たない）・DPI。**その 3 つを通した
+  結果は、実ピクセルを数えるしか見る方法が無い。**
+
+  2026-08-11 の実測がこの道具の由来である。`vertical_align(Center)` を入れた後、論理座標では
+  8 フォントすべてがぴたりと対称だったのに、実機ではキャレットが 8 種中 4 種で 1px ずれていた
+  （Windows 既定の Yu Gothic UI と Segoe UI が両方ずれる側）。**乖離そのものが発見**であり、
+  代理（論理座標）をいくら精密にしても届かない領域だった。
+
+  **判定（exit code）を持たない。** フォント依存の 1px は構造的に消せず（#1045 に経緯と、判定式が
+  作れないことの実測がある）、閾値を置けば「常に緑」か「常に赤」のどちらかに倒れる——
+  **永久に赤いゲートはゲートが無いのと機能的に同じである**（`SnotraWindowColors.psm1` が #953 で
+  同じ理由から旧述語を捨てたのと同型）。ここが出すのは表であり、読むのは人間である。
+
+  ゆえに**毎作業では走らせない**。使う契機は次のいずれか:
+
+  - egui / epaint を上げたとき（丸めの挙動が変われば全フォントの値が動く）
+  - 入力欄の描画・行高・フォント登録に触ったとき
+  - 「見え方が変わった気がする」と報告を受けたとき（前後で撮って数値で突き合わせる）
+
+  **I/O は呼び出し側が持つ**（`scripts/visual-input-metrics.ps1`）。ここに置くのは、集計済みの
+  数値配列から幾何を導く部分だけである——`SnotraWindowColors.psm1` と同じ分離（#953）。
+#>
+
+Set-StrictMode -Version Latest
+
+<#
+.SYNOPSIS
+  行ごとの「入力欄の塗り色の画素数」から、欄の内側の行範囲を導く。
+.DESCRIPTION
+  **窓が宣言した色で探す**——`input_background_color` は config が宣言する値であり、欄の内側は
+  その塗りが横一列に長く並ぶ。枠線（focus リング）は塗り色ではないので自然に外れ、**egui 側の
+  既定色が変わっても壊れない**。`SnotraWindowColors.psm1` が「宣言された色が届いているか」を
+  見るのと同じ思想である（#953）。
+
+  ゆえに返すのは**内側**そのものであって、枠線の位置ではない。中身（文字・キャレット・IME 帯）
+  の余白はこの内側に対して測る。
+
+  塗りの行が 1 つも無いときは `$null` を返す。**窓が出ていない・色の指定が食い違っている**の
+  どちらかであり、呼び出し側はそれを「余白 0」と混同してはならない。
+
+  **文字やキャレットが乗る行も塗りを含む**——それらは欄の一部を覆うだけで、行全体を潰しはしない。
+  `MinHits` は「欄の幅のうち何 px が塗りであれば欄の行と見なすか」であり、欄幅よりずっと小さく
+  取ってよい（文字で埋まった行を落とさないため）。
+#>
+function Find-SnotraFieldBounds {
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][int[]]$FillHits,
+        [Parameter(Mandatory)][int]$MinHits
+    )
+
+    $rows = @()
+    for ($i = 0; $i -lt $FillHits.Count; $i++) {
+        if ($FillHits[$i] -ge $MinHits) { $rows += $i }
+    }
+    if ($rows.Count -lt 1) { return $null }
+
+    [pscustomobject]@{
+        InnerTop    = $rows[0]
+        InnerBottom = $rows[-1]
+    }
+}
+
+<#
+.SYNOPSIS
+  「その行に対象の画素が在るか」の真偽列から、対象の縦範囲を導く。
+.DESCRIPTION
+  返すのは**最初と最後**であって、連続する最初の塊ではない。測る対象（文字列の galley・
+  IME の帯）は途中に隙間を持つ——文字と文字の間、字形の凹み——ので、塊で採ると範囲が縮む。
+
+  `Offset` は真偽列の先頭が画像の何行目に当たるかである（内側だけを走査した配列を渡す想定）。
+
+  1 つも真が無ければ `$null` を返す。**キャレットは点滅する**ので、これは「消えている瞬間を
+  撮った」ことを意味しうる。呼び出し側は撮り直しで対処すること（不在を結論にしない）。
+#>
+function Find-SnotraSpan {
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][bool[]]$Hits,
+        [int]$Offset = 0
+    )
+
+    $start = -1
+    $end = -1
+    for ($i = 0; $i -lt $Hits.Count; $i++) {
+        if ($Hits[$i]) {
+            if ($start -lt 0) { $start = $i }
+            $end = $i
+        }
+    }
+    if ($start -lt 0) { return $null }
+
+    [pscustomobject]@{
+        Top    = $start + $Offset
+        Bottom = $end + $Offset
+    }
+}
+
+<#
+.SYNOPSIS
+  入力欄の内側に対する、中身の上下余白を求める。
+.DESCRIPTION
+  `Skew` は「上余白 − 下余白」である。**符号を保つ**——0 との距離だけを見ると、上に寄ったのか
+  下に寄ったのかが消える。2026-08-11 の実測では、修正前が上 0 / 下 8（上に貼り付き）、修正後が
+  上 3 / 下 2（わずかに下寄り）で、**同じ「ずれ 1px」でも向きが逆**だった。
+
+  `InnerHeight` と `Height` の偶奇が食い違うと、余りを等分できないため `Skew` は 0 になれない。
+  これはフォントに依存する構造的な残余であって欠陥ではない（#1045）。
+#>
+function Get-SnotraVerticalMargins {
+    param(
+        [Parameter(Mandatory)]$Field,
+        [Parameter(Mandatory)]$Span
+    )
+
+    $top = $Span.Top - $Field.InnerTop
+    $bottom = $Field.InnerBottom - $Span.Bottom
+
+    [pscustomobject]@{
+        Top         = $top
+        Bottom      = $bottom
+        Skew        = $top - $bottom
+        Height      = $Span.Bottom - $Span.Top + 1
+        InnerHeight = $Field.InnerBottom - $Field.InnerTop + 1
+    }
+}
+
+Export-ModuleMember -Function @(
+    'Find-SnotraFieldBounds'
+    'Find-SnotraSpan'
+    'Get-SnotraVerticalMargins'
+)

--- a/scripts/visual-input-metrics.ps1
+++ b/scripts/visual-input-metrics.ps1
@@ -1,0 +1,226 @@
+#Requires -Version 7
+<#
+.SYNOPSIS
+  main 窓の入力欄の縦の幾何を、フォントを差し替えながら実ピクセルで測って**表に出す**（判定しない）。
+
+.DESCRIPTION
+  Rust 側の検査は egui の論理座標で galley の位置を縛るが、**実機のフォント解決・softbuffer の
+  ラスタライズ・DPI を通らない**。そこを通した結果を見る道具である。由来・使う契機・判定を
+  持たない理由は `scripts/lib/SnotraInputMetrics.psm1` の doc が正本。
+
+  **合否を出さない。** 出力は「欄の内側 / 中身の高さ / 上下余白 / Skew」の表であり、読むのは
+  人間である。前後で撮って突き合わせる使い方を想定している（例: egui を上げる前後）。
+
+.EXAMPLE
+  npm run check:input-metrics
+  npm run check:input-metrics -- -Fonts 'Yu Gothic UI','Segoe UI'
+#>
+[CmdletBinding()]
+param(
+    # 測るフォント。既定は日本語 4 種 + 英語 4 種で、**行高の偶奇が割れる代表**を選んである
+    # （2026-08-11 実測: 前 2 種は上下がずれ、後ろ 2 種は揃う）。
+    [string[]]$Fonts = @(
+        'Yu Gothic UI', 'Meiryo UI', 'Noto Sans JP', 'HackGen Console',
+        'Segoe UI', 'Arial', 'Consolas', 'Verdana'
+    ),
+    # 入力する文字。**A-Z のみ**（`Send-SnotraKey` が VK で送るため）。
+    [string]$Query = 'AGQ',
+    [string]$ExePath = '',
+    # スクリーンショットを残す（既定は測って捨てる）。
+    [switch]$KeepShots
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+Import-Module (Join-Path $PSScriptRoot 'lib/SnotraSmoke.psm1') -Force
+# 色キーの形（`R<<16 | G<<8 | B`）と 3 桁 hex の展開は**あちらが持つ**。ここへ写しを置かない。
+Import-Module (Join-Path $PSScriptRoot 'lib/SnotraWindowColors.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib/SnotraInputMetrics.psm1') -Force
+
+# 画面ロック中は窓が描かれず、撮った絵が黒一色になる（#866）。
+Assert-SnotraSessionUnlocked -Operation '入力欄の幾何測定'
+
+$exe = if ($ExePath) { $ExePath } else { Resolve-SnotraCargoExecutable -RepositoryRoot $repoRoot }
+if (-not (Test-Path $exe)) { throw "実行ファイルがありません: $exe" }
+Write-Host "対象: $exe"
+
+$outDir = Join-Path $repoRoot 'target/visual-input-metrics'
+New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+
+# **非既定色を使う**（`docs/build-commands.md`「`[visual]` の色を変える変更は非既定色で目視する」）。
+# 塗りを宣言色で探すため、背景と入力欄の塗りが明確に違う組を選ぶ。
+$backgroundColor = '#1E2430'
+$inputBackgroundColor = '#3A2A55'
+
+Add-Type -AssemblyName System.Drawing
+
+# **塗りの判定には許容差が要る。** 入力欄の塗りは領域によって成分が ±1 揺れる
+# （実測: `#3A2A55` に対し `392954` / `3A2A54` / `392A55` が混在）。`raster.rs` の重ね塗りで
+# 生じる誤差であり、**厳密一致で判定するとこの揺れを「中身」として拾い、16 行の偽の帯を
+# 上下余白として報告する**（2026-08-11 に実測）。
+#
+# `ConvertTo-SnotraColorKey`（厳密一致）を使わないのはこの一点である——あちらは「宣言した色が
+# 届いているか」の存在検査に十分だが、**領域の境界を引く**にはこちらが要る。
+$fill = @{
+    R = [Convert]::ToInt32($inputBackgroundColor.Substring(1, 2), 16)
+    G = [Convert]::ToInt32($inputBackgroundColor.Substring(3, 2), 16)
+    B = [Convert]::ToInt32($inputBackgroundColor.Substring(5, 2), 16)
+}
+$fillTolerance = 3
+
+function Test-IsFill {
+    param([Parameter(Mandatory)]$Pixel)
+    ([Math]::Abs([int]$Pixel.R - $fill.R) -le $fillTolerance) -and
+    ([Math]::Abs([int]$Pixel.G - $fill.G) -le $fillTolerance) -and
+    ([Math]::Abs([int]$Pixel.B - $fill.B) -le $fillTolerance)
+}
+
+# Bitmap → 行ごとの「入力欄の塗り画素数」。**I/O 側**（判定は純関数が持つ）。
+#
+# **`[int]` へ上げてからシフトする。** PowerShell の `-shl` は左オペランドの型で動くため、
+# `[byte] -shl 16` は型幅で切り詰められて 0 になる——R と G が消えた鍵は 1 画素とも一致せず、
+# 「塗りが 1 行も見つからない」形で**沈黙する**（2026-08-11 に実測）。この形とインライン化の
+# 理由は `scripts/visual-check-colors.ps1` の `Get-WindowColorHistogram` のコメントが正本。
+function Get-FillHitsPerRow {
+    param([Parameter(Mandatory)]$Capture)
+    $hits = @(0) * $Capture.Height
+    for ($y = 0; $y -lt $Capture.Height; $y++) {
+        $n = 0
+        for ($x = 0; $x -lt $Capture.Width; $x++) {
+            if (Test-IsFill -Pixel $Capture.Bitmap.GetPixel($x, $y)) { $n++ }
+        }
+        $hits[$y] = $n
+    }
+    $hits
+}
+
+# 代表行で塗りが占める x の範囲を返す。**枠線を探索から外すために要る**——枠線は塗り色ではなく
+# 縦に長く連なるので、これを除かないと「中身」として最初に拾われ、上下余白が 0 に化ける（実測）。
+function Get-FillColumnRange {
+    param([Parameter(Mandatory)]$Capture, [Parameter(Mandatory)][int]$Row)
+    $first = -1
+    $last = -1
+    for ($x = 0; $x -lt $Capture.Width; $x++) {
+        if (Test-IsFill -Pixel $Capture.Bitmap.GetPixel($x, $Row)) {
+            if ($first -lt 0) { $first = $x }
+            $last = $x
+        }
+    }
+    if ($first -lt 0) { return $null }
+    @{ First = $first; Last = $last }
+}
+
+# 欄の内側で「塗りでない画素」が縦に長く連なる列を探し、その列の真偽列を返す。
+#
+# **右から探す。** 入力した文字の縦棒（`A` の左辺など）も縦に長く連なるため、左から探すと
+# そちらを先に拾い、**上下余白が文字のインク範囲に化ける**（実測で Top/Bottom が 4/1 になった）。
+# キャレットは入力文字の**右**に立つので、右端から最初に見つかる縦線がそれである——色に依存せず
+# 分けられるので、egui の既定カーソル色が変わっても壊れない。
+#
+# **キャレットは点滅する**ので、見つからない＝消灯の瞬間を撮った可能性がある（呼び出し側で再試行）。
+function Get-CaretColumnHits {
+    param(
+        [Parameter(Mandatory)]$Capture,
+        [Parameter(Mandatory)]$Bounds,
+        [Parameter(Mandatory)][int]$MinRun,
+        [Parameter(Mandatory)][int]$FromX,
+        [Parameter(Mandatory)][int]$ToX
+    )
+    for ($x = $ToX; $x -ge $FromX; $x--) {
+        $hits = @()
+        $n = 0
+        for ($y = $Bounds.InnerTop; $y -le $Bounds.InnerBottom; $y++) {
+            $isFill = Test-IsFill -Pixel $Capture.Bitmap.GetPixel($x, $y)
+            $hits += (-not $isFill)
+            if (-not $isFill) { $n++ }
+        }
+        if ($n -ge $MinRun) { return @{ X = $x; Hits = [bool[]]$hits } }
+    }
+    $null
+}
+
+# **`;` 区切りの単一文字列も受ける。** `pwsh -File` は `-Fonts 'A','B'` を 1 つの文字列として
+# 渡すため（`[int[]]` と違い `[string[]]` はカンマで分割されない）、npm 経由の指定が
+# 「1 フォントだけ測って黙って終わる」形に化ける（実測）。
+$fontList = @($Fonts | ForEach-Object { $_ -split ';' } | Where-Object { $_.Trim() } | ForEach-Object { $_.Trim() })
+
+$rows = @()
+foreach ($font in $fontList) {
+    $slug = ($font -replace '[^A-Za-z0-9]', '')
+    $profileDir = Join-Path $outDir "profile-$slug"
+    $additional = @"
+[visual]
+background_color = "$backgroundColor"
+input_background_color = "$inputBackgroundColor"
+font_family = "$font"
+"@
+    $profile = New-SnotraVerificationProfile -ProfileDir $profileDir `
+        -GeneralSection 'show_on_startup = true' -AdditionalSections $additional -ShowIcons $false
+    $stderr = Join-Path $profileDir 'stderr.log'
+
+    $proc = $null
+    $capture = $null
+    $row = [ordered]@{ Font = $font; Inner = '-'; Caret = '-'; Top = '-'; Bottom = '-'; Skew = '-' }
+    try {
+        $proc = Start-SnotraProcess -ConfigDir $profile.FullPath -FilePath $exe `
+            -StandardErrorPath $stderr -NoNewWindow
+        $hwnd = Wait-SnotraWindow -Title 'Snotra' -Process $proc -TimeoutMs 120000 -PollMs 500
+        # 最初の present を跨ぐ（未描画の窓を撮ると塗りが 1 行も見つからない）。
+        Start-Sleep -Seconds 2
+        if (Set-SnotraForegroundWindow -Handle $hwnd) {
+            # VK_A..VK_Z は ASCII 大文字と同値。押下と解放を分けて送る（`Send-SnotraKey` の形）。
+            foreach ($ch in $Query.ToUpperInvariant().ToCharArray()) {
+                $vk = [byte][int][char]$ch
+                Send-SnotraKey -VirtualKey $vk
+                Start-Sleep -Milliseconds 30
+                Send-SnotraKey -VirtualKey $vk -Up
+                Start-Sleep -Milliseconds 30
+            }
+            Start-Sleep -Milliseconds 400
+        }
+
+        # **キャレットの点滅を跨ぐため撮り直す。** 消灯の瞬間は「中身が無い」として現れるので、
+        # 1 枚で結論すると `Caret` が欠けた表になる。
+        for ($attempt = 0; $attempt -lt 8; $attempt++) {
+            $capture = Get-SnotraWindowCapture -Handle $hwnd
+            $bounds = Find-SnotraFieldBounds -FillHits (Get-FillHitsPerRow -Capture $capture) -MinHits 100
+            if ($bounds) {
+                # 塗りの左右端の 1px 内側だけを探す（枠線を外す・`Get-FillColumnRange` の doc）。
+                $span_x = Get-FillColumnRange -Capture $capture -Row $bounds.InnerTop
+                $column = if ($span_x) {
+                    Get-CaretColumnHits -Capture $capture -Bounds $bounds -MinRun 15 `
+                        -FromX ($span_x.First + 1) -ToX ($span_x.Last - 1)
+                } else { $null }
+                if ($column) {
+                    Write-Verbose "caret x=$($column.X) fill=$($span_x.First)..$($span_x.Last) inner=$($bounds.InnerTop)..$($bounds.InnerBottom)"
+                    $span = Find-SnotraSpan -Hits $column.Hits -Offset $bounds.InnerTop
+                    $m = Get-SnotraVerticalMargins -Field $bounds -Span $span
+                    $row.Inner = $m.InnerHeight
+                    $row.Caret = $m.Height
+                    $row.Top = $m.Top
+                    $row.Bottom = $m.Bottom
+                    $row.Skew = $m.Skew
+                    if ($KeepShots) {
+                        $capture.Bitmap.Save((Join-Path $outDir "$slug.png"), [System.Drawing.Imaging.ImageFormat]::Png)
+                    }
+                    break
+                }
+            }
+            $capture.Bitmap.Dispose()
+            $capture = $null
+            Start-Sleep -Milliseconds 150
+        }
+    } finally {
+        if ($capture) { $capture.Bitmap.Dispose() }
+        if ($proc) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
+    }
+    $rows += [pscustomobject]$row
+}
+
+Write-Host ''
+Write-Host '入力欄の縦の幾何（Skew = 上余白 − 下余白。符号が寄った向きを表す）'
+$rows | Format-Table -AutoSize | Out-String -Width 200 | Write-Host
+Write-Host '判定は出さない。値の意味と読み方は scripts/lib/SnotraInputMetrics.psm1 の doc を参照。'
+if ($KeepShots) { Write-Host "スクリーンショット: $outDir" }


### PR DESCRIPTION
入力欄の縦の幾何を、フォントを差し替えながら実ピクセルで測って**表に出す**道具を置く。**合否は出さない。**

```
Font            Inner Caret Top Bottom Skew
----            ----- ----- --- ------ ----
Segoe UI           27    22   3      2    1
HackGen Console    27    19   4      4    0
Yu Gothic UI       27    22   3      2    1
Arial              27    19   4      4    0
```

## なぜ要るか

Rust 側の検査（`view.rs` の `input_text_sits_vertically_centered_for_both_body_and_hint`）は egui の**論理座標**で galley の位置を縛るが、**実機のフォント解決・softbuffer のラスタライズ・DPI を通らない**。

2026-08-11 の実測がこの道具の由来である。`vertical_align(Center)`（#1046）を入れた後、**論理座標では 8 フォントすべて対称だったのに、実機では 4 種で 1px ずれていた**（Windows 既定の Yu Gothic UI と Segoe UI が両方ずれる側）。乖離そのものが発見であり、代理をいくら精密にしても届かない領域だった。egui 0.36.1 への更新（#1047）でも、8 フォントの値が 0.35.0 と一寸違わないことをこの形で確かめている。

## 判定を持たせない

フォント依存の 1px は構造的に消せない（#1045 に、判定式が作れないことの実測がある）。閾値を置けば「常に緑」か「常に赤」のどちらかへ倒れる —— **永久に赤いゲートはゲートが無いのと機能的に同じである**（`check:colors` が #953 で旧述語を捨てたのと同型）。

ゆえに**毎作業では走らせない**。使う契機は doc に明記した: egui / epaint を上げたとき・入力欄の描画や行高やフォント登録に触ったとき・「見え方が変わった気がする」と報告を受けたとき。

## 構成

`SnotraWindowColors.psm1` と同じ分離（#953）に倣った。

| 層 | 置き場 |
|---|---|
| 判定（純関数・Pester が測る） | `scripts/lib/SnotraInputMetrics.psm1` |
| 起動・キャプチャ・表 | `scripts/visual-input-metrics.ps1` |
| プロファイル生成・起動・窓キャプチャ・キー注入 | **既存の `SnotraSmoke.psm1` を再利用** |

新規なのは幾何の導出だけである。`check:colors` と同じく CI では走らず、ユーザーの実 config にも触れない（`SNOTRA_CONFIG_DIR` で `target/visual-input-metrics/` を指す）。

## 実装中に踏んだ罠（いずれも doc / コメントへ残した）

- **`[byte] -shl 16` は型幅で切り詰められる。** R と G が消えた鍵は 1 画素とも一致せず、「塗りが 1 行も見つからない」形で**沈黙**した。**既存の `Get-WindowColorHistogram` には既にこの警告のコメントが在り**、読まずに写しを書いて同じ穴に落ちた
- **塗りの色は領域によって ±1 揺れる**（`#3A2A55` に対し `392954` 等が混在）。厳密一致ではこの揺れを「中身」として拾い、**16 行の偽の帯**を上下余白として報告した。宣言色の存在検査には厳密一致で十分だが、**領域の境界を引くには許容差が要る**
- **キャレット列は右から探す。** 左から探すと入力文字の縦棒を先に拾い、上下余白が文字のインク範囲に化ける。キャレットは入力文字の右に立つので、**向きだけで色に依存せず**分けられる（egui の既定カーソル色が変わっても壊れない）

## 検証

**既知の実測値を再現することを確かめた** —— 上の表は 2026-08-11 に別実装（session 限りの scratchpad スクリプト）で測った値と完全に一致する。独立に組み直した実装が同じ数値を返したので、道具として信用できる。

`npm run test:powershell`（128 passed）/ `npm run governance:check` / `npm test`（625 passed）通過。
