### PR TITLE
fix(egui): 検索 worker の死を送信 Err で検知し、古い行の誤起動を止める

### DIFF
--- a/src-tauri/src/egui_shell/launcher_controller.rs
+++ b/src-tauri/src/egui_shell/launcher_controller.rs
@@ -786,11 +786,22 @@ impl LauncherController {
                         }
                         let query = self.state.query().to_string();
                         let seq = self.dispatch.issue(self.last_input_at, Instant::now());
-                        // 送信失敗（worker が死んでいる）は無視する——次の打鍵で再送され、表示は前の行を保ったままになる。
-                        let _ = self
+                        // 送信できたなら**結果が届くまで前の行を保つ**（folder cache 未着枝と同じ扱い）。
+                        if self
                             .search_tx
-                            .send(crate::egui_shell::SearchRequest { seq, query });
-                        // **結果が届くまで前の行を保つ**（folder cache 未着枝と同じ扱い）。
+                            .send(crate::egui_shell::SearchRequest { seq, query })
+                            .is_err()
+                        {
+                            // **worker が死んでいる。** 無界チャネルゆえ `Err` はこれ以外を意味せず
+                            // （混雑・一時的失敗が存在しない）、死因（早期 return・panic・将来足す
+                            // 経路）を問わず必ずここを通る——死因ごとの塞ぎ方より射程が広い。
+                            // **再送では回復しない**（受け手はもう居ない）ため、前の行を保つと
+                            // 保持が恒久化し、debounce が armed でない Enter が旧クエリの項目を
+                            // 起動する（`on_enter` の flush が「どちらの枝でもクリアする」理由と
+                            // 同じ危険である）。上の空クエリ枝と同じ処置へ合流させる。
+                            self.dispatch.invalidate();
+                            self.state.set_results(Vec::new());
+                        }
                     }
                     QueryIntent::Instant {
                         filter_name,

--- a/src-tauri/src/egui_shell/search_worker.rs
+++ b/src-tauri/src/egui_shell/search_worker.rs
@@ -29,6 +29,12 @@ pub fn coalesce(first: SearchRequest, rest: impl Iterator<Item = SearchRequest>)
 }
 
 /// worker を 1 本立てる。`Sender` が drop されると `recv` が Err を返しループが終わる（join はしない・best-effort）。
+///
+/// **逆向きの契約が対である。** この worker の死（`AppState` 不在・engine lock の毒・将来足す
+/// 経路のいずれでも）は、`req_rx` が drop されることで**送信側の `Err`** として現れ、
+/// `LauncherController::run_search_with` の Plain 枝が行をクリアして誤起動を止める。無界チャネル
+/// ゆえ `Err` は「受け手が死んだ」以外を意味しない（混雑による偽陽性が無い）。**検知は 1 要求ぶん
+/// 遅れる**——死を招いた要求は応答もクリアも得ず、次の送信が失敗して初めて現れる。
 pub fn spawn_search_worker(app: tauri::AppHandle) -> (Sender<SearchRequest>, Receiver<SearchMsg>) {
     let (req_tx, req_rx) = channel::<SearchRequest>();
     let (msg_tx, msg_rx) = channel::<SearchMsg>();
@@ -36,10 +42,19 @@ pub fn spawn_search_worker(app: tauri::AppHandle) -> (Sender<SearchRequest>, Rec
         while let Ok(first) = req_rx.recv() {
             // recv で 1 つ取った後、溜まっている分を吸って最後だけ採用する。
             let picked = coalesce(first, req_rx.try_iter());
+            // **死ぬのが正しい。** `continue` にしてはならない——worker が生きたまま要求だけ
+            // 落ちると、送信は成功し続け seq は永久に settle せず、UI は古い行を保ったまま
+            // 無音になる——**沈黙する失敗を選ばない**。ここで抜ければ `req_rx`
+            // が drop され、次の送信が `Err` として送信側へ死を伝える（→ `run_search_with` の
+            // Plain 枝が行をクリアする）。**現に到達しない**（`AppState` は Builder 段階で
+            // manage され `unmanage` の呼び出し点は無い）が、到達したときに沈黙しない形を選ぶ。
             let Some(state) = app.try_state::<crate::AppState>() else {
                 return;
             };
             let (results, index_entries) = {
+                // 毒（poisoned）は debug/test でのみ生じる（release は `panic = "abort"`）。
+                // ここで panic して死ぬのは正しい——不整合な `Engine` で検索を続けると診断が
+                // 濁る。死は上と同じく送信側の `Err` として下流が受け止める。
                 let mut engine = state.engine.lock().unwrap();
                 let n = engine.entry_count();
                 (engine.search(&picked.query), n)


### PR DESCRIPTION
## 何を閉じるか

#1004（PR #1033）が受容した残余 5 件のうち **1 件だけ**を閉じる。

| 残余 | 本 PR |
|---|---|
| 送信失敗を握り潰し、UI が古い行を保ったまま無音になる | **閉じる** — 検知して行をクリアする |
| worker は一度死んだら復活しない | **意図して残す** — 死こそが検知の経路だから（下記） |
| 他 3 件（config 適用の交差窓 / flush-on-Enter の実機検証 / フレーム予算の CI 検出器） | 対象外 |

## 実害は「無音」より一段重い

`run_search_with` の Plain 枝は「結果が届くまで前の行を保つ」設計で、worker が死ぬとこの保持が**恒久化**する。`should_flush_on_enter` は debounce が armed のとき（打鍵後 50ms 以内）しか真にならないため、それを過ぎた Enter は同期 flush を通らず、`self.state.results()` に残る**旧クエリの項目を起動する**。健全な worker でも往復（40〜95ms）の間だけ同じ窓が開くが、死んだ worker では無限に開いたままになる。

## 直し方 — 死因ではなく死の帰結を押さえる

挙動を変えるのは `launcher_controller.rs` の `if` 4 行だけ。

```rust
if self.search_tx.send(SearchRequest { seq, query }).is_err() {
    self.dispatch.invalidate();
    self.state.set_results(Vec::new());
}
```

**無界チャネルゆえ `send` の `Err` は「受け手が死んだ」以外を意味しない**（混雑・一時的失敗が存在せず、偽陽性が原理的に無い）。ゆえにこの 1 点が、死因（`try_state` None の早期 return・engine lock の毒・将来足す経路）を問わず必ず通る合流点になる。死因ごとに塞ぐより射程が広い。

処置は上の空クエリ・indexing 中の枝と同一で、新しい規則を作っていない。`on_enter` の flush が「どちらの枝でもクリアする」理由として既に名指していた危険に、抜けていた 1 経路を当てただけである。

## `search_worker.rs` は挙動を変えない（コメントのみ）

レビュー指摘は `try_state` None の `return` を「永久停止」として挙げたが、**送信 Err の処置を入れた後では `return` が正しい**。

- `return` → worker 死亡 → `req_rx` drop → 次の送信が `Err` → 行クリア（**検知される失敗**）
- `continue` → worker 生存・要求だけ消失 → 送信は成功し続け seq は永久に settle しない → 古い行のまま無音（**検知されない失敗**）

engine lock の `.unwrap()` も同じ理由で維持する（毒は debug/test でのみ生じ、release は `panic = "abort"`）。この 2 つが意図的であること・逆向きの契約・**検知が 1 要求ぶん遅れる**こと（死を招いた要求は応答もクリアも得ず、次の送信が失敗して初めて現れる）を doc に記録した。次の読み手が善意で `continue` へ「直す」のを止めるため。

なお `try_state` None は**現に到達しない** — `AppState` は Builder 段階（`main.rs:266`）で manage され、worker が立つのは setup 中の `LauncherController::new`（`view.rs:123`）、`unmanage` の呼び出し点は 0 件（grep 実測）。潜在的な危険を、到達したときに沈黙しない形へ整えた変更である。

## 検証

**故障注入 A/B** — worker を 3 要求目で殺す細工を入れ、`smoke:egui` で実機打鍵（trace は実ファイルを読んで計数）。

| | `egui_search:settled` | 新しい枝の到達 |
|---|---|---|
| 故障注入 | 2（worker が生きていた分だけ） | **5 回** |
| 健全（最終コード） | **8**（全要求が着弾） | — |

健全側の根拠は `settled = 8` である（注入時の trace マーカーは撤去済みゆえ、その 0 件は証拠にならない）。細工の残存は `grep` で 0 件を確認した。

- clippy / fmt / test: PostToolUse hook 沈黙
- `cargo doc --workspace --no-deps --document-private-items`: clean（doc 編集のたび 2 回）
- `npm run governance:check`: 全 19 検査 passed
- `npm run smoke:egui`: green

**この変更に自動検知器は無い**（`smoke:egui` は worker が全く動かない場合しか捕まえられず、途中で死ぬ経路は緑で通る）。受容する残余として記す。

## trigger 表への応答

- **SPEC 同期**: 不要。plain 検索の行保持は `SPEC.md` に記述がなく（#1004 も SPEC を触っていない）、§4.7「結果の表示/非表示は `results` が空なら非表示」には**適合する**方向の変更である
- **`/race-check`**（channel の消費を変えたため発火）: 論点は「クリア後に `msg_rx` に残っていた `Done` が着弾して行が復活しないか」の 1 点。同じ `invalidate()` が pending を落とすため `accept` が `None` を返し、`drain_search` の `continue` で破棄される（`egui_search:dropped` として trace に残る）。閉じている

🤖 Generated with [Claude Code](https://claude.com/claude-code)
